### PR TITLE
issue #49: add replace command to cli

### DIFF
--- a/denominator-cli/src/main/java/denominator/cli/Denominator.java
+++ b/denominator-cli/src/main/java/denominator/cli/Denominator.java
@@ -24,6 +24,7 @@ import denominator.Provider;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetAdd;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetList;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetRemove;
+import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetReplace;
 
 public class Denominator {
     public static void main(String[] args) {
@@ -43,6 +44,7 @@ public class Denominator {
                .withDefaultCommand(ResourceRecordSetList.class)
                .withCommand(ResourceRecordSetList.class)
                .withCommand(ResourceRecordSetAdd.class)
+               .withCommand(ResourceRecordSetReplace.class)
                .withCommand(ResourceRecordSetRemove.class);
 
         Cli<Runnable> denominatorParser = builder.build();

--- a/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -14,6 +14,7 @@ import denominator.cli.Denominator.ZoneList;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetAdd;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetList;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetRemove;
+import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetReplace;
 import denominator.dynect.DynECTProvider;
 import denominator.mock.MockProvider;
 import denominator.route53.Route53Provider;
@@ -76,6 +77,31 @@ public class DenominatorTest {
         command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
                 ";; in zone denominator.io. adding to rrset www1.denominator.io. A values: [{address=1.1.1.1},{address=1.1.1.2}] applying ttl 3600",
+                ";; ok"));
+    }
+
+    @Test(description = "denominator -p mock record -z denominator.io. replace -n www1.denominator.io. -t A -d 1.1.1.1 -d 1.1.1.2")
+    public void testResourceRecordSetReplace() {
+        ResourceRecordSetReplace command = new ResourceRecordSetReplace();
+        command.zoneName = "denominator.io.";
+        command.name = "www1.denominator.io.";
+        command.type = "A";
+        command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
+        assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
+                ";; in zone denominator.io. replacing rrset www1.denominator.io. A with values: [{address=1.1.1.1},{address=1.1.1.2}]",
+                ";; ok"));
+    }
+
+    @Test(description = "denominator -p mock record -z denominator.io. replace -n www1.denominator.io. -t A --ttl 3600 -d 1.1.1.1 -d 1.1.1.2")
+    public void testResourceRecordSetReplaceWithTTL() {
+        ResourceRecordSetReplace command = new ResourceRecordSetReplace();
+        command.zoneName = "denominator.io.";
+        command.name = "www1.denominator.io.";
+        command.type = "A";
+        command.ttl = 3600;
+        command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
+        assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
+                ";; in zone denominator.io. replacing rrset www1.denominator.io. A with values: [{address=1.1.1.1},{address=1.1.1.2}] and ttl 3600",
                 ";; ok"));
     }
 


### PR DESCRIPTION
for issue #49

This allows the cli to idempotently replace records in a set.  `--ttl` is optional, and if absent implies zone default.

Example (keeping in mind mock is not durable)

```
$ denominator -p mock record -z denominator.io. replace -n www1.myzone.com. -t A -d 1.1.1.1 -d 1.1.1.2 -d 1.1.1.3
;; in zone denominator.io. replacing rrset www1.myzone.com. A with values: [{address=1.1.1.1},{address=1.1.1.2},{address=1.1.1.3}]
;; ok
```
