### PR TITLE
support add/remove record in DynECT

### DIFF
--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
@@ -1,23 +1,34 @@
 package denominator.dynect;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.collect.Iterators.filter;
 import static com.google.common.collect.Ordering.usingToString;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
 import org.jclouds.dynect.v3.DynECTApi;
+import org.jclouds.dynect.v3.domain.CreateRecord;
+import org.jclouds.dynect.v3.domain.Record;
 import org.jclouds.dynect.v3.domain.RecordId;
-import org.jclouds.dynect.v3.features.RecordApi;
+import org.jclouds.rest.ResourceNotFoundException;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceRecordSetApi;
 import denominator.model.ResourceRecordSet;
 
 public final class DynECTResourceRecordSetApi implements denominator.ResourceRecordSetApi {
     static final class Factory implements denominator.ResourceRecordSetApi.Factory {
-
         private final DynECTApi api;
 
         @Inject
@@ -26,30 +37,101 @@ public final class DynECTResourceRecordSetApi implements denominator.ResourceRec
         }
 
         @Override
-        public ResourceRecordSetApi create(final String zoneName) {
-            return new DynECTResourceRecordSetApi(api.getRecordApiForZone(zoneName));
+        public ResourceRecordSetApi create(String zoneName) {
+            checkNotNull(zoneName, "zoneName was null");
+            return new DynECTResourceRecordSetApi(api, zoneName);
         }
     }
 
-    private final RecordApi api;
+    private final DynECTApi api;
+    private final String zoneFQDN;
 
-    DynECTResourceRecordSetApi(RecordApi api) {
+    DynECTResourceRecordSetApi(DynECTApi api, String zoneFQDN) {
         this.api = api;
+        this.zoneFQDN = zoneFQDN;
     }
 
     @Override
     public Iterator<ResourceRecordSet<?>> list() {
-        Iterator<RecordId> orderedKeys = api.list().toSortedList(usingToString()).iterator();
-        return filter(new GroupByRecordNameAndTypeIterator(api, orderedKeys), notNull());
+        Iterator<RecordId> orderedKeys = api.getRecordApiForZone(zoneFQDN).list().toSortedList(usingToString())
+                .iterator();
+        return filter(new GroupByRecordNameAndTypeIterator(api.getRecordApiForZone(zoneFQDN), orderedKeys), notNull());
     }
 
     @Override
     public void add(ResourceRecordSet<?> rrset) {
-        throw new UnsupportedOperationException("not yet implemented");
+        checkNotNull(rrset, "rrset was null");
+        checkArgument(!rrset.isEmpty(), "rrset was empty %s", rrset);
+
+        Optional<UnsignedInteger> ttlToApply = rrset.getTTL();
+
+        List<Record<?>> existingRecords = pullExistingRecords(rrset);
+
+        List<Map<String, Object>> recordsLeftToCreate = Lists.newArrayList(rrset);
+
+        for (Record<?> existingRecord : existingRecords) {
+            if (!ttlToApply.isPresent())
+                ttlToApply = Optional.of(existingRecord.getTTL());
+            if (recordsLeftToCreate.contains(existingRecord.getRData())) {
+                if (ttlToApply.get().equals(existingRecord.getTTL())) {
+                    recordsLeftToCreate.remove(existingRecord.getRData());
+                    continue;
+                }
+                api.getRecordApiForZone(zoneFQDN).scheduleDelete(existingRecord);
+            } else if (!ttlToApply.get().equals(existingRecord.getTTL())) {
+                api.getRecordApiForZone(zoneFQDN).scheduleDelete(existingRecord);
+                recordsLeftToCreate.add(0, existingRecord.getRData());
+            }
+        }
+
+        if (recordsLeftToCreate.size() > 0) {
+            CreateRecord.Builder<Map<String, Object>> builder = CreateRecord.builder()
+                                                                            .fqdn(rrset.getName())
+                                                                            .type(rrset.getType())
+                                                                            .ttl(ttlToApply.orNull());
+            for (Map<String, Object> record : recordsLeftToCreate) {
+                api.getRecordApiForZone(zoneFQDN).scheduleCreate(builder.rdata(record).build());
+            }
+            api.getZoneApi().publish(zoneFQDN);
+        }
+    }
+
+    private List<Record<?>> pullExistingRecords(ResourceRecordSet<?> rrset) {
+        try {
+            return api.getRecordApiForZone(zoneFQDN).listByFQDNAndType(rrset.getName(), rrset.getType())
+                    .transform(new Function<RecordId, Record<?>>() {
+                        public Record<?> apply(RecordId in) {
+                            return api.getRecordApiForZone(zoneFQDN).get(in);
+                        }
+
+                        public String toString() {
+                            return "getRecord()";
+                        }
+                    }).filter(notNull()).toSortedList(usingToString());
+        } catch (ResourceNotFoundException e) {
+            // TODO: fix jclouds to just return an empty set
+            return ImmutableList.of();
+        }
     }
 
     @Override
     public void remove(ResourceRecordSet<?> rrset) {
-        throw new UnsupportedOperationException("not yet implemented");
+        checkNotNull(rrset, "rrset was null");
+        checkArgument(!rrset.isEmpty(), "rrset was empty %s", rrset);
+
+        List<RecordId> keys = api.getRecordApiForZone(zoneFQDN).listByFQDNAndType(rrset.getName(), rrset.getType())
+                .toSortedList(usingToString());
+        if (keys.isEmpty())
+            return;
+        boolean shouldPublish = false;
+        for (RecordId key : keys) {
+            Record<? extends Map<String, Object>> toEvaluate = api.getRecordApiForZone(zoneFQDN).get(key);
+            if (toEvaluate != null && rrset.contains(toEvaluate.getRData())) {
+                shouldPublish = true;
+                api.getRecordApiForZone(zoneFQDN).scheduleDelete(key);
+            }
+        }
+        if (shouldPublish)
+            api.getZoneApi().publish(zoneFQDN);
     }
 }

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderLiveTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderLiveTest.java
@@ -20,5 +20,6 @@ public class DynECTProviderLiveTest extends BaseProviderLiveTest {
         if (customer != null && username != null && password != null) {
             manager = Denominator.create(new DynECTProvider(), credentials(customer, username, password));
         }
+        mutableZone = emptyToNull(getProperty("dynect.zone"));
     }
 }

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTResourceRecordSetApiMockTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTResourceRecordSetApiMockTest.java
@@ -1,0 +1,289 @@
+package denominator.dynect;
+
+import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
+import static denominator.model.ResourceRecordSets.a;
+import static org.jclouds.Constants.PROPERTY_MAX_RETRIES;
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.Set;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.concurrent.config.ExecutorServiceModule;
+import org.jclouds.dynect.v3.DynECTApi;
+import org.jclouds.dynect.v3.DynECTApiMetadata;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+import com.google.mockwebserver.RecordedRequest;
+
+@Test(singleThreaded = true)
+public class DynECTResourceRecordSetApiMockTest {
+    static Set<Module> modules = ImmutableSet.<Module> of(new ExecutorServiceModule(sameThreadExecutor(),
+            sameThreadExecutor()));
+
+    static DynECTApi mockDynECTApi(String uri) {
+        Properties overrides = new Properties();
+        overrides.setProperty(PROPERTY_MAX_RETRIES, "1");
+        return ContextBuilder.newBuilder("dynect")
+                             .credentials("jclouds:joe", "letmein")
+                             .endpoint(uri)
+                             .overrides(overrides)
+                             .modules(modules)
+                             .build(DynECTApiMetadata.CONTEXT_TOKEN).getApi();
+    }
+
+    String session = "{\"status\": \"success\", \"data\": {\"token\": \"FFFFFFFFFF\", \"version\": \"3.3.8\"}, \"job_id\": 254417252, \"msgs\": [{\"INFO\": \"login: Login successful\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+    String success = "{\"status\": \"success\", \"data\": {}, \"job_id\": 262989027, \"msgs\": [{\"INFO\": \"thing done\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+
+    String createRecord1 = "{\"rdata\":{\"address\":\"1.2.3.4\"},\"ttl\":3600}";
+
+    @Test
+    public void addFirstRecordPostsAndPublishes() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(404)); // no existing records
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.play();
+
+        try {
+            DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
+                    mockDynECTApi(server.getUrl("/").toString()), "foo.com");
+            api.add(a("www.foo.com", 3600, "1.2.3.4"));
+        } finally {
+            assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
+
+            RecordedRequest listNameAndType = server.takeRequest();
+            assertEquals(listNameAndType.getRequestLine(), "GET /ARecord/foo.com/www.foo.com HTTP/1.1");
+
+            RecordedRequest postRecord1 = server.takeRequest();
+            assertEquals(postRecord1.getRequestLine(), "POST /ARecord/foo.com/www.foo.com HTTP/1.1");
+            assertEquals(new String(postRecord1.getBody()), createRecord1);
+
+            RecordedRequest publish = server.takeRequest();
+            assertEquals(publish.getRequestLine(), "PUT /Zone/foo.com HTTP/1.1");
+            assertEquals(new String(publish.getBody()), "{\"publish\":true}");
+
+            server.shutdown();
+        }
+    }
+
+    String recordIdsWithRecord1 = "{\"status\": \"success\", \"data\": [\"/REST/ARecord/foo.com/www.foo.com/1\"], \"job_id\": 273523368, \"msgs\": [{\"INFO\": \"get_tree: Here is your zone tree\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+    String record1Result = "{\"status\": \"success\", \"data\": {\"zone\": \"foo.com\", \"ttl\": 3600, \"fqdn\": \"www.foo.com\", \"record_type\": \"A\", \"rdata\": {\"address\": \"1.2.3.4\"}, \"record_id\": 1}, \"job_id\": 274279510, \"msgs\": [{\"INFO\": \"get: Found the record\", \"SOURCE\": \"API-B\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+
+    @Test
+    public void addAddExistingRecordDoesNothing() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(recordIdsWithRecord1));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(record1Result));
+        server.play();
+
+        try {
+            DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
+                    mockDynECTApi(server.getUrl("/").toString()), "foo.com");
+            api.add(a("www.foo.com", 3600, "1.2.3.4"));
+        } finally {
+            assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
+
+            RecordedRequest listNameAndType = server.takeRequest();
+            assertEquals(listNameAndType.getRequestLine(), "GET /ARecord/foo.com/www.foo.com HTTP/1.1");
+
+            RecordedRequest getRecord1 = server.takeRequest();
+            assertEquals(getRecord1.getRequestLine(), "GET /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            server.shutdown();
+        }
+    }
+
+    String createRecord2 = "{\"rdata\":{\"address\":\"5.6.7.8\"},\"ttl\":3600}";
+
+    @Test
+    public void addSecondRecordPostsRecordWithOldTTLAndPublishes() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(recordIdsWithRecord1));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(record1Result));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.play();
+
+        try {
+            DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
+                    mockDynECTApi(server.getUrl("/").toString()), "foo.com");
+            api.add(a("www.foo.com", "5.6.7.8"));
+        } finally {
+            assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
+
+            RecordedRequest listNameAndType = server.takeRequest();
+            assertEquals(listNameAndType.getRequestLine(), "GET /ARecord/foo.com/www.foo.com HTTP/1.1");
+
+            RecordedRequest getRecord1 = server.takeRequest();
+            assertEquals(getRecord1.getRequestLine(), "GET /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            RecordedRequest postRecord2 = server.takeRequest();
+            assertEquals(postRecord2.getRequestLine(), "POST /ARecord/foo.com/www.foo.com HTTP/1.1");
+            assertEquals(new String(postRecord2.getBody()), createRecord2);
+
+            RecordedRequest publish = server.takeRequest();
+            assertEquals(publish.getRequestLine(), "PUT /Zone/foo.com HTTP/1.1");
+            assertEquals(new String(publish.getBody()), "{\"publish\":true}");
+
+            server.shutdown();
+        }
+    }
+    
+    String createRecord1OverriddenTTL = "{\"rdata\":{\"address\":\"1.2.3.4\"},\"ttl\":10000000}";
+    String createRecord2OverriddenTTL = "{\"rdata\":{\"address\":\"5.6.7.8\"},\"ttl\":10000000}";
+
+    @Test
+    public void addSecondRecordWithNewTTLRecreatesFirstRecordWithTTLAndPublishes() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(recordIdsWithRecord1));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(record1Result));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.play();
+
+        try {
+            DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
+                    mockDynECTApi(server.getUrl("/").toString()), "foo.com");
+            api.add(a("www.foo.com", 10000000, "5.6.7.8"));
+        } finally {
+            assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
+
+            RecordedRequest listNameAndType = server.takeRequest();
+            assertEquals(listNameAndType.getRequestLine(), "GET /ARecord/foo.com/www.foo.com HTTP/1.1");
+
+            RecordedRequest getRecord1 = server.takeRequest();
+            assertEquals(getRecord1.getRequestLine(), "GET /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            RecordedRequest deleteRecord1 = server.takeRequest();
+            assertEquals(deleteRecord1.getRequestLine(), "DELETE /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            RecordedRequest postRecord1 = server.takeRequest();
+            assertEquals(postRecord1.getRequestLine(), "POST /ARecord/foo.com/www.foo.com HTTP/1.1");
+            assertEquals(new String(postRecord1.getBody()), createRecord1OverriddenTTL);
+
+            RecordedRequest postRecord2 = server.takeRequest();
+            assertEquals(postRecord2.getRequestLine(), "POST /ARecord/foo.com/www.foo.com HTTP/1.1");
+            assertEquals(new String(postRecord2.getBody()), createRecord2OverriddenTTL);
+
+            RecordedRequest publish = server.takeRequest();
+            assertEquals(publish.getRequestLine(), "PUT /Zone/foo.com HTTP/1.1");
+            assertEquals(new String(publish.getBody()), "{\"publish\":true}");
+
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void removeRecordSendsDeleteAndPublish() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(recordIdsWithRecord1));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(record1Result));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.play();
+
+        try {
+            DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
+                    mockDynECTApi(server.getUrl("/").toString()), "foo.com");
+            api.remove(a("www.foo.com", "1.2.3.4"));
+        } finally {
+            assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
+
+            RecordedRequest listNameAndType = server.takeRequest();
+            assertEquals(listNameAndType.getRequestLine(), "GET /ARecord/foo.com/www.foo.com HTTP/1.1");
+
+            RecordedRequest getRecord1 = server.takeRequest();
+            assertEquals(getRecord1.getRequestLine(), "GET /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            RecordedRequest deleteRecord1 = server.takeRequest();
+            assertEquals(deleteRecord1.getRequestLine(), "DELETE /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            RecordedRequest publish = server.takeRequest();
+            assertEquals(publish.getRequestLine(), "PUT /Zone/foo.com HTTP/1.1");
+            assertEquals(new String(publish.getBody()), "{\"publish\":true}");
+
+            server.shutdown();
+        }
+    }
+
+    String recordIdsWithRecords1And2 = "{\"status\": \"success\", \"data\": [\"/REST/ARecord/foo.com/www.foo.com/1\",\"/REST/ARecord/foo.com/www.foo.com/2\"], \"job_id\": 273523368, \"msgs\": [{\"INFO\": \"get_tree: Here is your zone tree\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+    String record2Result = "{\"status\": \"success\", \"data\": {\"zone\": \"foo.com\", \"ttl\": 3600, \"fqdn\": \"www.foo.com\", \"record_type\": \"A\", \"rdata\": {\"address\": \"5.6.7.8\"}, \"record_id\": 2}, \"job_id\": 274279510, \"msgs\": [{\"INFO\": \"get: Found the record\", \"SOURCE\": \"API-B\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+
+    @Test
+    public void removeRecord1ResultReplacesRRSet() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(recordIdsWithRecords1And2));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(record1Result));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(record2Result));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(success));
+        server.play();
+
+        try {
+            DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
+                    mockDynECTApi(server.getUrl("/").toString()), "foo.com");
+            api.remove(a("www.foo.com", "5.6.7.8"));
+        } finally {
+            assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
+
+            RecordedRequest listNameAndType = server.takeRequest();
+            assertEquals(listNameAndType.getRequestLine(), "GET /ARecord/foo.com/www.foo.com HTTP/1.1");
+
+            RecordedRequest getRecord1 = server.takeRequest();
+            assertEquals(getRecord1.getRequestLine(), "GET /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            RecordedRequest getRecord2 = server.takeRequest();
+            assertEquals(getRecord2.getRequestLine(), "GET /ARecord/foo.com/www.foo.com/2 HTTP/1.1");
+
+            RecordedRequest deleteRecord2 = server.takeRequest();
+            assertEquals(deleteRecord2.getRequestLine(), "DELETE /ARecord/foo.com/www.foo.com/2 HTTP/1.1");
+
+            RecordedRequest publish = server.takeRequest();
+            assertEquals(publish.getRequestLine(), "PUT /Zone/foo.com HTTP/1.1");
+            assertEquals(new String(publish.getBody()), "{\"publish\":true}");
+
+
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void removeWrongRecordDoesNothing() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(recordIdsWithRecord1));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(record1Result));
+
+        server.play();
+
+        try {
+            DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
+                    mockDynECTApi(server.getUrl("/").toString()), "foo.com");
+            api.remove(a("www.foo.com", "5.6.7.8"));
+        } finally {
+            assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
+
+            RecordedRequest listNameAndType = server.takeRequest();
+            assertEquals(listNameAndType.getRequestLine(), "GET /ARecord/foo.com/www.foo.com HTTP/1.1");
+
+            RecordedRequest getRecord1 = server.takeRequest();
+            assertEquals(getRecord1.getRequestLine(), "GET /ARecord/foo.com/www.foo.com/1 HTTP/1.1");
+
+            server.shutdown();
+        }
+    }
+}

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/GroupByRecordNameAndTypeIteratorMockTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/GroupByRecordNameAndTypeIteratorMockTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertFalse;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Properties;
+import java.util.Set;
 
 import org.jclouds.ContextBuilder;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
@@ -32,15 +33,17 @@ import denominator.model.rdata.SOAData;
 
 @Test(singleThreaded = true)
 public class GroupByRecordNameAndTypeIteratorMockTest {
+    static Set<Module> modules = ImmutableSet.<Module> of(new ExecutorServiceModule(sameThreadExecutor(),
+            sameThreadExecutor()));
 
-    static DynECTApi mockDynectApi(String uri) {
+    static DynECTApi mockDynECTApi(String uri) {
         Properties overrides = new Properties();
         overrides.setProperty(PROPERTY_MAX_RETRIES, "1");
         return ContextBuilder.newBuilder("dynect")
                              .credentials("jclouds:joe", "letmein")
                              .endpoint(uri)
                              .overrides(overrides)
-                             .modules(ImmutableSet.<Module> of(new ExecutorServiceModule(sameThreadExecutor(), sameThreadExecutor())))
+                             .modules(modules)
                              .build(DynECTApiMetadata.CONTEXT_TOKEN).getApi();
     }
 
@@ -69,7 +72,7 @@ public class GroupByRecordNameAndTypeIteratorMockTest {
         server.play();
         
         try {
-            RecordApi api = mockDynectApi(server.getUrl("/").toString()).getRecordApiForZone("denominator.io");
+            RecordApi api = mockDynECTApi(server.getUrl("/").toString()).getRecordApiForZone("denominator.io");
 
             Iterator<ResourceRecordSet<?>> iterator  = new GroupByRecordNameAndTypeIterator(api, recordIds.iterator());
             assertEquals(iterator.next(), ResourceRecordSet.<SOAData> builder()


### PR DESCRIPTION
addresses issue #35 

This implementation replaces, creates or deletes individual records in order to change values. The application of the changes are batched in the same session and published as a whole.

To run the live test, ensure you add -Ddynect.zone corresponding to a zone you are ok being modified.
