### PR TITLE
add an executable cli

### DIFF
--- a/denominator-cli/README.md
+++ b/denominator-cli/README.md
@@ -1,0 +1,42 @@
+# Denominator CLI
+
+The denominator CLI is a git-like-cli based on the [airline](https://github.com/airlift/airline) project.  It is packaged as a [really executable jar](http://skife.org/java/unix/2011/06/20/really_executable_jars.html) which means you can do `./denominator` without any of the `java -jar` stuff.
+
+## Building
+To build the cli, execute `./gradlew clean test install` from the root of your denominator clone.  The binary will end up at `/denominator-cli/build/denominator`
+
+## Running
+denominator will print out a help statement, but here's the gist.
+
+### Providers
+Execute `./denominator providers`  The output will tell you what credentials are needed for the provider.  Here's an example.
+
+```
+provider	credential type	credential parameters
+mock	
+dynect	password	customer username password
+ultradns	password	username password
+route53	accessKey	accessKey secretKey
+route53	session	accessKey secretKey sessionToken
+```
+
+The first field says the type, if any.  If there's no type listed, it needs no credentials.  If there is a type listed, the following fields are credential args.  Say for example, you were using `ultradns`.  
+
+```
+ultradns        password        username password
+```
+This says the provider `ultradns` supports `password` authentication, which needs two `-c` parameters: `username` and `password`.  To put it together, you'd specify the following to do a zone list:
+```
+./denominator -p ultradns -c myusername -c mypassword zone list
+```
+### Zones
+The only command yet implemented is zone list, and this returns the zones in your account.  Ex.
+```
+./denominator -p route53 -c access -c secret zone list
+```
+## Hooks
+### IAM Instance Profile
+If you are using the `route53` provider on an ec2 instance with a profile associated with it, you don't need to pass credentials.  The syntax would end up like this.
+```
+./denominator -p route53 zone list
+```

--- a/denominator-cli/build.gradle
+++ b/denominator-cli/build.gradle
@@ -1,0 +1,81 @@
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
+
+eclipse {
+  classpath {
+    downloadSources = true
+    downloadJavadoc = true
+  }
+}
+
+dependencies {
+  compile      project(':denominator-core')
+  compile      project(':providers:denominator-dynect')
+  compile      project(':providers:denominator-ultradns')
+  compile      project(':providers:denominator-route53')
+  compile     'io.airlift:airline:0.5'
+}
+
+// create a self-contained jar that is executable
+// the file output name is "build/denominator"
+task fat(dependsOn: classes, type: Jar) { 
+  classifier = "fat"
+  destinationDir = buildDir
+  archiveName = "denominator"  
+
+  // merge provider files together
+  // http://java.dzone.com/articles/jar-deps-dont-meta
+  def providerFile = "META-INF/services/denominator.Provider"
+
+  def mergeDir = "${buildDir}/merge"
+
+  def runtimeDeps = configurations.runtime.collect {
+    it.isDirectory() ? it : zipTree(it)
+  }
+
+  doFirst {
+    new File(mergeDir).delete()
+    def mergedFile = new File(mergeDir, providerFile)
+    new File(mergedFile.parent).mkdirs()
+    runtimeDeps*.matching({ include "**/${providerFile}" })*.each {
+      mergedFile << it.bytes
+    }
+  }
+
+  from (sourceSets*.output.classesDir) {
+    exclude providerFile
+  }
+
+  from {
+    configurations.compile.collect {
+      it.isDirectory() ? it : zipTree(it)
+    }    
+  }
+
+  from(mergeDir)  
+
+  // really executable jar
+  // http://skife.org/java/unix/2011/06/20/really_executable_jars.html
+
+  manifest {
+    attributes 'Main-Class': 'denominator.cli.Denominator'
+  }
+
+  doLast {
+    def srcFile = new File("${destinationDir}/${archiveName}")
+    def tmpFile = new File(srcFile.getAbsolutePath() + ".tmp")
+    tmpFile.delete()
+    tmpFile << "#!/usr/bin/env sh\n"
+    tmpFile << 'exec java -jar $0 "$@"' + "\n"
+    tmpFile << srcFile.bytes
+    tmpFile.setExecutable(true, true)
+    tmpFile.renameTo(srcFile)
+  }
+}
+
+artifacts {
+    archives fat
+}

--- a/denominator-cli/src/main/java/denominator/cli/Denominator.java
+++ b/denominator-cli/src/main/java/denominator/cli/Denominator.java
@@ -1,0 +1,97 @@
+package denominator.cli;
+
+import static com.google.common.io.Closeables.closeQuietly;
+import static denominator.Credentials.ListCredentials.from;
+import static denominator.CredentialsConfiguration.credentials;
+import static denominator.Denominator.create;
+import static denominator.Denominator.listProviders;
+import io.airlift.command.Cli;
+import io.airlift.command.Cli.CliBuilder;
+import io.airlift.command.Command;
+import io.airlift.command.Help;
+import io.airlift.command.Option;
+import io.airlift.command.OptionType;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+
+import com.google.common.base.Joiner;
+
+import denominator.DNSApiManager;
+import denominator.Provider;
+
+public class Denominator {
+    public static void main(String[] args) {
+        CliBuilder<Runnable> builder = Cli.<Runnable> builder("denominator")
+                                          .withDescription("dns manager")
+                                          .withDefaultCommand(Help.class)
+                                          .withCommand(Help.class)
+                                          .withCommand(ListProviders.class);
+
+        builder.withGroup("zone")
+               .withDescription("manage zones")
+               .withDefaultCommand(ZoneList.class)
+               .withCommand(ZoneList.class);
+
+        Cli<Runnable> denominatorParser = builder.build();
+
+        denominatorParser.parse(args).run();
+    }
+
+    @Command(name = "providers", description = "List the providers and their expected credentials")
+    public static class ListProviders implements Runnable {
+        public void run() {
+            System.out.println(providerAndCredentialsTable());
+        }
+
+        public static String providerAndCredentialsTable() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("provider\tcredential type\tcredential parameters\n");
+            for (Provider provider : listProviders()) {
+                if (provider.getCredentialTypeToParameterNames().isEmpty())
+                    builder.append(provider.getName()).append('\t').append('\n');
+                for (Entry<String, Collection<String>> entry : provider.getCredentialTypeToParameterNames().asMap()
+                        .entrySet()) {
+                    builder.append(provider.getName()).append('\t').append(entry.getKey()).append('\t')
+                            .append(Joiner.on(' ').join(entry.getValue())).append('\n');
+                }
+            }
+            return builder.toString();
+        }
+    }
+
+    public static abstract class DenominatorCommand implements Runnable {
+        @Option(type = OptionType.GLOBAL, required = true, name = { "-p", "--provider" }, description = "provider to affect")
+        public String providerName;
+
+        @Option(type = OptionType.GLOBAL, name = { "-c", "--credential" }, description = "adds a credential argument")
+        public List<String> credentialArgs;
+
+        public void run() {
+            DNSApiManager mgr = null;
+            try {
+                if (credentialArgs == null)
+                    mgr = create(providerName);
+                else
+                    mgr = create(providerName, credentials(from(credentialArgs)));
+                for (String line : doRun(mgr))
+                    System.out.println(line);
+            } finally {
+                closeQuietly(mgr);
+            }
+        }
+
+        /**
+         * return a lazy iterable where possible to improve the perceived responsiveness of the cli
+         */
+        protected abstract Iterable<String> doRun(DNSApiManager mgr);
+    }
+
+    @Command(name = "list", description = "Lists the zone names present in this provider")
+    public static class ZoneList extends DenominatorCommand {
+        public Iterable<String> doRun(DNSApiManager mgr) {
+            return mgr.getApi().getZoneApi().list();
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include 'denominator-model', \
 'denominator-core', \
 'providers:denominator-route53', \
 'providers:denominator-ultradns', \
-'providers:denominator-dynect'
+'providers:denominator-dynect', \
+'denominator-cli'


### PR DESCRIPTION
# Denominator CLI

The denominator CLI is a git-like-cli based on the [airline](https://github.com/airlift/airline) project.  It is packaged as a [really executable jar](http://skife.org/java/unix/2011/06/20/really_executable_jars.html) which means you can do `./denominator` without any of the `java -jar` stuff.
## Building

To build the cli, execute `./gradlew clean test install` from the root of your denominator clone.  The binary will end up at `/denominator-cli/build/denominator`
## Running

only one real command is supported so far, but more will be this week.  Here's how to do a zone list on ultradns:

```
./denominator -p ultradns -c myusername -c mypassword zone list
```
## IAM Instance Profile

If you are using the `route53` provider on an ec2 instance with a profile associated with it, you don't need to pass credentials.  The syntax would end up like this.

```
./denominator -p route53 zone list
```

Special thanks to @brianm for the executable idea.
