### PR TITLE
update to jclouds 1.6.0-rc.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,7 @@ buildscript {
 
 allprojects {
     repositories { mavenLocal()
-                   mavenCentral() 
-                   maven { url 'https://oss.sonatype.org/content/repositories/snapshots' } }
+                   mavenCentral() }
 }
 
 apply from: file('gradle/convention.gradle')

--- a/providers/denominator-dynect/build.gradle
+++ b/providers/denominator-dynect/build.gradle
@@ -21,7 +21,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.labs:dynect:1.6.0-SNAPSHOT'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-SNAPSHOT'
+  compile     'org.jclouds.provider:dynect:1.6.0-rc.1'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.1'
 }
 

--- a/providers/denominator-route53/build.gradle
+++ b/providers/denominator-route53/build.gradle
@@ -20,7 +20,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:aws-route53:1.6.0-alpha.4'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-alpha.4'
+  compile     'org.jclouds.provider:aws-route53:1.6.0-rc.1'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.1'
 }
 

--- a/providers/denominator-ultradns/build.gradle
+++ b/providers/denominator-ultradns/build.gradle
@@ -20,7 +20,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.labs:ultradns-ws:1.6.0-SNAPSHOT'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-SNAPSHOT'
+  compile     'org.jclouds.provider:ultradns-ws:1.6.0-rc.1'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.1'
 }
 


### PR DESCRIPTION
pulls providers we use out of labs and helps get us off alpha releases.
