### PR TITLE
update to jclouds 1.6.0-alpha.3, guava 14.0-rc3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
     }
 
     dependencies {
-        compile     'com.google.guava:guava:14.0-rc2'
+        compile     'com.google.guava:guava:14.0-rc3'
         testCompile 'org.testng:testng:6.8'
     }
 }

--- a/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
@@ -1,9 +1,10 @@
 package denominator;
 
-import static com.google.common.io.Closeables.closeQuietly;
+import static com.google.common.io.Closeables.close;
 import static java.lang.String.format;
 import static java.util.logging.Logger.getAnonymousLogger;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.testng.SkipException;
@@ -31,7 +32,7 @@ public abstract class BaseProviderLiveTest {
     }
 
     @AfterClass
-    private void tearDown() {
-        closeQuietly(manager);
+    private void tearDown() throws IOException {
+       close(manager, true);
     }
 }

--- a/providers/denominator-dynect/build.gradle
+++ b/providers/denominator-dynect/build.gradle
@@ -20,6 +20,6 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.labs:dynect:1.6.0-alpha.2'
+  compile     'org.jclouds.labs:dynect:1.6.0-alpha.3'
 }
 

--- a/providers/denominator-route53/build.gradle
+++ b/providers/denominator-route53/build.gradle
@@ -19,6 +19,6 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:aws-route53:1.6.0-alpha.2'
+  compile     'org.jclouds.provider:aws-route53:1.6.0-alpha.3'
 }
 

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53ZoneApi.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53ZoneApi.java
@@ -3,7 +3,7 @@ package denominator.route53;
 import javax.inject.Inject;
 
 import org.jclouds.route53.Route53Api;
-import org.jclouds.route53.domain.Zone;
+import org.jclouds.route53.domain.HostedZone;
 
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
@@ -16,15 +16,15 @@ public final class Route53ZoneApi implements denominator.ZoneApi {
         this.api = api;
     }
 
-    private static enum ZoneName implements Function<Zone, String> {
+    private static enum ZoneName implements Function<HostedZone, String> {
         INSTANCE;
-        public String apply(Zone input) {
+        public String apply(HostedZone input) {
             return input.getName();
         }
     }
 
     @Override
     public FluentIterable<String> list() {
-        return api.getZoneApi().list().concat().transform(ZoneName.INSTANCE);
+        return api.getHostedZoneApi().list().concat().transform(ZoneName.INSTANCE);
     }
 }

--- a/providers/denominator-ultradns/build.gradle
+++ b/providers/denominator-ultradns/build.gradle
@@ -19,6 +19,6 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.labs:ultradns-ws:1.6.0-alpha.2'
+  compile     'org.jclouds.labs:ultradns-ws:1.6.0-alpha.3'
 }
 


### PR DESCRIPTION
both are stabilizing and in fact guava 14.0 final is syncing to maven central now.   Latest jclouds release fleshes out record apis for all three providers, and supports IAM Instance Profile (IIP).
