### PR TITLE
issue #55: add get rrset by name and type command to cli

### DIFF
--- a/denominator-cli/src/main/java/denominator/cli/Denominator.java
+++ b/denominator-cli/src/main/java/denominator/cli/Denominator.java
@@ -22,6 +22,7 @@ import com.google.common.base.Joiner;
 import denominator.DNSApiManager;
 import denominator.Provider;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetAdd;
+import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetGet;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetList;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetRemove;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetReplace;
@@ -43,6 +44,7 @@ public class Denominator {
                .withDescription("manage resource record sets in a zone")
                .withDefaultCommand(ResourceRecordSetList.class)
                .withCommand(ResourceRecordSetList.class)
+               .withCommand(ResourceRecordSetGet.class)
                .withCommand(ResourceRecordSetAdd.class)
                .withCommand(ResourceRecordSetReplace.class)
                .withCommand(ResourceRecordSetRemove.class);

--- a/denominator-cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
+++ b/denominator-cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
@@ -49,6 +49,20 @@ class ResourceRecordSetCommands {
         }
     }
 
+    @Command(name = "get", description = "gets a normal record record set by name and type, if present in this zone")
+    public static class ResourceRecordSetGet extends ResourceRecordSetCommand {
+        @Option(type = OptionType.COMMAND, required = true, name = { "-n", "--name" }, description = "name of the record set. ex. www.denominator.io.")
+        public String name;
+
+        @Option(type = OptionType.COMMAND, required = true, name = { "-t", "--type" }, description = "type of the record set. ex. CNAME")
+        public String type;
+
+        public Iterator<String> doRun(DNSApiManager mgr) {
+            return Iterators.forArray(mgr.getApi().getResourceRecordSetApiForZone(zoneName)
+                    .getByNameAndType(name, type).transform(ResourceRecordSetToString.INSTANCE).or(""));
+        }
+    }
+
     private static abstract class ModifyRecordSetCommand extends ResourceRecordSetCommand {
         @Option(type = OptionType.COMMAND, required = true, name = { "-n", "--name" }, description = "name of the record set. ex. www.denominator.io.")
         public String name;

--- a/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -12,6 +12,7 @@ import denominator.Provider;
 import denominator.cli.Denominator.ListProviders;
 import denominator.cli.Denominator.ZoneList;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetAdd;
+import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetGet;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetList;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetRemove;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetReplace;
@@ -53,6 +54,26 @@ public class DenominatorTest {
                 "www1.denominator.io.                              A      3600  1.1.1.1",
                 "www1.denominator.io.                              A      3600  1.1.1.2",
                 "www2.denominator.io.                              A      3600  2.2.2.2"));
+    }
+
+    @Test(description = "denominator -p mock record -z denominator.io. get -n www1.denominator.io. -t A ")
+    public void testResourceRecordSetGetWhenPresent() {
+        ResourceRecordSetGet command = new ResourceRecordSetGet();
+        command.zoneName = "denominator.io.";
+        command.name = "www1.denominator.io.";
+        command.type = "A";
+        assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
+                "www1.denominator.io.                              A      3600  1.1.1.1",
+                "www1.denominator.io.                              A      3600  1.1.1.2"));
+    }
+
+    @Test(description = "denominator -p mock record -z denominator.io. get -n www3.denominator.io. -t A ")
+    public void testResourceRecordSetGetWhenAbsent() {
+        ResourceRecordSetGet command = new ResourceRecordSetGet();
+        command.zoneName = "denominator.io.";
+        command.name = "www3.denominator.io.";
+        command.type = "A";
+        assertEquals(Joiner.on('\n').join(command.doRun(mgr)), "");
     }
 
     @Test(description = "denominator -p mock record -z denominator.io. add -n www1.denominator.io. -t A -d 1.1.1.1 -d 1.1.1.2")


### PR DESCRIPTION
for issue #55

This allows the cli to get a record set by name and type.  no output is returned if that set doesn't exist.

Example:

```
$ denominator -p mock record -z denominator.io. get -n www1.denominator.io. -t A 
www1.denominator.io.                              A      3600  1.1.1.1
www1.denominator.io.                              A      3600  1.1.1.2
```
