### PR TITLE
have route53 by default take credentials from IAM Instance Profile

### DIFF
--- a/denominator-core/src/main/java/denominator/CredentialsConfiguration.java
+++ b/denominator-core/src/main/java/denominator/CredentialsConfiguration.java
@@ -142,7 +142,8 @@ public class CredentialsConfiguration {
     public static Credentials firstValidCredentialsForProvider(Set<Supplier<Credentials>> allSuppliers,
             Provider provider) {
         for (Supplier<Credentials> supplier : allSuppliers) {
-            return checkValidForProvider(supplier.get(), provider);
+            Credentials credentials = supplier.get();
+            return checkValidForProvider(credentials, provider);
         }
         return checkValidForProvider(AnonymousCredentials.INSTANCE, provider);
     }
@@ -217,7 +218,7 @@ public class CredentialsConfiguration {
 
     private static boolean credentialConfigurationHasKeys(Provider provider, Set<?> keys) {
         for (String credentialType : provider.getCredentialTypeToParameterNames().keySet())
-            if (keys.equals(provider.getCredentialTypeToParameterNames().get(credentialType)))
+            if (keys.containsAll(provider.getCredentialTypeToParameterNames().get(credentialType)))
                 return true;
         return false;
     }

--- a/providers/denominator-route53/build.gradle
+++ b/providers/denominator-route53/build.gradle
@@ -20,5 +20,6 @@ dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
   compile     'org.jclouds.provider:aws-route53:1.6.0-alpha.3'
+  testCompile     'com.google.mockwebserver:mockwebserver:20130201'
 }
 

--- a/providers/denominator-route53/src/main/java/denominator/route53/InstanceProfileCredentialsSupplier.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/InstanceProfileCredentialsSupplier.java
@@ -1,0 +1,131 @@
+package denominator.route53;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.util.Strings2.toStringAndClose;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
+import denominator.Credentials;
+import denominator.Credentials.MapCredentials;
+
+/**
+ * Credentials supplier implementation that loads credentials from the Amazon
+ * EC2 Instance Metadata Service.
+ */
+public class InstanceProfileCredentialsSupplier implements Supplier<Credentials> {
+    private final Supplier<String> iipJsonSupplier;
+
+    public InstanceProfileCredentialsSupplier() {
+        this(new ReadFirstInstanceProfileCredentialsOrNull());
+    }
+
+    public InstanceProfileCredentialsSupplier(String baseUri) {
+        this(new ReadFirstInstanceProfileCredentialsOrNull(baseUri));
+    }
+
+    public InstanceProfileCredentialsSupplier(Supplier<String> iipJsonSupplier) {
+        this.iipJsonSupplier = checkNotNull(iipJsonSupplier, "iipJsonSupplier");
+    }
+
+    @Override
+    public Credentials get() {
+        return MapCredentials.from(parseJson(iipJsonSupplier.get()));
+    }
+
+    private static final Map<String, String> keyMap = ImmutableMap.of("AccessKeyId", "accessKey", "SecretAccessKey",
+            "secretKey", "Token", "sessionToken");
+
+    /**
+     * IAM Instance Profile format is simple, non-nested json.
+     * 
+     * ex.
+     * 
+     * <pre>
+     * {
+     *   "Code" : "Success",
+     *   "LastUpdated" : "2013-02-26T02:03:57Z",
+     *   "Type" : "AWS-HMAC",
+     *   "AccessKeyId" : "AAAAA",
+     *   "SecretAccessKey" : "SSSSSSS",
+     *   "Token" : "TTTTTTT",
+     *   "Expiration" : "2013-02-26T08:12:23Z"
+     * }
+     * 
+     * </pre>
+     * 
+     * This impl avoids choosing a json library by parsing the simple structure
+     * above directly.
+     * 
+     */
+    static Map<String, String> parseJson(String in) {
+        if (in == null)
+            return ImmutableMap.of();
+        String noBraces = in.replace('{', ' ').replace('}', ' ').trim();
+        Builder<String, String> builder = ImmutableMap.<String, String> builder();
+        for (Entry<String, String> entry : Splitter.on(',').withKeyValueSeparator(" : ").split(noBraces).entrySet()) {
+            String key = keyMap.get(entry.getKey().replace('"', ' ').trim());
+            if (key != null)
+                builder.put(key, entry.getValue().replace('"', ' ').trim());
+        }
+        return builder.build();
+    }
+
+    /**
+     * default means to grab instance credentials, or return null
+     */
+    static class ReadFirstInstanceProfileCredentialsOrNull implements Supplier<String> {
+        private final String baseUri;
+
+        public ReadFirstInstanceProfileCredentialsOrNull() {
+            this("http://169.254.169.254/");
+        }
+
+        /**
+         * @param baseUri
+         *            uri string with trailing slash
+         */
+        public ReadFirstInstanceProfileCredentialsOrNull(String baseUri) {
+            this.baseUri = checkNotNull(baseUri, "baseUri");
+        }
+
+        @Override
+        public String get() {
+            String resource = baseUri + "latest/meta-data/iam/security-credentials/";
+            try {
+                String output = toStringAndClose(openStream(resource)).trim();
+                List<String> roles = ImmutableList.copyOf(Splitter.on('\n').split(output));
+                if (roles.isEmpty())
+                    return null;
+                return toStringAndClose(openStream(resource + roles.get(0)));
+            } catch (IOException e) {
+                return null;
+            }
+        }
+
+        private InputStream openStream(String resource) throws IOException {
+            HttpURLConnection connection = HttpURLConnection.class.cast(URI.create(resource).toURL().openConnection());
+            connection.setConnectTimeout(1000 * 2);
+            connection.setReadTimeout(1000 * 2);
+            connection.setAllowUserInteraction(false);
+            connection.setInstanceFollowRedirects(false);
+            return connection.getInputStream();
+        }
+
+        @Override
+        public String toString() {
+            return "ReadFirstInstanceProfileCredentialsOrNull(" + baseUri + ")";
+        }
+    }
+}

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53Provider.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53Provider.java
@@ -15,6 +15,7 @@ import org.jclouds.rest.RestContext;
 import org.jclouds.route53.Route53AsyncApi;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -32,6 +33,11 @@ public class Route53Provider extends Provider {
     @Provides
     protected Provider provideThis() {
         return this;
+    }
+
+    @Override
+    public Optional<Supplier<denominator.Credentials>> defaultCredentialSupplier() {
+        return Optional.<Supplier<denominator.Credentials>> of(new InstanceProfileCredentialsSupplier());
     }
 
     @Provides

--- a/providers/denominator-route53/src/test/java/denominator/route53/InstanceProfileCredentialsSupplierTest.java
+++ b/providers/denominator-route53/src/test/java/denominator/route53/InstanceProfileCredentialsSupplierTest.java
@@ -1,0 +1,147 @@
+package denominator.route53;
+
+import static com.google.mockwebserver.SocketPolicy.DISCONNECT_AT_START;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+
+import denominator.Credentials;
+import denominator.Credentials.MapCredentials;
+import denominator.CredentialsConfiguration;
+import denominator.route53.InstanceProfileCredentialsSupplier.ReadFirstInstanceProfileCredentialsOrNull;
+
+@Test
+public class InstanceProfileCredentialsSupplierTest {
+    Credentials sessionCredentials = MapCredentials.from(ImmutableMap.of("accessKey", "AAAAA", "secretKey", "SSSSSSS",
+            "sessionToken", "TTTTTTT"));
+
+    public void sessionCredentialsValidForRoute53() {
+        CredentialsConfiguration.checkValidForProvider(sessionCredentials, new Route53Provider());
+    }
+
+    public void whenInstanceProfileCredentialsInMetadataServiceReturnMapCredentials() throws Exception {
+        String securityCredentialsJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream(
+                "/security-credentials.json")));
+        MockWebServer server = new MockWebServer();
+        try {
+
+            server.enqueue(new MockResponse().setBody("route53-readonly"));
+            server.enqueue(new MockResponse().setBody(securityCredentialsJson));
+            server.play();
+
+            assertEquals(new InstanceProfileCredentialsSupplier(new ReadFirstInstanceProfileCredentialsOrNull(server
+                    .getUrl("/").toString())).get(), sessionCredentials);
+
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/ HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/route53-readonly HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test(timeOut = 3000)
+    public void whenMetadataServiceIsntRunningWeDontHangMoreThan3Seconds() throws Exception {
+        MockWebServer server = new MockWebServer();
+        try {
+            server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AT_START));
+            server.play();
+
+            assertNull(new ReadFirstInstanceProfileCredentialsOrNull(server.getUrl("/").toString()).get());
+
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/ HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void whenNoInstanceProfileCredentialsInMetadataServiceReturnNull() throws Exception {
+        MockWebServer server = new MockWebServer();
+        try {
+
+            server.enqueue(new MockResponse().setBody(""));
+            server.play();
+
+            assertNull(new ReadFirstInstanceProfileCredentialsOrNull(server.getUrl("/").toString()).get());
+
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/ HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void whenInstanceProfileCredentialsInMetadataServiceReturnJson() throws Exception {
+        String securityCredentialsJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream(
+                "/security-credentials.json")));
+        MockWebServer server = new MockWebServer();
+        try {
+
+            server.enqueue(new MockResponse().setBody("route53-readonly"));
+            server.enqueue(new MockResponse().setBody(securityCredentialsJson));
+            server.play();
+
+            assertEquals(new ReadFirstInstanceProfileCredentialsOrNull(server.getUrl("/").toString()).get(),
+                    securityCredentialsJson);
+
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/ HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/route53-readonly HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void whenMultipleInstanceProfileCredentialsInMetadataServiceReturnJsonFromFirst() throws Exception {
+        String securityCredentialsJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream(
+                "/security-credentials.json")));
+        MockWebServer server = new MockWebServer();
+        try {
+
+            server.enqueue(new MockResponse().setBody("route53-readonly\nbooberry"));
+            server.enqueue(new MockResponse().setBody(securityCredentialsJson));
+            server.play();
+
+            assertEquals(new ReadFirstInstanceProfileCredentialsOrNull(server.getUrl("/").toString()).get(),
+                    securityCredentialsJson);
+
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/ HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(),
+                    "GET /latest/meta-data/iam/security-credentials/route53-readonly HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void testParseInstanceProfileCredentialsFromJsonWhenNull() {
+        assertEquals(InstanceProfileCredentialsSupplier.parseJson(null), ImmutableMap.of());
+    }
+
+    public void testParseInstanceProfileCredentialsFromJsonWhenWrongKeys() {
+        assertEquals(InstanceProfileCredentialsSupplier.parseJson("{\"Code\" : \"Failure\"}"), ImmutableMap.of());
+    }
+
+    public void testParseInstanceProfileCredentialsFromJsonWhenAccessAndSecretPresent() {
+        assertEquals(
+                InstanceProfileCredentialsSupplier
+                        .parseJson("{\"AccessKeyId\" : \"AAAAA\",\"SecretAccessKey\" : \"SSSSSSS\"}"),
+                ImmutableMap.of("accessKey", "AAAAA", "secretKey", "SSSSSSS"));
+    }
+
+    public void testParseInstanceProfileCredentialsFromJsonWhenAccessSecretAndTokenPresent() {
+        assertEquals(
+                InstanceProfileCredentialsSupplier
+                        .parseJson("{\"AccessKeyId\" : \"AAAAA\",\"SecretAccessKey\" : \"SSSSSSS\", \"Token\" : \"TTTTTTT\"}"),
+                ImmutableMap.of("accessKey", "AAAAA", "secretKey", "SSSSSSS", "sessionToken", "TTTTTTT"));
+    }
+}

--- a/providers/denominator-route53/src/test/resources/security-credentials.json
+++ b/providers/denominator-route53/src/test/resources/security-credentials.json
@@ -1,0 +1,9 @@
+{
+  "Code" : "Success",
+  "LastUpdated" : "2013-02-26T02:03:57Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "AAAAA",
+  "SecretAccessKey" : "SSSSSSS",
+  "Token" : "TTTTTTT",
+  "Expiration" : "2013-02-26T08:12:23Z"
+}


### PR DESCRIPTION
This allows users to skip passing credentials when running on an EC2 instance with an IAM Instance Profile associated and assigned a role that permits route53:*

ex.

```
route53 = Denominator.create("route53");
```
