### PR TITLE
handle providers with variable credential types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ apply from: file('gradle/release.gradle')
 subprojects {
     group = "com.netflix.${githubProjectName}"
 
+    test {
+        useTestNG()
+    }
+
     dependencies {
         compile     'com.google.guava:guava:14.0-rc2'
         testCompile 'org.testng:testng:6.8'

--- a/denominator-core/src/main/java/denominator/Credentials.java
+++ b/denominator-core/src/main/java/denominator/Credentials.java
@@ -1,0 +1,166 @@
+package denominator;
+
+import static com.google.common.base.Objects.equal;
+
+import com.google.common.base.Objects;
+
+/**
+ * Abstractly encapsulates credentials used by a Provider. We only support
+ * providers that have a maximum of 3 part credentials.
+ */
+public abstract class Credentials {
+
+    /**
+     * convenience method that creates an instance of two-part credentials.
+     * 
+     * @param firstPart
+     *            first part of the credentials, for example your username.
+     * @param secondPart
+     *            second part of the credentials, for example your password.
+     */
+    public static <F, S> Credentials twoPartCredentials(final F firstPart, final S secondPart) {
+        return new TwoPartCredentials<F, S>() {
+            public F getFirstPart() {
+                return firstPart;
+            }
+
+            public S getSecondPart() {
+                return secondPart;
+            }
+        };
+    }
+
+    /**
+     * convenience method that creates an instance of three-part credentials.
+     * 
+     * @param firstPart
+     *            first part of the credentials, for example your tenant.
+     * @param secondPart
+     *            second part of the credentials, for example your username.
+     * @param thirdPart
+     *            second part of the credentials, for example your password.
+     */
+    public static <F, S, T> Credentials threePartCredentials(final F firstPart, final S secondPart, final T thirdPart) {
+        return new ThreePartCredentials<F, S, T>() {
+            public F getFirstPart() {
+                return firstPart;
+            }
+
+            public S getSecondPart() {
+                return secondPart;
+            }
+
+            public T getThirdPart() {
+                return thirdPart;
+            }
+        };
+    }
+
+    // ctor is private to ensure providers only need to consider hierarchies
+    // with roots defined here.
+    private Credentials() {
+    }
+
+    /**
+     * Encapsulate providers that use two pieces of authenticating information,
+     * such as access key and secret key or username and password. Abstract so
+     * that fields can be named appropriately for serialization purposes.
+     * 
+     * @param <F>
+     *            type of the first part, for example String for a username
+     * @param <S>
+     *            type of the second part, for example {@code PrivateKey}
+     */
+    public static abstract class TwoPartCredentials<F, S> extends Credentials {
+
+        protected TwoPartCredentials() {
+        }
+
+        /**
+         * for example access key or username
+         */
+        public abstract F getFirstPart();
+
+        /**
+         * for example secret key or password
+         */
+        public abstract S getSecondPart();
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getFirstPart(), getSecondPart());
+        }
+
+        /**
+         * equals check here doesn't require classes to be the same. This allows
+         * subclasses to inherit the equals method and have {@code equals}
+         * return true when the instance is the same, but for example from
+         * properties vs from memory.
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (!(obj instanceof TwoPartCredentials))
+                return false;
+            TwoPartCredentials<?, ?> that = TwoPartCredentials.class.cast(obj);
+            return equal(getFirstPart(), that.getFirstPart()) && equal(getSecondPart(), that.getSecondPart());
+        }
+    }
+
+    /**
+     * Encapsulate providers that use three pieces of authenticating
+     * information, such as a renewable set of two part credentials, like amazon
+     * temporary credentials. Abstract so that fields can be named appropriately
+     * for serialization purposes.
+     * 
+     * @param <F>
+     *            type of the first part, for example String for a tenant id
+     * @param <S>
+     *            type of the second part, for example String for a username
+     * @param <T>
+     *            type of the third part, for example {@code PrivateKey}
+     */
+    public static abstract class ThreePartCredentials<F, S, T> extends Credentials {
+
+        protected ThreePartCredentials() {
+        }
+
+        /**
+         * for example tenantid or renew token
+         */
+        public abstract F getFirstPart();
+
+        /**
+         * for example access key or username
+         */
+        public abstract S getSecondPart();
+
+        /**
+         * for example secret key or password
+         */
+        public abstract T getThirdPart();
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getFirstPart(), getSecondPart(), getThirdPart());
+        }
+
+        /**
+         * equals check here doesn't require classes to be the same. This allows
+         * subclasses to inherit the equals method and have {@code equals}
+         * return true when the instance is the same, but for example from
+         * properties vs from memory.
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (!(obj instanceof ThreePartCredentials))
+                return false;
+            ThreePartCredentials<?, ?, ?> that = ThreePartCredentials.class.cast(obj);
+            return equal(getFirstPart(), that.getFirstPart()) && equal(getSecondPart(), that.getSecondPart())
+                    && equal(getThirdPart(), that.getThirdPart());
+        }
+    }
+}

--- a/denominator-core/src/main/java/denominator/CredentialsConfiguration.java
+++ b/denominator-core/src/main/java/denominator/CredentialsConfiguration.java
@@ -1,0 +1,110 @@
+package denominator;
+
+import static denominator.Credentials.threePartCredentials;
+import static denominator.Credentials.twoPartCredentials;
+
+import javax.inject.Singleton;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * use this for providers who need credentials.
+ * 
+ * ex. for two-part
+ * 
+ * <pre>
+ * ultra = Denominator.create(new UltraDNSProvider(), staticCredentials(username, password));
+ * route53 = Denominator.create(new Route53Provider(), staticCredentials(accesskey, secretkey));
+ * </pre>
+ * 
+ * ex. for three-part
+ * 
+ * <pre>
+ * dynect = Denominator.create(new DynECTProvider(), staticCredentials(customer, username, password));
+ * </pre>
+ * 
+ * ex. for dynamic credentials
+ * 
+ * <pre>
+ * final AWSCredentialsProvider provider = // from wherever
+ * Supplier&lt;Credentials&gt; converter = new Supplier&lt;Credentials&gt;() {
+ *     public Credentials get() {
+ *         AWSCredentials awsCreds = provider.getCredentials();
+ *         return twoPartCredentials(awsCreds.getAWSAccessKeyId(), awsCreds.getAWSSecretKey());
+ *     }
+ * };
+ * 
+ * route53 = Denominator.create(new Route53Provider(), dynamicCredentials(converter));
+ * </pre>
+ */
+public class CredentialsConfiguration {
+    private CredentialsConfiguration() {
+    }
+
+    @Module(entryPoints = DNSApiManager.class, complete = false)
+    static class CredentialsSupplier {
+        private final Supplier<Credentials> creds;
+
+        private CredentialsSupplier(Supplier<Credentials> creds) {
+            this.creds = creds;
+        }
+
+        @Provides
+        @Singleton
+        Supplier<Credentials> supplyCredentials() {
+            return creds;
+        }
+    }
+
+    /**
+     * used to set a base case where no credentials are available or needed.
+     */
+    static CredentialsSupplier none() {
+        return new CredentialsSupplier(Suppliers.<Credentials> ofInstance(null));
+    };
+
+    /**
+     * 
+     * @param firstPart
+     *            first part of credentials, such as a username or accessKey
+     * @param secondPart
+     *            second part of credentials, such as a password or secretKey
+     */
+    public static <F, S> CredentialsSupplier staticCredentials(F firstPart, S secondPart) {
+        return new CredentialsSupplier(Suppliers.ofInstance(twoPartCredentials(firstPart, secondPart)));
+    }
+
+    /**
+     * 
+     * @param firstPart
+     *            first part of credentials, such as a customer or tenant
+     * @param secondPart
+     *            second part of credentials, such as a username or accessKey
+     * @param thirdPart
+     *            third part of credentials, such as a password or secretKey
+     */
+    public static <F, S, T> CredentialsSupplier staticCredentials(F firstPart, S secondPart, T thirdPart) {
+        return new CredentialsSupplier(Suppliers.ofInstance(threePartCredentials(firstPart, secondPart, thirdPart)));
+    }
+
+    /**
+     * @param credentials
+     *            will always be used on the provider
+     */
+    public static CredentialsSupplier staticCredentials(Credentials credentials) {
+        return new CredentialsSupplier(Suppliers.ofInstance(credentials));
+    }
+
+    /**
+     * @param dynamicCredentials
+     *            {@link Supplier#get()} will be called each time credentials
+     *            are needed, facilitating runtime credential changes.
+     */
+    public static CredentialsSupplier dynamicCredentials(Supplier<Credentials> dynamicCredentials) {
+        return new CredentialsSupplier(dynamicCredentials);
+    }
+}

--- a/denominator-core/src/main/java/denominator/DNSApiManager.java
+++ b/denominator-core/src/main/java/denominator/DNSApiManager.java
@@ -1,5 +1,7 @@
 package denominator;
 
+import static com.google.common.base.Objects.toStringHelper;
+
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -10,11 +12,13 @@ import javax.inject.Inject;
  * {@link Provider} that implements it.
  */
 public class DNSApiManager implements Closeable {
+    private final String providerKey;
     private final DNSApi api;
     private final Closeable closer;
 
     @Inject
-    DNSApiManager(DNSApi api, Closeable closer) {
+    DNSApiManager(String providerKey, DNSApi api, Closeable closer) {
+        this.providerKey = providerKey;
         this.api = api;
         this.closer = closer;
     }
@@ -33,5 +37,10 @@ public class DNSApiManager implements Closeable {
     @Override
     public void close() throws IOException {
         closer.close();
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this).add("provider", providerKey).toString();
     }
 }

--- a/denominator-core/src/main/java/denominator/Denominator.java
+++ b/denominator-core/src/main/java/denominator/Denominator.java
@@ -2,14 +2,20 @@ package denominator;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Predicates.instanceOf;
+import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Maps.uniqueIndex;
 
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 
 import dagger.ObjectGraph;
+import denominator.CredentialsConfiguration.CredentialsSupplier;
 import denominator.mock.MockProvider;
 
 public final class Denominator {
@@ -23,23 +29,47 @@ public final class Denominator {
 
     /**
      * creates a new manager for a provider using its type, such as
-     * {@link MockProvider}
+     * {@link MockProvider}.
      * 
+     * ex.
+     * 
+     * <pre>
+     * route53 = Denominator.create(new Route53Provider(), staticCredentials(accesskey, secretkey));
+     * </pre>
+     * 
+     * @see CredentialsConfiguration
      * @see #listProviders
      */
-    public static DNSApiManager create(Provider in) {
-        return ObjectGraph.create(in).get(DNSApiManager.class);
+    public static DNSApiManager create(Provider in, Object... modules) {
+        Builder<Object> modulesForGraph = ImmutableList.builder().add(in);
+        List<Object> inputModules;
+        if (modules == null || modules.length == 0) {
+            inputModules = ImmutableList.of();
+        } else {
+            inputModules = ImmutableList.copyOf(modules);
+        }
+        if (!any(inputModules, instanceOf(CredentialsSupplier.class)))
+            modulesForGraph.add(CredentialsConfiguration.none());
+        modulesForGraph.addAll(inputModules);
+        return ObjectGraph.create(modulesForGraph.build().toArray()).get(DNSApiManager.class);
     }
 
     /**
      * creates a new manager for a provider, based on key look up. Ex.
      * {@code mock}
      * 
+     * ex.
+     * 
+     * <pre>
+     * route53 = Denominator.create(&quot;route53&quot;, staticCredentials(accesskey, secretkey));
+     * </pre>
+     * 
      * @see Provider#getName()
+     * @see CredentialsConfiguration
      * @throws IllegalArgumentException
      *             if the providerName is not configured
      */
-    public static DNSApiManager create(String providerName) throws IllegalArgumentException {
+    public static DNSApiManager create(String providerName, Object... modules) throws IllegalArgumentException {
         checkNotNull(providerName, "providerName");
         Map<String, Provider> allProvidersByName = uniqueIndex(listProviders(), new Function<Provider, String>() {
             public String apply(Provider input) {
@@ -48,6 +78,7 @@ public final class Denominator {
         });
         checkArgument(allProvidersByName.containsKey(providerName),
                 "provider %s not in set of configured providers: %s", providerName, allProvidersByName.keySet());
-        return ObjectGraph.create(allProvidersByName.get(providerName)).get(DNSApiManager.class);
+        return create(allProvidersByName.get(providerName), modules);
     }
+
 }

--- a/denominator-core/src/main/java/denominator/Provider.java
+++ b/denominator-core/src/main/java/denominator/Provider.java
@@ -3,12 +3,25 @@ package denominator;
 import static com.google.common.base.Objects.equal;
 import static com.google.common.base.Objects.toStringHelper;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Objects;
+import com.google.common.io.Closer;
+
+import dagger.Provides;
 
 /**
  * provides components that implement the {@link DNSApi}.
+ * 
+ * subclass this, and annotate with the following:
+ * 
+ * {@code  @Module(entryPoints = DNSApiManager.class) }
+ * 
+ * make sure your subclass has {@link Provides} methods for {@code String} (used
+ * for toString), {@link DNSApi} and {@link Closer}
  */
+@Beta
 public abstract class Provider {
+
     /**
      * configuration key associated with this {@link DNSApi}. For example,
      * {@code hopper}
@@ -33,5 +46,4 @@ public abstract class Provider {
     public String toString() {
         return toStringHelper(this).add("name", getName()).toString();
     }
-
 }

--- a/denominator-core/src/main/java/denominator/mock/MockDNSApi.java
+++ b/denominator-core/src/main/java/denominator/mock/MockDNSApi.java
@@ -4,11 +4,11 @@ import javax.inject.Inject;
 
 import denominator.DNSApi;
 
-public class MockNetworkServices implements DNSApi {
+public class MockDNSApi implements DNSApi {
     private final MockZoneApi zoneApi;
 
     @Inject
-    MockNetworkServices(MockZoneApi zoneApi) {
+    MockDNSApi(MockZoneApi zoneApi) {
         this.zoneApi = zoneApi;
     }
 

--- a/denominator-core/src/main/java/denominator/mock/MockProvider.java
+++ b/denominator-core/src/main/java/denominator/mock/MockProvider.java
@@ -6,14 +6,15 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
-import denominator.Provider;
-import denominator.DNSApiManager;
 import denominator.DNSApi;
+import denominator.DNSApiManager;
+import denominator.Provider;
 
 @Module(entryPoints = DNSApiManager.class)
 public class MockProvider extends Provider implements Closeable {
 
     @Override
+    @Provides
     public String getName() {
         return "mock";
     }
@@ -21,7 +22,7 @@ public class MockProvider extends Provider implements Closeable {
     @Provides
     @Singleton
     DNSApi provideNetworkServices() {
-        return new MockNetworkServices(new MockZoneApi());
+        return new MockDNSApi(new MockZoneApi());
     }
 
     /**

--- a/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
@@ -1,0 +1,37 @@
+package denominator;
+
+import static com.google.common.io.Closeables.closeQuietly;
+import static java.lang.String.format;
+import static java.util.logging.Logger.getAnonymousLogger;
+
+import java.util.List;
+
+import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * extend this and initialize manager {@link BeforeClass}
+ */
+public abstract class BaseProviderLiveTest {
+
+    protected DNSApiManager manager;
+
+    @Test
+    public void testListZones() {
+        skipIfNoCredentials();
+        List<String> zoneNames = manager.getApi().getZoneApi().list().toList();
+        getAnonymousLogger().info(format("%s has %s zones", manager, zoneNames.size()));
+    }
+
+    protected void skipIfNoCredentials() {
+        if (manager == null)
+            throw new SkipException("manager not configured");
+    }
+
+    @AfterClass
+    private void tearDown() {
+        closeQuietly(manager);
+    }
+}

--- a/denominator-core/src/test/java/denominator/CredentialsTest.java
+++ b/denominator-core/src/test/java/denominator/CredentialsTest.java
@@ -1,0 +1,52 @@
+package denominator;
+
+import static denominator.Credentials.threePartCredentials;
+import static denominator.Credentials.twoPartCredentials;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.google.common.base.Supplier;
+
+@Test
+public class CredentialsTest {
+
+    public void testTwoPartCredentialsEqualsHashCode() {
+        assertEquals(twoPartCredentials("user", "pass"), twoPartCredentials("user", "pass"));
+        assertEquals(twoPartCredentials("user", "pass").hashCode(), twoPartCredentials("user", "pass").hashCode());
+    }
+
+    public void testThreePartCredentialsEqualsHashCode() {
+        assertEquals(threePartCredentials("customer", "user", "pass"), threePartCredentials("customer", "user", "pass"));
+        assertEquals(threePartCredentials("customer", "user", "pass").hashCode(),
+                threePartCredentials("customer", "user", "pass").hashCode());
+    }
+
+    private static enum AWSCredentials {
+        INSTANCE;
+        String getAWSAccessKeyId() {
+            return "accessKey";
+        }
+
+        String getAWSSecretKey() {
+            return "secretKey";
+        }
+    }
+
+    private static class AWSCredentialsProvider {
+        AWSCredentials getCredentials() {
+            return AWSCredentials.INSTANCE;
+        }
+    }
+
+    public void testHowToConvertSomethingLikeAmazon() {
+        final AWSCredentialsProvider provider = new AWSCredentialsProvider();
+        Supplier<Credentials> converter = new Supplier<Credentials>() {
+            public Credentials get() {
+                AWSCredentials awsCreds = provider.getCredentials();
+                return twoPartCredentials(awsCreds.getAWSAccessKeyId(), awsCreds.getAWSSecretKey());
+            }
+        };
+        assertEquals(converter.get(), twoPartCredentials("accessKey", "secretKey"));
+    }
+}

--- a/denominator-core/src/test/java/denominator/DenominatorTest.java
+++ b/denominator-core/src/test/java/denominator/DenominatorTest.java
@@ -6,7 +6,7 @@ import denominator.Denominator;
 
 public class DenominatorTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "provider foo not in set of configured providers: [mock]")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "provider foo not in set of configured providers: \\[mock\\]")
     public void testNiceMessageWhenProviderNotFound() {
         Denominator.create("foo");
     }

--- a/denominator-core/src/test/java/denominator/mock/MockProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/mock/MockProviderLiveTest.java
@@ -1,0 +1,15 @@
+package denominator.mock;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseProviderLiveTest;
+import denominator.Denominator;
+
+@Test
+public class MockProviderLiveTest extends BaseProviderLiveTest {
+    @BeforeClass
+    private void setUp() {
+        manager = Denominator.create(new MockProvider());
+    }
+}

--- a/providers/denominator-dynect/build.gradle
+++ b/providers/denominator-dynect/build.gradle
@@ -11,8 +11,15 @@ eclipse {
   }
 }
 
+test {
+  systemProperty 'dynect.customer', System.getProperty('dynect.customer', '')
+  systemProperty 'dynect.username', System.getProperty('dynect.username', '')
+  systemProperty 'dynect.password', System.getProperty('dynect.password', '')
+}
+
 dependencies {
   compile      project(':denominator-core')
+  testCompile  project(':denominator-core').sourceSets.test.output
   compile     'org.jclouds.labs:dynect:1.6.0-alpha.2'
 }
 

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTProvider.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTProvider.java
@@ -1,5 +1,7 @@
 package denominator.dynect;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.io.Closeable;
 
 import javax.inject.Singleton;
@@ -14,6 +16,7 @@ import com.google.common.base.Supplier;
 
 import dagger.Module;
 import dagger.Provides;
+import denominator.Credentials.ThreePartCredentials;
 import denominator.DNSApi;
 import denominator.DNSApiManager;
 import denominator.Provider;
@@ -22,6 +25,7 @@ import denominator.Provider;
 public class DynECTProvider extends Provider {
 
     @Override
+    @Provides
     public String getName() {
         return "dynect";
     }
@@ -34,10 +38,15 @@ public class DynECTProvider extends Provider {
 
     @Provides
     @Singleton
-    Supplier<Credentials> supplyCredentials() {
+    Supplier<Credentials> supplyJCloudsCredentials(final Supplier<denominator.Credentials> denominatorCredentials) {
         return new Supplier<Credentials>() {
             public Credentials get() {
-                throw new UnsupportedOperationException("TODO: configuration");
+                denominator.Credentials input = denominatorCredentials.get();
+                checkState(input != null && input instanceof ThreePartCredentials,
+                        "%s requires credentials with three parts: customer, username, password", getName());
+                ThreePartCredentials<?, ?, ?> threeParts = ThreePartCredentials.class.cast(input);
+                return new Credentials(threeParts.getFirstPart() + ":" + threeParts.getSecondPart(), threeParts
+                        .getThirdPart().toString());
             }
         };
     }

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderLiveTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderLiveTest.java
@@ -1,0 +1,24 @@
+package denominator.dynect;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static denominator.CredentialsConfiguration.staticCredentials;
+import static java.lang.System.getProperty;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseProviderLiveTest;
+import denominator.Denominator;
+
+@Test
+public class DynECTProviderLiveTest extends BaseProviderLiveTest {
+    @BeforeClass
+    private void setUp() {
+        String customer = emptyToNull(getProperty("dynect.customer"));
+        String username = emptyToNull(getProperty("dynect.username"));
+        String password = emptyToNull(getProperty("dynect.password"));
+        if (customer != null && username != null && password != null) {
+            manager = Denominator.create(new DynECTProvider(), staticCredentials(customer, username, password));
+        }
+    }
+}

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderTest.java
@@ -1,5 +1,6 @@
 package denominator.dynect;
 
+import static denominator.CredentialsConfiguration.staticCredentials;
 import static denominator.Denominator.create;
 import static denominator.Denominator.listProviders;
 import static org.testng.Assert.assertEquals;
@@ -11,6 +12,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
+import denominator.DNSApiManager;
 import denominator.Provider;
 
 public class DynECTProviderTest {
@@ -23,7 +25,14 @@ public class DynECTProviderTest {
 
     @Test
     public void testProviderWiresDynECTZoneApi() {
-        assertEquals(create(new DynECTProvider()).getApi().getZoneApi().getClass(), DynECTZoneApi.class);
-        assertEquals(create("dynect").getApi().getZoneApi().getClass(), DynECTZoneApi.class);
+        DNSApiManager manager = create(new DynECTProvider(), staticCredentials("customer", "username", "password"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), DynECTZoneApi.class);
+        manager = create("dynect", staticCredentials("customer", "username", "password"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), DynECTZoneApi.class);
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "dynect requires credentials with three parts: customer, username, password")
+    public void testCredentialsRequired() {
+        create(new DynECTProvider()).getApi().getZoneApi().list();
     }
 }

--- a/providers/denominator-route53/build.gradle
+++ b/providers/denominator-route53/build.gradle
@@ -11,8 +11,14 @@ eclipse {
   }
 }
 
+test {
+  systemProperty 'route53.accesskey', System.getProperty('route53.accesskey', '')
+  systemProperty 'route53.secretkey', System.getProperty('route53.secretkey', '')
+}
+
 dependencies {
   compile      project(':denominator-core')
+  testCompile  project(':denominator-core').sourceSets.test.output
   compile     'org.jclouds.provider:aws-route53:1.6.0-alpha.2'
 }
 

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53Provider.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53Provider.java
@@ -1,5 +1,7 @@
 package denominator.route53;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.io.Closeable;
 
 import javax.inject.Singleton;
@@ -14,6 +16,7 @@ import com.google.common.base.Supplier;
 
 import dagger.Module;
 import dagger.Provides;
+import denominator.Credentials.TwoPartCredentials;
 import denominator.DNSApi;
 import denominator.DNSApiManager;
 import denominator.Provider;
@@ -22,6 +25,7 @@ import denominator.Provider;
 public class Route53Provider extends Provider {
 
     @Override
+    @Provides
     public String getName() {
         return "route53";
     }
@@ -34,10 +38,14 @@ public class Route53Provider extends Provider {
 
     @Provides
     @Singleton
-    Supplier<Credentials> supplyCredentials() {
+    Supplier<Credentials> supplyJCloudsCredentials(final Supplier<denominator.Credentials> denominatorCredentials) {
         return new Supplier<Credentials>() {
             public Credentials get() {
-                throw new UnsupportedOperationException("TODO: configuration");
+                denominator.Credentials input = denominatorCredentials.get();
+                checkState(input != null && input instanceof TwoPartCredentials,
+                        "%s requires credentials with two parts: accessKey and secretKey", getName());
+                TwoPartCredentials<?, ?> twoParts = TwoPartCredentials.class.cast(input);
+                return new Credentials(twoParts.getFirstPart().toString(), twoParts.getSecondPart().toString());
             }
         };
     }

--- a/providers/denominator-route53/src/test/java/denominator/route53/Route53ProviderLiveTest.java
+++ b/providers/denominator-route53/src/test/java/denominator/route53/Route53ProviderLiveTest.java
@@ -1,0 +1,23 @@
+package denominator.route53;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static denominator.CredentialsConfiguration.staticCredentials;
+import static java.lang.System.getProperty;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseProviderLiveTest;
+import denominator.Denominator;
+
+@Test
+public class Route53ProviderLiveTest extends BaseProviderLiveTest {
+    @BeforeClass
+    private void setUp() {
+        String accesskey = emptyToNull(getProperty("route53.accesskey"));
+        String secretkey = emptyToNull(getProperty("route53.secretkey"));
+        if (accesskey != null && secretkey != null) {
+            manager = Denominator.create(new Route53Provider(), staticCredentials(accesskey, secretkey));
+        }
+    }
+}

--- a/providers/denominator-route53/src/test/java/denominator/route53/Route53ProviderTest.java
+++ b/providers/denominator-route53/src/test/java/denominator/route53/Route53ProviderTest.java
@@ -1,5 +1,6 @@
 package denominator.route53;
 
+import static denominator.CredentialsConfiguration.staticCredentials;
 import static denominator.Denominator.create;
 import static denominator.Denominator.listProviders;
 import static org.testng.Assert.assertEquals;
@@ -11,6 +12,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
+import denominator.DNSApiManager;
 import denominator.Provider;
 
 public class Route53ProviderTest {
@@ -23,7 +25,14 @@ public class Route53ProviderTest {
 
     @Test
     public void testProviderWiresRoute53ZoneApi() {
-        assertEquals(create(new Route53Provider()).getApi().getZoneApi().getClass(), Route53ZoneApi.class);
-        assertEquals(create("route53").getApi().getZoneApi().getClass(), Route53ZoneApi.class);
+        DNSApiManager manager = create(new Route53Provider(), staticCredentials("accesskey", "secretkey"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), Route53ZoneApi.class);
+        manager = create("route53", staticCredentials("accesskey", "secretkey"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), Route53ZoneApi.class);
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "route53 requires credentials with two parts: accessKey and secretKey")
+    public void testCredentialsRequired() {
+        create(new Route53Provider()).getApi().getZoneApi().list();
     }
 }

--- a/providers/denominator-ultradns/build.gradle
+++ b/providers/denominator-ultradns/build.gradle
@@ -11,8 +11,14 @@ eclipse {
   }
 }
 
+test {
+  systemProperty 'ultradns.username', System.getProperty('ultradns.username', '')
+  systemProperty 'ultradns.password', System.getProperty('ultradns.password', '')
+}
+
 dependencies {
   compile      project(':denominator-core')
+  testCompile  project(':denominator-core').sourceSets.test.output
   compile     'org.jclouds.labs:ultradns-ws:1.6.0-alpha.2'
 }
 

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
@@ -1,5 +1,7 @@
 package denominator.ultradns;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.io.Closeable;
 
 import javax.inject.Singleton;
@@ -14,6 +16,7 @@ import com.google.common.base.Supplier;
 
 import dagger.Module;
 import dagger.Provides;
+import denominator.Credentials.TwoPartCredentials;
 import denominator.DNSApi;
 import denominator.DNSApiManager;
 import denominator.Provider;
@@ -22,6 +25,7 @@ import denominator.Provider;
 public class UltraDNSProvider extends Provider {
 
     @Override
+    @Provides
     public String getName() {
         return "ultradns";
     }
@@ -34,10 +38,14 @@ public class UltraDNSProvider extends Provider {
 
     @Provides
     @Singleton
-    Supplier<Credentials> supplyCredentials() {
+    Supplier<Credentials> supplyJCloudsCredentials(final Supplier<denominator.Credentials> denominatorCredentials) {
         return new Supplier<Credentials>() {
             public Credentials get() {
-                throw new UnsupportedOperationException("TODO: configuration");
+                denominator.Credentials input = denominatorCredentials.get();
+                checkState(input != null && input instanceof TwoPartCredentials,
+                        "%s requires credentials with two parts: username and password", getName());
+                TwoPartCredentials<?, ?> twoParts = TwoPartCredentials.class.cast(input);
+                return new Credentials(twoParts.getFirstPart().toString(), twoParts.getSecondPart().toString());
             }
         };
     }

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSProviderLiveTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSProviderLiveTest.java
@@ -1,0 +1,24 @@
+package denominator.ultradns;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static denominator.CredentialsConfiguration.staticCredentials;
+import static java.lang.System.getProperty;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseProviderLiveTest;
+import denominator.Denominator;
+
+@Test
+public class UltraDNSProviderLiveTest extends BaseProviderLiveTest {
+
+    @BeforeClass
+    private void setUp() {
+        String username = emptyToNull(getProperty("ultradns.username"));
+        String password = emptyToNull(getProperty("ultradns.password"));
+        if (username != null && password != null) {
+            manager = Denominator.create(new UltraDNSProvider(), staticCredentials(username, password));
+        }
+    }
+}

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSProviderTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSProviderTest.java
@@ -1,5 +1,6 @@
 package denominator.ultradns;
 
+import static denominator.CredentialsConfiguration.staticCredentials;
 import static denominator.Denominator.create;
 import static denominator.Denominator.listProviders;
 import static org.testng.Assert.assertEquals;
@@ -11,6 +12,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
+import denominator.DNSApiManager;
 import denominator.Provider;
 
 public class UltraDNSProviderTest {
@@ -23,7 +25,14 @@ public class UltraDNSProviderTest {
 
     @Test
     public void testProviderWiresUltraDNSZoneApi() {
-        assertEquals(create(new UltraDNSProvider()).getApi().getZoneApi().getClass(), UltraDNSZoneApi.class);
-        assertEquals(create("ultradns").getApi().getZoneApi().getClass(), UltraDNSZoneApi.class);
+        DNSApiManager manager = create(new UltraDNSProvider(), staticCredentials("username", "password"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), UltraDNSZoneApi.class);
+        manager = create("ultradns", staticCredentials("username", "password"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), UltraDNSZoneApi.class);
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "ultradns requires credentials with two parts: username and password")
+    public void testCredentialsRequired() {
+        create(new UltraDNSProvider()).getApi().getZoneApi().list();
     }
 }


### PR DESCRIPTION
The following pull request creates a system by which we can generically send two or three part credentials to providers that require them.
### Static Credentials

```
import static denominator.CredentialsConfiguration.staticCredentials;
...
ultradns = Denominator.create(new UltraDNSProvider(), staticCredentials(username, password));
route53 = Denominator.create(new Route53Provider(), staticCredentials(accesskey, secretkey));
dynect = Denominator.create(new DynECTProvider(), staticCredentials(customer, username, password));
```
### Dynamic Credentials

When providers should dynamically change credentials, pass in your own instance of `Supplier<Credentials>`

```
import static denominator.CredentialsConfiguration.dynamicCredentials;
import static denominator.Credentials.twoPartCredentials;
...
AWSCredentialsProvider provider = // from where-ever
Supplier<Credentials> converter = new Supplier<Credentials>() {
    public Credentials get() {
        AWSCredentials awsCreds = provider.getCredentials();
        return twoPartCredentials(awsCreds.getAWSAccessKeyId(), awsCreds.getAWSSecretKey());
    }
};
route53 = Denominator.create(new Route53Provider(), dynamicCredentials(converter));
```
### No Credentials

Providers that do not need credentials can skip the argument:

```
mock = Denominator.create(new MockProvider());
```
### Testing

In order to test this, you will need to see info output from gradle.  Here's an example:

```
gradle -i clean test -Droute53.accesskey=YOUR_ACCESS_KEY -Droute53.secretkey=YOUR_SECRET_KEY
```

Of course, you can supply all credentials via args, if you have them.
