### PR TITLE
issue #69: route53 implementation for ResourceRecordSetApi.deleteByNameAndType

### DIFF
--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
@@ -162,7 +162,10 @@ final class Route53ResourceRecordSetApi implements denominator.ResourceRecordSet
 
     @Override
     public void deleteByNameAndType(String name, String type) {
-        throw new UnsupportedOperationException("not yet implemented");
+        Optional<org.jclouds.route53.domain.ResourceRecordSet> oldRRS = getRoute53RRSByNameAndType(name, type);
+        if (!oldRRS.isPresent())
+            return;
+        route53RRsetApi.delete(oldRRS.get());
     }
 
     static final class Factory implements denominator.ResourceRecordSetApi.Factory {


### PR DESCRIPTION
issue #69: route53 implementation for ResourceRecordSetApi.deleteByNameAndType
