### PR TITLE
enabled slf4j and setup default log files for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,10 @@ subprojects {
     }
 
     dependencies {
-        compile     'com.google.guava:guava:14.0'
+	compile     'com.google.guava:guava:14.0'
+        compile     'org.slf4j:slf4j-api:1.7.2'
         testCompile 'org.testng:testng:6.8'
+        testCompile 'ch.qos.logback:logback-classic:1.0.9'
         testCompile     'com.google.mockwebserver:mockwebserver:20130201'
     }
 }

--- a/providers/denominator-dynect/build.gradle
+++ b/providers/denominator-dynect/build.gradle
@@ -22,5 +22,6 @@ dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
   compile     'org.jclouds.labs:dynect:1.6.0-alpha.4'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-alpha.4'
 }
 

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTProvider.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTProvider.java
@@ -11,11 +11,13 @@ import org.jclouds.ContextBuilder;
 import org.jclouds.domain.Credentials;
 import org.jclouds.dynect.v3.DynECTAsyncApi;
 import org.jclouds.dynect.v3.DynECTProviderMetadata;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.rest.RestContext;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import dagger.Module;
@@ -68,7 +70,9 @@ public class DynECTProvider extends Provider {
     @Provides
     @Singleton
     RestContext<org.jclouds.dynect.v3.DynECTApi, DynECTAsyncApi> provideContext(Supplier<Credentials> credentials) {
-        return ContextBuilder.newBuilder(new DynECTProviderMetadata()).credentialsSupplier(credentials).build();
+        return ContextBuilder.newBuilder(new DynECTProviderMetadata())
+                             .credentialsSupplier(credentials)
+                             .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule())).build();
     }
 
     @Provides

--- a/providers/denominator-dynect/src/test/resources/logback.xml
+++ b/providers/denominator-dynect/src/test/resources/logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+    
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+</configuration>

--- a/providers/denominator-route53/build.gradle
+++ b/providers/denominator-route53/build.gradle
@@ -21,5 +21,6 @@ dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
   compile     'org.jclouds.provider:aws-route53:1.6.0-alpha.4'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-alpha.4'
 }
 

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53Provider.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53Provider.java
@@ -11,6 +11,7 @@ import org.jclouds.ContextBuilder;
 import org.jclouds.aws.domain.SessionCredentials;
 import org.jclouds.aws.route53.AWSRoute53ProviderMetadata;
 import org.jclouds.domain.Credentials;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.rest.RestContext;
 import org.jclouds.route53.Route53AsyncApi;
 
@@ -18,6 +19,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import dagger.Module;
@@ -69,7 +71,9 @@ public class Route53Provider extends Provider {
     @Provides
     @Singleton
     RestContext<org.jclouds.route53.Route53Api, Route53AsyncApi> provideContext(Supplier<Credentials> credentials) {
-        return ContextBuilder.newBuilder(new AWSRoute53ProviderMetadata()).credentialsSupplier(credentials).build();
+        return ContextBuilder.newBuilder(new AWSRoute53ProviderMetadata())
+                             .credentialsSupplier(credentials)
+                             .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule())).build();
     }
 
     @Provides

--- a/providers/denominator-route53/src/test/resources/logback.xml
+++ b/providers/denominator-route53/src/test/resources/logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+    
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+</configuration>

--- a/providers/denominator-ultradns/build.gradle
+++ b/providers/denominator-ultradns/build.gradle
@@ -20,5 +20,6 @@ dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
   compile     'org.jclouds.labs:ultradns-ws:1.6.0-alpha.4'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-alpha.4'
 }
 

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
@@ -9,6 +9,7 @@ import javax.inject.Singleton;
 
 import org.jclouds.ContextBuilder;
 import org.jclouds.domain.Credentials;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.rest.RestContext;
 import org.jclouds.ultradns.ws.UltraDNSWSApi;
 import org.jclouds.ultradns.ws.UltraDNSWSAsyncApi;
@@ -17,6 +18,7 @@ import org.jclouds.ultradns.ws.UltraDNSWSProviderMetadata;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import dagger.Module;
@@ -55,7 +57,9 @@ public class UltraDNSProvider extends Provider {
     @Provides
     @Singleton
     RestContext<UltraDNSWSApi, UltraDNSWSAsyncApi> provideContext(Supplier<Credentials> credentials) {
-        return ContextBuilder.newBuilder(new UltraDNSWSProviderMetadata()).credentialsSupplier(credentials).build();
+        return ContextBuilder.newBuilder(new UltraDNSWSProviderMetadata())
+                             .credentialsSupplier(credentials)
+                             .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule())).build();
     }
 
     @Provides

--- a/providers/denominator-ultradns/src/test/resources/logback.xml
+++ b/providers/denominator-ultradns/src/test/resources/logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+    
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+</configuration>


### PR DESCRIPTION
sets up slf4j and default log files when running tests.

For example, when running Live tests, `target/test-data/jclouds-wire.log` will contain http traffic generated from the provider.

Ex. logs created during ultradns tests

```
./providers/denominator-ultradns/target/test-data/jclouds-wire.log
./providers/denominator-ultradns/target/test-data/jclouds.log
```
