### PR TITLE
change ResourceRecordSetApi operations to accept rrset args

### DIFF
--- a/denominator-core/src/main/java/denominator/ResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/ResourceRecordSetApi.java
@@ -1,9 +1,6 @@
 package denominator;
 
 import java.util.Iterator;
-import java.util.Map;
-
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.model.ResourceRecordSet;
 
@@ -25,40 +22,46 @@ public interface ResourceRecordSetApi {
     /**
      * If a {@link ResourceRecordSet} exists with
      * {@link ResourceRecordSet#getName() name} and
-     * {@link ResourceRecordSet#getName() type} corresponding to parameters,
+     * {@link ResourceRecordSet#getName() type} corresponding to {@code rrset},
      * this adds the {@code rdata} to that set. Otherwise, it creates a
-     * {@link ResourceRecordSet} initially comprised of the specified arguments.
+     * {@link ResourceRecordSet} initially comprised of the specified
+     * {@code rrset}.
      * 
-     * @param name
-     *            the {@link ResourceRecordSet#getName() name} of the record set
-     * @param type
-     *            the {@link ResourceRecordSet#getType() type} of the record set
-     * @param ttl
-     *            the {@link ResourceRecordSet#getTTL() ttl} of the record set
-     * @param rdata
-     *            the rdata to add to the record set
+     * Example of adding "1.2.3.4" to the {@code A} record set for
+     * {@code www.denominator.io.}
+     * 
+     * <pre>
+     * import static denominator.model.ResourceRecordSets.a;
+     * ...
+     * rrsApi.add(a("www.denominator.io.", 3600, "1.2.3.4"));
+     * </pre>
+     * 
+     * @param rrset
+     *            contains the {@code rdata} elements to be added. If
+     *            {@link ResourceRecordSet#getTTL() ttl} is present, it will
+     *            replace the TTL on all records.
      */
-    void add(String name, String type, UnsignedInteger ttl, Map<String, Object> rdata);
-
-    /**
-     * like {@link #add(String, String, UnsignedInteger, Map)}, except using the
-     * default ttl for the zone.
-     */
-    void add(String name, String type, Map<String, Object> rdata);
+    void add(ResourceRecordSet<?> rrset);
 
     /**
      * If a {@link ResourceRecordSet} exists with
      * {@link ResourceRecordSet#getName() name} and
-     * {@link ResourceRecordSet#getName() type} corresponding to parameters,
-     * this either removes the value corresponding to the {@code rdata}, or
-     * removes the set entirely, if this is the only entry.
+     * {@link ResourceRecordSet#getName() type} corresponding to {@code rrset},
+     * remove values corresponding to input {@code rdata}, or removes the set
+     * entirely, if this is the only entry.
      * 
-     * @param name
-     *            the {@link ResourceRecordSet#getName() name} of the record set
-     * @param type
-     *            the {@link ResourceRecordSet#getType() type} of the record set
-     * @param rdata
-     *            the rdata to remove from the record set
+     * Example of removing "1.2.3.4" from the {@code A} record set for
+     * {@code www.denominator.io.}
+     * 
+     * <pre>
+     * import static denominator.model.ResourceRecordSets.a;
+     * ...
+     * rrsApi.remove(a("www.denominator.io.", "1.2.3.4"));
+     * </pre>
+     * 
+     * @param rrset
+     *            contains the {@code rdata} elements to be removed. The
+     *            {@link ResourceRecordSet#getTTL() ttl} is ignored.
      */
-    void remove(String name, String type, Map<String, Object> rdata);
+    void remove(ResourceRecordSet<?> rrset);
 }

--- a/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
@@ -5,6 +5,7 @@ import static com.google.common.collect.Iterators.any;
 import static com.google.common.collect.Iterators.size;
 import static com.google.common.collect.Iterators.tryFind;
 import static com.google.common.io.Closeables.close;
+import static denominator.model.ResourceRecordSets.a;
 import static denominator.model.ResourceRecordSets.nameAndType;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
@@ -85,9 +86,9 @@ public abstract class BaseProviderLiveTest {
 
         skipIfRRSetExists(zoneName, recordName, recordType);
 
-        UnsignedInteger ttl = UnsignedInteger.fromIntBits(0);
+        UnsignedInteger ttl = UnsignedInteger.fromIntBits(1800);
 
-        rrsApi(zoneName).add(recordName, recordType, ttl, rdata);
+        rrsApi(zoneName).add(a(recordName, ttl.intValue(), rdata.getAddress()));
 
         Optional<ResourceRecordSet<?>> rrs = tryFind(rrsApi(zoneName).list(), nameAndType(recordName, recordType));
 
@@ -108,7 +109,7 @@ public abstract class BaseProviderLiveTest {
         String zoneName = skipIfNoMutableZone();
         String recordName = recordPrefix + "." + zoneName;
 
-        rrsApi(zoneName).add(recordName, recordType, rdata2);
+        rrsApi(zoneName).add(a(recordName, rdata2.getAddress()));
 
         Optional<ResourceRecordSet<?>> rrs = tryFind(rrsApi(zoneName).list(), nameAndType(recordName, recordType));
 
@@ -127,7 +128,7 @@ public abstract class BaseProviderLiveTest {
         String zoneName = skipIfNoMutableZone();
         String recordName = recordPrefix + "." + zoneName;
 
-        rrsApi(zoneName).remove(recordName, recordType, rdata2);
+        rrsApi(zoneName).remove(a(recordName, rdata2.getAddress()));
 
         Optional<ResourceRecordSet<?>> rrs = tryFind(rrsApi(zoneName).list(), nameAndType(recordName, recordType));
 
@@ -145,7 +146,7 @@ public abstract class BaseProviderLiveTest {
         String zoneName = skipIfNoMutableZone();
         String recordName = recordPrefix + "." + zoneName;
 
-        rrsApi(zoneName).remove(recordName, recordType, rdata);
+        rrsApi(zoneName).remove(a(recordName, rdata.getAddress()));
 
         Optional<ResourceRecordSet<?>> rrs = tryFind(rrsApi(zoneName).list(), nameAndType(recordName, recordType));
 

--- a/denominator-model/src/main/java/denominator/model/ResourceRecordSet.java
+++ b/denominator-model/src/main/java/denominator/model/ResourceRecordSet.java
@@ -136,7 +136,7 @@ public class ResourceRecordSet<D extends Map<String, Object>> extends Forwarding
          * </pre>
          */
         public Builder<D> addAll(D... rdata) {
-            this.rdata = ImmutableList.<D> builder().addAll(ImmutableList.copyOf(checkNotNull(rdata, "rdata")));
+            this.rdata.addAll(ImmutableList.copyOf(checkNotNull(rdata, "rdata")));
             return this;
         }
 
@@ -151,7 +151,7 @@ public class ResourceRecordSet<D extends Map<String, Object>> extends Forwarding
          * </pre>
          */
         public <R extends D> Builder<D> addAll(Iterable<R> rdata) {
-            this.rdata = ImmutableList.<D> builder().addAll(checkNotNull(rdata, "rdata"));
+            this.rdata.addAll(checkNotNull(rdata, "rdata"));
             return this;
         }
 

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
@@ -5,15 +5,12 @@ import static com.google.common.collect.Iterators.filter;
 import static com.google.common.collect.Ordering.usingToString;
 
 import java.util.Iterator;
-import java.util.Map;
 
 import javax.inject.Inject;
 
 import org.jclouds.dynect.v3.DynECTApi;
 import org.jclouds.dynect.v3.domain.RecordId;
 import org.jclouds.dynect.v3.features.RecordApi;
-
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceRecordSetApi;
 import denominator.model.ResourceRecordSet;
@@ -47,17 +44,12 @@ public final class DynECTResourceRecordSetApi implements denominator.ResourceRec
     }
 
     @Override
-    public void add(String name, String type, UnsignedInteger ttl, Map<String, Object> rdata) {
+    public void add(ResourceRecordSet<?> rrset) {
         throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override
-    public void add(String name, String type, Map<String, Object> rdata) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public void remove(String name, String type, Map<String, Object> rdata) {
+    public void remove(ResourceRecordSet<?> rrset) {
         throw new UnsupportedOperationException("not yet implemented");
     }
 }

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Predicates.not;
 import static denominator.route53.ToDenominatorResourceRecordSet.isAlias;
 
 import java.util.Iterator;
-import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -14,7 +13,6 @@ import org.jclouds.route53.domain.HostedZone;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceRecordSetApi;
 import denominator.model.ResourceRecordSet;
@@ -67,17 +65,12 @@ final class Route53ResourceRecordSetApi implements denominator.ResourceRecordSet
     }
 
     @Override
-    public void add(String name, String type, UnsignedInteger ttl, Map<String, Object> rdata) {
+    public void add(ResourceRecordSet<?> rrset) {
         throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override
-    public void add(String name, String type, Map<String, Object> rdata) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public void remove(String name, String type, Map<String, Object> rdata) {
+    public void remove(ResourceRecordSet<?> rrset) {
         throw new UnsupportedOperationException("not yet implemented");
     }
 }

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
@@ -3,15 +3,12 @@ package denominator.ultradns;
 import static com.google.common.collect.Ordering.usingToString;
 
 import java.util.Iterator;
-import java.util.Map;
 
 import javax.inject.Inject;
 
 import org.jclouds.ultradns.ws.UltraDNSWSApi;
 import org.jclouds.ultradns.ws.domain.ResourceRecordMetadata;
 import org.jclouds.ultradns.ws.features.ResourceRecordApi;
-
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceRecordSetApi;
 import denominator.model.ResourceRecordSet;
@@ -45,17 +42,12 @@ public final class UltraDNSResourceRecordSetApi implements denominator.ResourceR
     }
 
     @Override
-    public void add(String name, String type, UnsignedInteger ttl, Map<String, Object> rdata) {
+    public void add(ResourceRecordSet<?> rrset) {
         throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override
-    public void add(String name, String type, Map<String, Object> rdata) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public void remove(String name, String type, Map<String, Object> rdata) {
+    public void remove(ResourceRecordSet<?> rrset) {
         throw new UnsupportedOperationException("not yet implemented");
     }
 }


### PR DESCRIPTION
based on feedback from @jdamick that I agree with, it seems less operations and more coherent to have `ResourceRecordSetApi` operations accept `ResourceRecordSet<?>` args.
