### PR TITLE
model rdata as Map<String, Object>

### DIFF
--- a/denominator-model/src/main/java/denominator/model/rdata/AAAAData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/AAAAData.java
@@ -1,0 +1,74 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Corresponds to the binary representation of the {@code AAAA} (Address) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.AAAAData.aaaa;
+ * ...
+ * AAAAData rdata = aaaa("1234:ab00:ff00::6b14:abcd");
+ * </pre>
+ * 
+ * @see <aaaa href="http://www.ietf.org/rfc/rfc3596.txt">RFC 3596</aaaa>
+ */
+public class AAAAData extends ForwardingMap<String, Object> {
+    private final ImmutableMap<String, Object> delegate;
+
+    @ConstructorProperties("address")
+    private AAAAData(String address) {
+        this.delegate = ImmutableMap.<String, Object> of("address", checkNotNull(address, "address"));
+    }
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * a 128 bit IPv6 address
+     */
+    public String getAddress() {
+        return get("address").toString();
+    }
+
+    public static AAAAData aaaa(String address) {
+        return builder().address(address).build();
+    }
+
+    public static AAAAData.Builder builder() {
+        return new Builder();
+    }
+
+    public AAAAData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String address;
+
+        /**
+         * @see AAAAData#getAddress()
+         */
+        public AAAAData.Builder address(String address) {
+            this.address = address;
+            return this;
+        }
+
+        public AAAAData build() {
+            return new AAAAData(address);
+        }
+
+        public AAAAData.Builder from(AAAAData in) {
+            return this.address(in.getAddress());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/AData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/AData.java
@@ -1,0 +1,74 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Corresponds to the binary representation of the {@code A} (Address) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.AData.a;
+ * ...
+ * AData rdata = a("ptr.foo.com.");
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
+ */
+public class AData extends ForwardingMap<String, Object> {
+    private final ImmutableMap<String, Object> delegate;
+
+    @ConstructorProperties("address")
+    private AData(String address) {
+        this.delegate = ImmutableMap.<String, Object> of("address", checkNotNull(address, "address"));
+    }
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * a 32-bit internet address
+     */
+    public String getAddress() {
+        return get("address").toString();
+    }
+
+    public static AData a(String address) {
+        return builder().address(address).build();
+    }
+
+    public static AData.Builder builder() {
+        return new Builder();
+    }
+
+    public AData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String address;
+
+        /**
+         * @see AData#getAddress()
+         */
+        public AData.Builder address(String address) {
+            this.address = address;
+            return this;
+        }
+
+        public AData build() {
+            return new AData(address);
+        }
+
+        public AData.Builder from(AData in) {
+            return this.address(in.getAddress());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/CNAMEData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/CNAMEData.java
@@ -1,0 +1,76 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Corresponds to the binary representation of the {@code CNAME} (Canonical
+ * Name) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.CNAMEData.cname;
+ * ...
+ * CNAMEData rdata = cname("cname.foo.com.");
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
+ */
+public class CNAMEData extends ForwardingMap<String, Object> {
+    private final ImmutableMap<String, Object> delegate;
+
+    @ConstructorProperties("cname")
+    private CNAMEData(String cname) {
+        this.delegate = ImmutableMap.<String, Object> of("cname", checkNotNull(cname, "cname"));
+    }
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * domain-name which specifies the canonical or primary name for the owner.
+     * The owner name is an alias.
+     */
+    public String getCname() {
+        return get("cname").toString();
+    }
+
+    public static CNAMEData cname(String cname) {
+        return builder().cname(cname).build();
+    }
+
+    public static CNAMEData.Builder builder() {
+        return new Builder();
+    }
+
+    public CNAMEData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String cname;
+
+        /**
+         * @see CNAMEData#getCname()
+         */
+        public CNAMEData.Builder cname(String cname) {
+            this.cname = cname;
+            return this;
+        }
+
+        public CNAMEData build() {
+            return new CNAMEData(cname);
+        }
+
+        public CNAMEData.Builder from(CNAMEData in) {
+            return this.cname(in.getCname());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/MXData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/MXData.java
@@ -1,0 +1,104 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedInteger;
+
+/**
+ * Corresponds to the binary representation of the {@code MX} (Mail Exchange)
+ * RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.MXData.mx;
+ * ...
+ * MXData rdata = mx(1, "mail.jclouds.org");
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
+ */
+public class MXData extends ForwardingMap<String, Object> {
+
+    @ConstructorProperties({ "preference", "exchange" })
+    private MXData(UnsignedInteger preference, String exchange) {
+        this.delegate = ImmutableMap.<String, Object> builder()
+                .put("preference", checkNotNull(preference, "preference"))
+                .put("exchange", checkNotNull(exchange, "exchange")).build();
+    }
+
+    private final ImmutableMap<String, Object> delegate;
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * specifies the preference given to this RR among others at the same owner.
+     * Lower values are preferred.
+     */
+    public UnsignedInteger getPreference() {
+        return UnsignedInteger.class.cast(get("preference"));
+    }
+
+    /**
+     * domain-name which specifies a host willing to act as a mail exchange for
+     * the owner name.
+     */
+    public String getExchange() {
+        return String.class.cast(get("exchange"));
+    }
+
+    public static MXData mx(int preference, String exchange) {
+        return builder().preference(preference).exchange(exchange).build();
+    }
+
+    public static MXData.Builder builder() {
+        return new Builder();
+    }
+
+    public MXData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private UnsignedInteger preference;
+        private String exchange;
+
+        /**
+         * @see MXData#getPreference()
+         */
+        public MXData.Builder preference(int preference) {
+            return preference(UnsignedInteger.fromIntBits(preference));
+        }
+
+        /**
+         * @see MXData#getPreference()
+         */
+        public MXData.Builder preference(UnsignedInteger preference) {
+            this.preference = preference;
+            return this;
+        }
+
+        /**
+         * @see MXData#getExchange()
+         */
+        public MXData.Builder exchange(String exchange) {
+            this.exchange = exchange;
+            return this;
+        }
+
+        public MXData build() {
+            return new MXData(preference, exchange);
+        }
+
+        public MXData.Builder from(MXData in) {
+            return this.preference(in.getPreference()).exchange(in.getExchange());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/NSData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/NSData.java
@@ -1,0 +1,76 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Corresponds to the binary representation of the {@code NS} (Name Server)
+ * RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.NSData.ns;
+ * ...
+ * NSData rdata = ns("ns.foo.com.");
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
+ */
+public class NSData extends ForwardingMap<String, Object> {
+    private final ImmutableMap<String, Object> delegate;
+
+    @ConstructorProperties("nsdname")
+    private NSData(String nsdname) {
+        this.delegate = ImmutableMap.<String, Object> of("nsdname", checkNotNull(nsdname, "nsdname"));
+    }
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * domain-name which specifies a host which should be authoritative for the
+     * specified class and domain.
+     */
+    public String getNsdname() {
+        return get("nsdname").toString();
+    }
+
+    public static NSData ns(String nsdname) {
+        return builder().nsdname(nsdname).build();
+    }
+
+    public static NSData.Builder builder() {
+        return new Builder();
+    }
+
+    public NSData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String nsdname;
+
+        /**
+         * @see NSData#getNsdname()
+         */
+        public NSData.Builder nsdname(String nsdname) {
+            this.nsdname = nsdname;
+            return this;
+        }
+
+        public NSData build() {
+            return new NSData(nsdname);
+        }
+
+        public NSData.Builder from(NSData in) {
+            return this.nsdname(in.getNsdname());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/PTRData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/PTRData.java
@@ -1,0 +1,74 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Corresponds to the binary representation of the {@code PTR} (Pointer) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.PTRData.ptr;
+ * ...
+ * PTRData rdata = ptr("ptr.foo.com.");
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
+ */
+public class PTRData extends ForwardingMap<String, Object> {
+    private final ImmutableMap<String, Object> delegate;
+
+    @ConstructorProperties("ptrdname")
+    private PTRData(String ptrdname) {
+        this.delegate = ImmutableMap.<String, Object> of("ptrdname", checkNotNull(ptrdname, "ptrdname"));
+    }
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * domain-name which points to some location in the domain name space.
+     */
+    public String getPtrdname() {
+        return get("ptrdname").toString();
+    }
+
+    public static PTRData ptr(String ptrdname) {
+        return builder().ptrdname(ptrdname).build();
+    }
+
+    public static PTRData.Builder builder() {
+        return new Builder();
+    }
+
+    public PTRData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String ptrdname;
+
+        /**
+         * @see PTRData#getPtrdname()
+         */
+        public PTRData.Builder ptrdname(String ptrdname) {
+            this.ptrdname = ptrdname;
+            return this;
+        }
+
+        public PTRData build() {
+            return new PTRData(ptrdname);
+        }
+
+        public PTRData.Builder from(PTRData in) {
+            return this.ptrdname(in.getPtrdname());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/SOAData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SOAData.java
@@ -1,0 +1,222 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedInteger;
+
+/**
+ * Corresponds to the binary representation of the {@code SOA} (Start of
+ * Authority) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * SOAData rdata = SOAData.builder()
+ *                        .rname(&quot;foo.com.&quot;)
+ *                        .mname(&quot;admin.foo.com.&quot;)
+ *                        .serial(1)
+ *                        .refresh(3600)
+ *                        .retry(600)
+ *                        .expire(604800)
+ *                        .minimum(60).build()
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
+ */
+public class SOAData extends ForwardingMap<String, Object> {
+
+    @ConstructorProperties({ "mname", "rname", "serial", "refresh", "retry", "expire", "minimum" })
+    private SOAData(String mname, String rname, UnsignedInteger serial, UnsignedInteger refresh, UnsignedInteger retry,
+            UnsignedInteger expire, UnsignedInteger minimum) {
+        this.delegate = ImmutableMap.<String, Object> builder()
+                .put("mname", checkNotNull(mname, "mname"))
+                .put("rname", checkNotNull(rname, "rname of %s", mname))
+                .put("serial", checkNotNull(serial, "serial of %s", mname))
+                .put("refresh", checkNotNull(refresh, "refresh of %s", mname))
+                .put("retry", checkNotNull(retry, "retry of %s", mname))
+                .put("expire", checkNotNull(expire, "expire of %s", mname))
+                .put("minimum", checkNotNull(minimum, "minimum of %s", mname)).build();
+    }
+
+    private final ImmutableMap<String, Object> delegate;
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * domain-name of the name server that was the original or primary source of
+     * data for this zone
+     */
+    public String getMname() {
+        return String.class.cast(get("mname"));
+    }
+
+    /**
+     * domain-name which specifies the mailbox of the person responsible for
+     * this zone.
+     */
+    public String getRname() {
+        return String.class.cast(get("rname"));
+    }
+
+    /**
+     * version number of the original copy of the zone.
+     */
+    public UnsignedInteger getSerial() {
+        return UnsignedInteger.class.cast(get("serial"));
+    }
+
+    /**
+     * time interval before the zone should be refreshed
+     */
+    public UnsignedInteger getRefresh() {
+        return UnsignedInteger.class.cast(get("refresh"));
+    }
+
+    /**
+     * time interval that should elapse before a failed refresh should be
+     * retried
+     */
+    public UnsignedInteger getRetry() {
+        return UnsignedInteger.class.cast(get("retry"));
+    }
+
+    /**
+     * time value that specifies the upper limit on the time interval that can
+     * elapse before the zone is no longer authoritative.
+     */
+    public UnsignedInteger getExpire() {
+        return UnsignedInteger.class.cast(get("expire"));
+    }
+
+    /**
+     * minimum TTL field that should be exported with any RR from this zone.
+     */
+    public UnsignedInteger getMinimum() {
+        return UnsignedInteger.class.cast(get("minimum"));
+    }
+
+    public static SOAData.Builder builder() {
+        return new Builder();
+    }
+
+    public SOAData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String mname;
+        private String rname;
+        private UnsignedInteger serial;
+        private UnsignedInteger refresh;
+        private UnsignedInteger retry;
+        private UnsignedInteger expire;
+        private UnsignedInteger minimum;
+
+        /**
+         * @see SOAData#getMname()
+         */
+        public SOAData.Builder mname(String mname) {
+            this.mname = mname;
+            return this;
+        }
+
+        /**
+         * @see SOAData#getRname()
+         */
+        public SOAData.Builder rname(String rname) {
+            this.rname = rname;
+            return this;
+        }
+
+        /**
+         * @see SOAData#getSerial()
+         */
+        public SOAData.Builder serial(UnsignedInteger serial) {
+            this.serial = serial;
+            return this;
+        }
+
+        /**
+         * @see SOAData#getSerial()
+         */
+        public SOAData.Builder serial(int serial) {
+            return serial(UnsignedInteger.fromIntBits(serial));
+        }
+
+        /**
+         * @see SOAData#getRefresh()
+         */
+        public SOAData.Builder refresh(UnsignedInteger refresh) {
+            this.refresh = refresh;
+            return this;
+        }
+
+        /**
+         * @see SOAData#getRefresh()
+         */
+        public SOAData.Builder refresh(int refresh) {
+            return refresh(UnsignedInteger.fromIntBits(refresh));
+        }
+
+        /**
+         * @see SOAData#getRetry()
+         */
+        public SOAData.Builder retry(UnsignedInteger retry) {
+            this.retry = retry;
+            return this;
+        }
+
+        /**
+         * @see SOAData#getRetry()
+         */
+        public SOAData.Builder retry(int retry) {
+            return retry(UnsignedInteger.fromIntBits(retry));
+        }
+
+        /**
+         * @see SOAData#getExpire()
+         */
+        public SOAData.Builder expire(UnsignedInteger expire) {
+            this.expire = expire;
+            return this;
+        }
+
+        /**
+         * @see SOAData#getExpire()
+         */
+        public SOAData.Builder expire(int expire) {
+            return expire(UnsignedInteger.fromIntBits(expire));
+        }
+
+        /**
+         * @see SOAData#getMinimum()
+         */
+        public SOAData.Builder minimum(UnsignedInteger minimum) {
+            this.minimum = minimum;
+            return this;
+        }
+
+        /**
+         * @see SOAData#getMinimum()
+         */
+        public SOAData.Builder minimum(int minimum) {
+            return minimum(UnsignedInteger.fromIntBits(minimum));
+        }
+
+        public SOAData build() {
+            return new SOAData(mname, rname, serial, refresh, retry, expire, minimum);
+        }
+
+        public SOAData.Builder from(SOAData in) {
+            return this.mname(in.getMname()).rname(in.getRname()).serial(in.getSerial()).refresh(in.getRefresh())
+                    .expire(in.getExpire()).minimum(in.getMinimum());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/SPFData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SPFData.java
@@ -1,0 +1,74 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Corresponds to the binary representation of the {@code SPF} (Sender Policy Framework) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.SPFData.spf;
+ * ...
+ * SPFData rdata = spf("v=spf1 +mx a:colo.example.com/28 -all");
+ * </pre>
+ * 
+ * @see <a href="http://tools.ietf.org/html/rfc4408#section-3.1.1">RFC 4408</a>
+ */
+public class SPFData extends ForwardingMap<String, Object> {
+    private final ImmutableMap<String, Object> delegate;
+
+    @ConstructorProperties("spfdata")
+    private SPFData(String spfdata) {
+        this.delegate = ImmutableMap.<String, Object> of("spfdata", checkNotNull(spfdata, "spfdata"));
+    }
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * One or more character-strings.
+     */
+    public String getSpfdata() {
+        return get("spfdata").toString();
+    }
+
+    public static SPFData spf(String spfdata) {
+        return builder().spfdata(spfdata).build();
+    }
+
+    public static SPFData.Builder builder() {
+        return new Builder();
+    }
+
+    public SPFData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String spfdata;
+
+        /**
+         * @see SPFData#getSpfdata()
+         */
+        public SPFData.Builder spfdata(String spfdata) {
+            this.spfdata = spfdata;
+            return this;
+        }
+
+        public SPFData build() {
+            return new SPFData(spfdata);
+        }
+
+        public SPFData.Builder from(SPFData in) {
+            return this.spfdata(in.getSpfdata());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/SRVData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SRVData.java
@@ -1,0 +1,154 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedInteger;
+
+/**
+ * Corresponds to the binary representation of the {@code SRV} (Service) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * SRVData rdata = SRVData.builder()
+ *                        .priority(0)
+ *                        .weight(1)
+ *                        .port(80)
+ *                        .target(&quot;www.foo.com.&quot;).build()
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc2782.txt">RFC 2782</a>
+ */
+public class SRVData extends ForwardingMap<String, Object> {
+
+    @ConstructorProperties({ "priority", "weight", "port", "target" })
+    private SRVData(UnsignedInteger priority, UnsignedInteger weight, UnsignedInteger port, String target) {
+        this.delegate = ImmutableMap.<String, Object> builder()
+                .put("priority", checkNotNull(priority, "priority of %s", target))
+                .put("weight", checkNotNull(weight, "weight of %s", target))
+                .put("port", checkNotNull(port, "port of %s", target))
+                .put("target", checkNotNull(target, "target"))
+                .build();
+    }
+
+    private final ImmutableMap<String, Object> delegate;
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * The priority of this target host. A client MUST attempt to contact the
+     * target host with the lowest-numbered priority it can reach; target hosts
+     * with the same priority SHOULD be tried in an order defined by the weight
+     * field.
+     */
+    public UnsignedInteger getPriority() {
+        return UnsignedInteger.class.cast(get("priority"));
+    }
+
+    /**
+     * The weight field specifies a relative weight for entries with the same
+     * priority. Larger weights SHOULD be given a proportionately higher
+     * probability of being selected.
+     */
+    public UnsignedInteger getWeight() {
+        return UnsignedInteger.class.cast(get("weight"));
+    }
+
+    /**
+     * The port on this target host of this service.
+     */
+    public UnsignedInteger getPort() {
+        return UnsignedInteger.class.cast(get("port"));
+    }
+
+    /**
+     * The domain name of the target host. There MUST be one or more address
+     * records for this name, the name MUST NOT be an alias.
+     */
+    public String getTarget() {
+        return String.class.cast(get("target"));
+    }
+
+    public static SRVData.Builder builder() {
+        return new Builder();
+    }
+
+    public SRVData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private UnsignedInteger priority;
+        private UnsignedInteger weight;
+        private UnsignedInteger port;
+        private String target;
+
+        /**
+         * @see SRVData#getPriority()
+         */
+        public SRVData.Builder priority(UnsignedInteger priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        /**
+         * @see SRVData#getPriority()
+         */
+        public SRVData.Builder priority(int priority) {
+            return priority(UnsignedInteger.fromIntBits(priority));
+        }
+
+        /**
+         * @see SRVData#getWeight()
+         */
+        public SRVData.Builder weight(UnsignedInteger weight) {
+            this.weight = weight;
+            return this;
+        }
+
+        /**
+         * @see SRVData#getWeight()
+         */
+        public SRVData.Builder weight(int weight) {
+            return weight(UnsignedInteger.fromIntBits(weight));
+        }
+
+        /**
+         * @see SRVData#getPort()
+         */
+        public SRVData.Builder port(UnsignedInteger port) {
+            this.port = port;
+            return this;
+        }
+
+        /**
+         * @see SRVData#getPort()
+         */
+        public SRVData.Builder port(int port) {
+            return port(UnsignedInteger.fromIntBits(port));
+        }
+
+        /**
+         * @see SRVData#getTarget()
+         */
+        public SRVData.Builder target(String target) {
+            this.target = target;
+            return this;
+        }
+
+        public SRVData build() {
+            return new SRVData(priority, weight, port, target);
+        }
+
+        public SRVData.Builder from(SRVData in) {
+            return this.priority(in.getPriority()).weight(in.getWeight()).port(in.getPort()).target(in.getTarget());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/SSHFPData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SSHFPData.java
@@ -1,0 +1,145 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedInteger;
+
+/**
+ * Corresponds to the binary representation of the {@code SSHFP} (SSH Fingerprint) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.SSHFPData.sshfpDSA;
+ * ...
+ * SSHFPData rdata = SSHFPData.builder()
+ *                            .algorithm(2)
+ *                            .type(1)
+ *                            .fingerprint(&quot;123456789abcdef67890123456789abcdef67890&quot;).build();
+ *  // or shortcut
+ * SSHFPData rdata = sshfpDSA(&quot;123456789abcdef67890123456789abcdef67890&quot;);
+ * </pre>
+ * 
+ * @see <a href="http://www.rfc-editor.org/rfc/rfc4255.txt">RFC 4255</a>
+ */
+public class SSHFPData extends ForwardingMap<String, Object> {
+
+    @ConstructorProperties({ "algorithm", "type", "fingerprint" })
+    private SSHFPData(UnsignedInteger algorithm, UnsignedInteger type, String fingerprint) {
+        this.delegate = ImmutableMap.<String, Object> builder()
+                .put("algorithm", checkNotNull(algorithm, "algorithm of %s", fingerprint))
+                .put("type", checkNotNull(type, "type of %s", fingerprint))
+                .put("fingerprint", checkNotNull(fingerprint, "fingerprint"))
+                .build();
+    }
+
+    private final ImmutableMap<String, Object> delegate;
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * This algorithm number octet describes the algorithm of the public key.
+     * @return most often {@code 1} for {@code RSA} or {@code 2} for {@code DSA}. 
+     */
+    public UnsignedInteger getAlgorithm() {
+        return UnsignedInteger.class.cast(get("algorithm"));
+    }
+
+    /**
+     * The fingerprint type octet describes the message-digest algorithm used to
+     * calculate the fingerprint of the public key.
+     * 
+     * @return most often {@code 1} for {@code SHA-1}
+     */
+    public UnsignedInteger getType() {
+        return UnsignedInteger.class.cast(get("type"));
+    }
+
+    /**
+     * The fingerprint calculated over the public key blob.
+     */
+    public String getFingerprint() {
+        return String.class.cast(get("fingerprint"));
+    }
+
+    public static SSHFPData.Builder builder() {
+        return new Builder();
+    }
+
+    public SSHFPData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    /**
+     * @param fingerprint {@code DSA} {@code SHA-1} fingerprint 
+     */
+    public static SSHFPData sshfpDSA(String fingerprint) {
+        return builder().algorithm(1).type(2).fingerprint(fingerprint).build();
+    }
+
+    /**
+     * @param fingerprint {@code RSA} {@code SHA-1} fingerprint 
+     */
+    public static SSHFPData sshfpRSA(String fingerprint) {
+        return builder().algorithm(1).type(1).fingerprint(fingerprint).build();
+    }
+
+    public final static class Builder {
+        private UnsignedInteger algorithm;
+        private UnsignedInteger type;
+        private String fingerprint;
+
+        /**
+         * @see SSHFPData#getAlgorithm()
+         */
+        public SSHFPData.Builder algorithm(UnsignedInteger algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+
+        /**
+         * @see SSHFPData#getAlgorithm()
+         */
+        public SSHFPData.Builder algorithm(int algorithm) {
+            return algorithm(UnsignedInteger.fromIntBits(algorithm));
+        }
+
+        /**
+         * @see SSHFPData#getType()
+         */
+        public SSHFPData.Builder type(UnsignedInteger type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * @see SSHFPData#getType()
+         */
+        public SSHFPData.Builder type(int type) {
+            return type(UnsignedInteger.fromIntBits(type));
+        }
+
+        /**
+         * @see SSHFPData#getFingerprint()
+         */
+        public SSHFPData.Builder fingerprint(String fingerprint) {
+            this.fingerprint = fingerprint;
+            return this;
+        }
+
+        public SSHFPData build() {
+            return new SSHFPData(algorithm, type, fingerprint);
+        }
+
+        public SSHFPData.Builder from(SSHFPData in) {
+            return this.algorithm(in.getAlgorithm()).type(in.getType()).fingerprint(in.getFingerprint());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/TXTData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/TXTData.java
@@ -1,0 +1,74 @@
+package denominator.model.rdata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Corresponds to the binary representation of the {@code TXT} (Text) RData
+ * 
+ * <h4>Example</h4>
+ * 
+ * <pre>
+ * import static denominator.model.rdata.TXTData.txt;
+ * ...
+ * TXTData rdata = txt("=spf1 ip4:1.1.1.1/24 ip4:2.2.2.2/24 -all");
+ * </pre>
+ * 
+ * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
+ */
+public class TXTData extends ForwardingMap<String, Object> {
+    private final ImmutableMap<String, Object> delegate;
+
+    @ConstructorProperties("txtdata")
+    private TXTData(String txtdata) {
+        this.delegate = ImmutableMap.<String, Object> of("txtdata", checkNotNull(txtdata, "txtdata"));
+    }
+
+    protected Map<String, Object> delegate() {
+        return delegate;
+    }
+
+    /**
+     * One or more character-strings.
+     */
+    public String getTxtdata() {
+        return get("txtdata").toString();
+    }
+
+    public static TXTData txt(String txtdata) {
+        return builder().txtdata(txtdata).build();
+    }
+
+    public static TXTData.Builder builder() {
+        return new Builder();
+    }
+
+    public TXTData.Builder toBuilder() {
+        return builder().from(this);
+    }
+
+    public final static class Builder {
+        private String txtdata;
+
+        /**
+         * @see TXTData#getTxtdata()
+         */
+        public TXTData.Builder txtdata(String txtdata) {
+            this.txtdata = txtdata;
+            return this;
+        }
+
+        public TXTData build() {
+            return new TXTData(txtdata);
+        }
+
+        public TXTData.Builder from(TXTData in) {
+            return this.txtdata(in.getTxtdata());
+        }
+    }
+}

--- a/denominator-model/src/main/java/denominator/model/rdata/package-info.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * DNS record data ({@code rdata}) in <a href="http://tools.ietf.org/html/rfc1035">Master File Format</a> are represented as {@code Map<String, Object>}, preferring values to be {@link com.google.common.primitives.UnsignedInteger} or {@code String}.
+ *
+ */
+package denominator.model.rdata;


### PR DESCRIPTION
Recent discussions have led to dropping the idea of keeping backend rdata formats in their native form.  As originally suggested by @jdamick going with Master Record Format.

Constructing these come in either simple or builder form, depending on the complexity of the rdata.

ex. ipv6 is single value 

```
import static denominator.model.rdata.AAAAData.aaaa;
...
AAAAData rdata = aaaa("1234:ab00:ff00::6b14:abcd");
```

where srv data is more complex

```
SRVData rdata = SRVData.builder()
                       .priority(0)
                       .weight(2)
                       .port(80)
                       .target("www.denominator.io.").build()
```

In either case, an RData base type isn't explicitly defined, rather rdata is or extends `Map<String, Object>`.  For example, a `RecordSet<R extends Map<String, Object>>` allows  `RecordSet<AAAA>` as well  `RecordSet<Map<String, Object>>` for unknown types.

In these Maps, the field names correspond to the record names, and the values are typically `String` or `UnsignedInteger`.  Using simple value types help in many ways, not the least of which codec to and from thrift or json.

ex. rdata is a map, so it can be serialized as json such as srvData below

```
{"priority": 0, "weight": 2, "port": 80, "target": "www.denominator.io."}
```

One constraint this design concedes is that providers who represent records in text format (ex. route53) will require codec and that due to the nature of text format, comments are lost in translation.  This is "ok" as for example route53 only supports limited record types and we'd probably need helper codecs for text format anyway.

Ex. we need a utility that does the following:

```
srvData = fromText("0 2 80 www.denominator.io.");
```
