### PR TITLE
use ServiceLoader to discover backends and Dagger to wire them together

### DIFF
--- a/denominator-core/src/main/java/denominator/Backend.java
+++ b/denominator-core/src/main/java/denominator/Backend.java
@@ -1,0 +1,37 @@
+package denominator;
+
+import static com.google.common.base.Objects.equal;
+import static com.google.common.base.Objects.toStringHelper;
+
+import com.google.common.base.Objects;
+
+/**
+ * an implementation that allows you to control edge network services including
+ * DNS
+ */
+public abstract class Backend {
+    /**
+     * configuration key associated with this edge. For example, {@code hopper}
+     */
+    public abstract String getName();
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getName());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        return equal(this.getName(), Backend.class.cast(obj).getName());
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this).add("name", getName()).toString();
+    }
+
+}

--- a/denominator-core/src/main/java/denominator/Connection.java
+++ b/denominator-core/src/main/java/denominator/Connection.java
@@ -1,0 +1,26 @@
+package denominator;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+public class Connection implements Closeable {
+    @Inject
+    Edge edge;
+    @Inject
+    Closeable closer;
+
+    public Edge open() {
+        return edge;
+    }
+
+    /**
+     * closes resources associated with the connections, such as thread pools or
+     * open files.
+     */
+    @Override
+    public void close() throws IOException {
+        closer.close();
+    }
+}

--- a/denominator-core/src/main/java/denominator/Denominator.java
+++ b/denominator-core/src/main/java/denominator/Denominator.java
@@ -1,0 +1,52 @@
+package denominator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Maps.uniqueIndex;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import com.google.common.base.Function;
+
+import dagger.ObjectGraph;
+import denominator.stub.StubBackend;
+
+public final class Denominator {
+
+    /**
+     * returns the currently configured backends
+     */
+    public static Iterable<Backend> listBackends() {
+        return ServiceLoader.load(Backend.class);
+    }
+
+    /**
+     * creates a connection to the backend, such as {@link StubBackend}
+     * 
+     * @see #listBackends
+     */
+    public static Connection connectToBackend(Backend in) {
+        return ObjectGraph.create(in).get(Connection.class);
+    }
+
+    /**
+     * creates a connection to the backend, based on key look up. Ex.
+     * {@code stub}
+     * 
+     * @see Backend#getName()
+     * @throws IllegalArgumentException
+     *             if the backendName is not configured
+     */
+    public static Connection connectToBackend(String backendName) throws IllegalArgumentException {
+        checkNotNull(backendName, "backendName");
+        Map<String, Backend> allBackendsByName = uniqueIndex(listBackends(), new Function<Backend, String>() {
+            public String apply(Backend input) {
+                return input.getName();
+            }
+        });
+        checkArgument(allBackendsByName.containsKey(backendName), "backend %s not in set of configured backends: %s",
+                backendName, allBackendsByName.keySet());
+        return ObjectGraph.create(allBackendsByName.get(backendName)).get(Connection.class);
+    }
+}

--- a/denominator-core/src/main/java/denominator/Edge.java
+++ b/denominator-core/src/main/java/denominator/Edge.java
@@ -1,0 +1,5 @@
+package denominator;
+
+public interface Edge {
+    ZoneApi getZoneApi();
+}

--- a/denominator-core/src/main/java/denominator/ZoneApi.java
+++ b/denominator-core/src/main/java/denominator/ZoneApi.java
@@ -1,0 +1,7 @@
+package denominator;
+
+import java.util.List;
+
+public interface ZoneApi {
+    List<String> list();
+}

--- a/denominator-core/src/main/java/denominator/stub/StubBackend.java
+++ b/denominator-core/src/main/java/denominator/stub/StubBackend.java
@@ -1,0 +1,42 @@
+package denominator.stub;
+
+import java.io.Closeable;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+import denominator.Backend;
+import denominator.Connection;
+import denominator.Edge;
+
+@Module(entryPoints = Connection.class)
+public class StubBackend extends Backend implements Closeable {
+
+    @Override
+    public String getName() {
+        return "stub";
+    }
+
+    @Provides
+    @Singleton
+    Edge provideZoneApi() {
+        return new StubEdge(new StubZoneApi());
+    }
+
+    /**
+     * in a real implementation, we would likely inject resources that need
+     * cleanup and call them here. For example, shutting down thread pools, or
+     * syncing disk write.
+     */
+    @Provides
+    @Singleton
+    Closeable provideCloser() {
+        return this;
+    }
+
+    @Override
+    public void close() {
+        // no need to close anything
+    }
+}

--- a/denominator-core/src/main/java/denominator/stub/StubEdge.java
+++ b/denominator-core/src/main/java/denominator/stub/StubEdge.java
@@ -1,0 +1,19 @@
+package denominator.stub;
+
+import javax.inject.Inject;
+
+import denominator.Edge;
+
+public class StubEdge implements Edge {
+    private final StubZoneApi zoneApi;
+
+    @Inject
+    StubEdge(StubZoneApi zoneApi) {
+        this.zoneApi = zoneApi;
+    }
+
+    @Override
+    public StubZoneApi getZoneApi() {
+        return zoneApi;
+    }
+}

--- a/denominator-core/src/main/java/denominator/stub/StubZoneApi.java
+++ b/denominator-core/src/main/java/denominator/stub/StubZoneApi.java
@@ -1,0 +1,18 @@
+package denominator.stub;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import com.google.common.collect.ImmutableList;
+
+final class StubZoneApi implements denominator.ZoneApi {
+    @Inject
+    StubZoneApi() {
+    }
+
+    @Override
+    public List<String> list() {
+        return ImmutableList.of("denominator.io");
+    }
+}

--- a/denominator-core/src/main/resources/META-INF/services/denominator.Backend
+++ b/denominator-core/src/main/resources/META-INF/services/denominator.Backend
@@ -1,0 +1,1 @@
+denominator.stub.StubBackend

--- a/denominator-core/src/test/java/denominator/stub/DenominatorTest.java
+++ b/denominator-core/src/test/java/denominator/stub/DenominatorTest.java
@@ -1,0 +1,13 @@
+package denominator.stub;
+
+import org.testng.annotations.Test;
+
+import denominator.Denominator;
+
+public class DenominatorTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "backend foo not in set of configured backends: [stub]")
+    public void testNiceMessageWhenBackendNotFound() {
+        Denominator.connectToBackend("foo");
+    }
+}

--- a/denominator-core/src/test/java/denominator/stub/StubBackendTest.java
+++ b/denominator-core/src/test/java/denominator/stub/StubBackendTest.java
@@ -1,0 +1,29 @@
+package denominator.stub;
+
+import static denominator.Denominator.connectToBackend;
+import static denominator.Denominator.listBackends;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import denominator.Backend;
+
+public class StubBackendTest {
+
+    @Test
+    public void testStubRegistered() {
+        Set<Backend> allBackends = ImmutableSet.copyOf(listBackends());
+        assertTrue(allBackends.contains(new StubBackend()));
+    }
+
+    @Test
+    public void testBackendWiresStubZoneApi() {
+        assertEquals(connectToBackend(new StubBackend()).open().getZoneApi().getClass(), StubZoneApi.class);
+        assertEquals(connectToBackend("stub").open().getZoneApi().getClass(), StubZoneApi.class);
+    }
+}


### PR DESCRIPTION
A `Backend` provides us a `Connection` to the `Edge` we wish to control.  
### Why no configuration (yet)?

Some of these backends will not need configuration, and others will need more configuration than others.  For example, an in-memory `stub` backend will not need configuration.  A `hopper` backend will only need a small amount of configuration, such as listen port. An `ultradns-ws` backend will need dynamic credentials and potentially changing endpoints.  Configuration will be addressed in later pull requests.
### Why ServiceLoader?

Apart from `StubModule` Backends are in separate jar files, and the simplest way to look them up is via `ServiceLoader`.  This implementation uses `Dagger` to bridge the abstract backend to its specific wiring needed in order to manage connections to an `Edge`.  
### Why Dagger?
1.  We want denominator to work on android with least problems possible.  Unlike Guice, Dagger was written from ground-up to support android.
2.  Most configuration is be specific to backends which in-turn will likely depend on guice or spring.  Compile-time injection avoids the issue relating to nested injectors.
3.  Dagger has a smaller subset of features than Guice, and less chances for things to go wrong as almost all work is performed by the compiler.
