### PR TITLE
switch to honest, hopefully lazy iterator for list results

### DIFF
--- a/denominator-cli/src/main/java/denominator/cli/Denominator.java
+++ b/denominator-cli/src/main/java/denominator/cli/Denominator.java
@@ -13,6 +13,7 @@ import io.airlift.command.Option;
 import io.airlift.command.OptionType;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -75,22 +76,22 @@ public class Denominator {
                     mgr = create(providerName);
                 else
                     mgr = create(providerName, credentials(from(credentialArgs)));
-                for (String line : doRun(mgr))
-                    System.out.println(line);
+                for (Iterator<String> i = doRun(mgr); i.hasNext();)
+                    System.out.println(i.next());
             } finally {
                 closeQuietly(mgr);
             }
         }
 
         /**
-         * return a lazy iterable where possible to improve the perceived responsiveness of the cli
+         * return a lazy iterator where possible to improve the perceived responsiveness of the cli
          */
-        protected abstract Iterable<String> doRun(DNSApiManager mgr);
+        protected abstract Iterator<String> doRun(DNSApiManager mgr);
     }
 
     @Command(name = "list", description = "Lists the zone names present in this provider")
     public static class ZoneList extends DenominatorCommand {
-        public Iterable<String> doRun(DNSApiManager mgr) {
+        public Iterator<String> doRun(DNSApiManager mgr) {
             return mgr.getApi().getZoneApi().list();
         }
     }

--- a/denominator-core/src/main/java/denominator/ZoneApi.java
+++ b/denominator-core/src/main/java/denominator/ZoneApi.java
@@ -1,11 +1,11 @@
 package denominator;
 
-import com.google.common.collect.FluentIterable;
+import java.util.Iterator;
 
 public interface ZoneApi {
     /**
      * a listing of all zone names, including trailing dot. ex.
-     * {@code netflix.com.}
+     * {@code netflix.com.}. Implementations are lazy when possible.
      */
-    FluentIterable<String> list();
+    Iterator<String> list();
 }

--- a/denominator-core/src/main/java/denominator/mock/MockZoneApi.java
+++ b/denominator-core/src/main/java/denominator/mock/MockZoneApi.java
@@ -1,8 +1,9 @@
 package denominator.mock;
 
+import java.util.Iterator;
+
 import javax.inject.Inject;
 
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
 public final class MockZoneApi implements denominator.ZoneApi {
@@ -11,7 +12,7 @@ public final class MockZoneApi implements denominator.ZoneApi {
     }
 
     @Override
-    public FluentIterable<String> list() {
-        return FluentIterable.from(ImmutableList.of("denominator.io."));
+    public Iterator<String> list() {
+        return ImmutableList.of("denominator.io.").iterator();
     }
 }

--- a/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
@@ -1,11 +1,11 @@
 package denominator;
 
+import static com.google.common.collect.Iterators.size;
 import static com.google.common.io.Closeables.close;
 import static java.lang.String.format;
 import static java.util.logging.Logger.getAnonymousLogger;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -22,8 +22,8 @@ public abstract class BaseProviderLiveTest {
     @Test
     public void testListZones() {
         skipIfNoCredentials();
-        List<String> zoneNames = manager.getApi().getZoneApi().list().toList();
-        getAnonymousLogger().info(format("%s has %s zones", manager, zoneNames.size()));
+        int zoneCount = size(manager.getApi().getZoneApi().list());
+        getAnonymousLogger().info(format("%s has %s zones", manager, zoneCount));
     }
 
     protected void skipIfNoCredentials() {

--- a/denominator-core/src/test/java/denominator/DynamicCredentialsProviderExampleTest.java
+++ b/denominator-core/src/test/java/denominator/DynamicCredentialsProviderExampleTest.java
@@ -8,6 +8,7 @@ import static denominator.Denominator.create;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -20,7 +21,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -68,12 +68,12 @@ public class DynamicCredentialsProviderExampleTest {
          * arise when the user supplies the incorrect form of credentials.
          */
         @Override
-        public FluentIterable<String> list() {
+        public Iterator<String> list() {
             // IllegalArgumentException is possible on lazy get
             CustomerUsernamePassword cup = creds.get();
             // normally, the credentials object would be used to invoke a remote
             // command. in this case, we don't and say we did :)
-            return FluentIterable.from(ImmutableList.of(cup.customer, cup.username, cup.password));
+            return ImmutableList.of(cup.customer, cup.username, cup.password).iterator();
         }
     }
 
@@ -180,12 +180,12 @@ public class DynamicCredentialsProviderExampleTest {
     public void testImplicitDynamicCredentialsUpdate() {
         DNSApiManager mgr = create(new DynamicCredentialsProvider());
         ZoneApi zoneApi = mgr.getApi().getZoneApi();
-        assertEquals(zoneApi.list().toList(), ImmutableList.of("acme", "wily", "coyote"));
-        assertEquals(zoneApi.list().toList(), ImmutableList.of("acme", "road", "runner"));
+        assertEquals(ImmutableList.copyOf(zoneApi.list()), ImmutableList.of("acme", "wily", "coyote"));
+        assertEquals(ImmutableList.copyOf(zoneApi.list()), ImmutableList.of("acme", "road", "runner"));
         // now, if the supplier doesn't supply a set of credentials, we should
         // get a correct message
         try {
-            zoneApi.list().toList();
+            ImmutableList.copyOf(zoneApi.list());
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "no credentials supplied. dynamic requires customer, username, password");

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTZoneApi.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTZoneApi.java
@@ -1,10 +1,10 @@
 package denominator.dynect;
 
+import java.util.Iterator;
+
 import javax.inject.Inject;
 
 import org.jclouds.dynect.v3.DynECTApi;
-
-import com.google.common.collect.FluentIterable;
 
 public final class DynECTZoneApi implements denominator.ZoneApi {
     private final DynECTApi api;
@@ -15,7 +15,7 @@ public final class DynECTZoneApi implements denominator.ZoneApi {
     }
 
     @Override
-    public FluentIterable<String> list() {
-        return api.getZoneApi().list();
+    public Iterator<String> list() {
+        return api.getZoneApi().list().iterator();
     }
 }

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53ZoneApi.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53ZoneApi.java
@@ -1,12 +1,13 @@
 package denominator.route53;
 
+import java.util.Iterator;
+
 import javax.inject.Inject;
 
 import org.jclouds.route53.Route53Api;
 import org.jclouds.route53.domain.HostedZone;
 
 import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
 
 public final class Route53ZoneApi implements denominator.ZoneApi {
     private final Route53Api api;
@@ -24,7 +25,7 @@ public final class Route53ZoneApi implements denominator.ZoneApi {
     }
 
     @Override
-    public FluentIterable<String> list() {
-        return api.getHostedZoneApi().list().concat().transform(ZoneName.INSTANCE);
+    public Iterator<String> list() {
+        return api.getHostedZoneApi().list().concat().transform(ZoneName.INSTANCE).iterator();
     }
 }

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSZoneApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSZoneApi.java
@@ -1,12 +1,13 @@
 package denominator.ultradns;
 
+import java.util.Iterator;
+
 import javax.inject.Inject;
 
 import org.jclouds.ultradns.ws.UltraDNSWSApi;
 import org.jclouds.ultradns.ws.domain.Zone;
 
 import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
 
 public final class UltraDNSZoneApi implements denominator.ZoneApi {
     private final UltraDNSWSApi api;
@@ -24,10 +25,10 @@ public final class UltraDNSZoneApi implements denominator.ZoneApi {
     }
 
     /**
-     * in UltraDNS, zones are scoped to an account. This list
+     * in UltraDNS, zones are scoped to an account.
      */
     @Override
-    public FluentIterable<String> list() {
-        return api.getZoneApi().listByAccount(api.getCurrentAccount().getId()).transform(ZoneName.INSTANCE);
+    public Iterator<String> list() {
+        return api.getZoneApi().listByAccount(api.getCurrentAccount().getId()).transform(ZoneName.INSTANCE).iterator();
     }
 }


### PR DESCRIPTION
per irc conversation.  returning Iterable instead of Iterator from lists is a somewhat troublesome.  
### lazy is a virtue, also honesty, and not surprising people

We want denominator to be as lazy as possible, as for example some results take several minutes or longer to return.  Returning any subclass of Iterable implies that we need to recreate the list any time `Iterable.iterator()` is called.  This could be surprising to users, who might not expect a call to .size() followed by .get(13) to take a large amount of network calls each.   Either storing inside the iterable how to recreate each iterator, or lazy persisting the iterable to remember the elements if asked again are troublesome in code and could lead to surprises from users.  Switching to Iterator return type is more honest about what's going on, essentially an attempt to lazy iterate.  
### Iterators are a bit of a pain but better than inconsistent impl of Iterable

While you can't use `for (Thing t: list())` with an iterator, one can easily create a list by using `ImmutableList.copyOf(iterator)` or `for (Iterator<Thing> t = list(); t.hasNext();)` forms.
