### PR TITLE
temporarily update to jclouds snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,8 @@ buildscript {
 
 allprojects {
     repositories { mavenLocal()
-                   mavenCentral() }
+                   mavenCentral()
+                   maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }}
 }
 
 apply from: file('gradle/convention.gradle')

--- a/providers/denominator-dynect/build.gradle
+++ b/providers/denominator-dynect/build.gradle
@@ -21,7 +21,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:dynect:1.6.0-rc.1'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.1'
+  compile     'org.jclouds.provider:dynect:1.6.0-SNAPSHOT'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-SNAPSHOT'
 }
 

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
@@ -76,7 +76,7 @@ public final class DynECTResourceRecordSetApi implements denominator.ResourceRec
 
         for (Record<?> existingRecord : existingRecords) {
             if (!ttl.isPresent())
-                ttl = Optional.of(existingRecord.getTTL().intValue());
+                ttl = Optional.of(existingRecord.getTTL());
             builder.add(existingRecord.getRData());
         }
         return Optional.<ResourceRecordSet<?>> of(builder.ttl(ttl.get()).build());
@@ -95,14 +95,14 @@ public final class DynECTResourceRecordSetApi implements denominator.ResourceRec
 
         for (Record<?> existingRecord : existingRecords) {
             if (!ttlToApply.isPresent())
-                ttlToApply = Optional.of(existingRecord.getTTL().intValue());
+                ttlToApply = Optional.of(existingRecord.getTTL());
             if (recordsLeftToCreate.contains(existingRecord.getRData())) {
-                if (ttlToApply.get().intValue() == existingRecord.getTTL().intValue()) {
+                if (ttlToApply.get().intValue() == existingRecord.getTTL()) {
                     recordsLeftToCreate.remove(existingRecord.getRData());
                     continue;
                 }
                 api.getRecordApiForZone(zoneFQDN).scheduleDelete(existingRecord);
-            } else if (ttlToApply.get().intValue() != existingRecord.getTTL().intValue()) {
+            } else if (ttlToApply.get().intValue() != existingRecord.getTTL()) {
                 api.getRecordApiForZone(zoneFQDN).scheduleDelete(existingRecord);
                 recordsLeftToCreate.add(0, existingRecord.getRData());
             }
@@ -131,7 +131,7 @@ public final class DynECTResourceRecordSetApi implements denominator.ResourceRec
         List<Record<?>> recordsToRecreate = Lists.newArrayList(existingRecords);
 
         for (Record<?> existingRecord : existingRecords) {
-            if (ttl == existingRecord.getTTL().intValue()) {
+            if (ttl == existingRecord.getTTL()) {
                 recordsToRecreate.remove(existingRecord);
                 continue;
             }
@@ -162,7 +162,7 @@ public final class DynECTResourceRecordSetApi implements denominator.ResourceRec
 
         for (Record<?> existingRecord : existingRecords) {
             if (recordsLeftToCreate.contains(existingRecord.getRData())
-                    && ttlToApply == existingRecord.getTTL().intValue()) {
+                    && ttlToApply == existingRecord.getTTL()) {
                 recordsLeftToCreate.remove(existingRecord.getRData());
                 continue;
             }

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/GroupByRecordNameAndTypeIterator.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/GroupByRecordNameAndTypeIterator.java
@@ -39,7 +39,7 @@ class GroupByRecordNameAndTypeIterator implements Iterator<ResourceRecordSet<?>>
         Builder<Map<String, Object>> builder = ResourceRecordSet.builder()
                                                                 .name(record.getFQDN())
                                                                 .type(record.getType())
-                                                                .ttl(record.getTTL().intValue())
+                                                                .ttl(record.getTTL())
                                                                 .add(record.getRData());
         while (hasNext()) {
             RecordId next = peekingIterator.peek();

--- a/providers/denominator-route53/build.gradle
+++ b/providers/denominator-route53/build.gradle
@@ -20,7 +20,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:aws-route53:1.6.0-rc.1'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.1'
+  compile     'org.jclouds.provider:aws-route53:1.6.0-SNAPSHOT'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-SNAPSHOT'
 }
 

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
@@ -17,12 +17,10 @@ import org.jclouds.route53.domain.ChangeBatch;
 import org.jclouds.route53.domain.HostedZone;
 import org.jclouds.route53.domain.ResourceRecordSetIterable.NextRecord;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceRecordSetApi;
 import denominator.model.ResourceRecordSet;
@@ -80,12 +78,7 @@ final class Route53ResourceRecordSetApi implements denominator.ResourceRecordSet
         Optional<org.jclouds.route53.domain.ResourceRecordSet> oldRRS = getRoute53RRSByNameAndType(rrset.getName(),
                 rrset.getType());
         if (oldRRS.isPresent()) {
-            ttlToApply = ttlToApply.or(oldRRS.get().getTTL().transform(new Function<UnsignedInteger, Integer>() {
-                // temporary until jclouds 1.6 rc2
-                public Integer apply( UnsignedInteger input) {
-                    return Integer.valueOf(input.intValue());
-                }
-            }));
+            ttlToApply = ttlToApply.or(oldRRS.get().getTTL());
             changes.delete(oldRRS.get());
             values.addAll(oldRRS.get().getValues());
             values.addAll(filter(toTextFormat(rrset), not(in(oldRRS.get().getValues()))));

--- a/providers/denominator-ultradns/build.gradle
+++ b/providers/denominator-ultradns/build.gradle
@@ -20,7 +20,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:ultradns-ws:1.6.0-rc.1'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.1'
+  compile     'org.jclouds.provider:ultradns-ws:1.6.0-SNAPSHOT'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-SNAPSHOT'
 }
 

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/GroupByRecordNameAndTypeIterator.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/GroupByRecordNameAndTypeIterator.java
@@ -10,7 +10,6 @@ import org.jclouds.ultradns.ws.domain.ResourceRecord;
 import org.jclouds.ultradns.ws.domain.ResourceRecordMetadata;
 
 import com.google.common.collect.PeekingIterator;
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceTypeToValue;
 import denominator.model.ResourceRecordSet;
@@ -31,12 +30,11 @@ class GroupByRecordNameAndTypeIterator implements Iterator<ResourceRecordSet<?>>
     @Override
     public ResourceRecordSet<?> next() {
         ResourceRecord record = peekingIterator.next().getRecord();
-        UnsignedInteger typeCode = record.getType();
-        String type = new ResourceTypeToValue().inverse().get(Integer.valueOf(typeCode.intValue()));
+        String type = new ResourceTypeToValue().inverse().get(record.getType());
         Builder<Map<String, Object>> builder = ResourceRecordSet.builder()
                                                                 .name(record.getName())
                                                                 .type(type)
-                                                                .ttl(record.getTTL().intValue());
+                                                                .ttl(record.getTTL());
 
         builder.add(toRdataMap().apply(record));
 
@@ -58,6 +56,6 @@ class GroupByRecordNameAndTypeIterator implements Iterator<ResourceRecordSet<?>>
     }
 
     static boolean fqdnAndTypeEquals(ResourceRecord actual, ResourceRecord expected) {
-        return actual.getName().equals(expected.getName()) && actual.getType().equals(expected.getType());
+        return actual.getName().equals(expected.getName()) && actual.getType() == expected.getType();
     }   
 }

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSFunctions.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSFunctions.java
@@ -10,7 +10,6 @@ import org.jclouds.ultradns.ws.domain.ResourceRecordMetadata;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceTypeToValue;
 import denominator.model.rdata.AAAAData;
@@ -57,8 +56,7 @@ final class UltraDNSFunctions {
         @Override
         public Map<String, Object> apply(ResourceRecord in) {
             List<String> parts = in.getRData();
-            UnsignedInteger typeCode = in.getType();
-            String type = new ResourceTypeToValue().inverse().get(Integer.valueOf(typeCode.intValue()));
+            String type = new ResourceTypeToValue().inverse().get(in.getType());
             if ("A".equals(type)) {
                 return AData.create(parts.get(0));
             } else if ("AAAA".equals(type)) {

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSPredicates.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSPredicates.java
@@ -28,7 +28,7 @@ final class UltraDNSPredicates {
 
         @Override
         public boolean apply(ResourceRecord in) {
-            return typeValue == in.getType().intValue();
+            return typeValue == in.getType();
         }
 
         @Override

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
@@ -88,7 +88,7 @@ public final class UltraDNSResourceRecordSetApi implements denominator.ResourceR
         // name = zoneName
         return api.list().filter(new Predicate<ResourceRecordMetadata>() {
             public boolean apply(ResourceRecordMetadata in) {
-                return name.equals(in.getRecord().getName()) && typeValue == in.getRecord().getType().intValue();
+                return name.equals(in.getRecord().getName()) && typeValue == in.getRecord().getType();
             }
         }).toSortedList(usingToString());
     }
@@ -109,19 +109,19 @@ public final class UltraDNSResourceRecordSetApi implements denominator.ResourceR
         for (ResourceRecordMetadata reference : references) {
             ResourceRecord record = reference.getRecord();
             if (!ttlToApply.isPresent())
-                ttlToApply = Optional.of(record.getTTL().intValue());
+                ttlToApply = Optional.of(record.getTTL());
             ResourceRecord updateTTL = record.toBuilder().ttl(ttlToApply.or(defaultTTL)).build();
 
             Map<String, Object> rdata = toRdataMap().apply(record);
             if (recordsLeftToCreate.contains(rdata)) {
                 recordsLeftToCreate.remove(rdata);
                 // all ok.
-                if (ttlToApply.get().intValue() == record.getTTL().intValue()) {
+                if (ttlToApply.get().intValue() == record.getTTL()) {
                     continue;
                 }
                 // update ttl of rdata in input
                 api.update(reference.getGuid(), updateTTL);
-            } else if (ttlToApply.get().intValue() != record.getTTL().intValue()) {
+            } else if (ttlToApply.get().intValue() != record.getTTL()) {
                 // update ttl of other record
                 api.update(reference.getGuid(), updateTTL);
             }
@@ -160,7 +160,7 @@ public final class UltraDNSResourceRecordSetApi implements denominator.ResourceR
             if (recordsLeftToCreate.contains(rdata)) {
                 recordsLeftToCreate.remove(rdata);
                 // all ok.
-                if (ttlToApply == record.getTTL().intValue()) {
+                if (ttlToApply == record.getTTL()) {
                     continue;
                 }
                 // update ttl of rdata in input

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSRoundRobinPoolApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSRoundRobinPoolApi.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
-import com.google.common.primitives.UnsignedInteger;
 
 import denominator.ResourceTypeToValue;
 
@@ -48,9 +47,9 @@ class UltraDNSRoundRobinPoolApi {
             String recordId = null;
             String address = rdata.get("address").toString();
             if (type.equals("A")) {
-                recordId = roundRobinPoolApi.addARecordWithAddressAndTTL(poolId, address, UnsignedInteger.fromIntBits(ttl));
+                recordId = roundRobinPoolApi.addARecordWithAddressAndTTL(poolId, address, ttl);
             } else {
-                recordId = roundRobinPoolApi.addAAAARecordWithAddressAndTTL(poolId, address, UnsignedInteger.fromIntBits(ttl));
+                recordId = roundRobinPoolApi.addAAAARecordWithAddressAndTTL(poolId, address, ttl);
             }
             LOGGER.debug("record ({}) created with id({})", address, recordId);
         }

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSFunctionsTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSFunctionsTest.java
@@ -20,7 +20,7 @@ import denominator.model.rdata.CNAMEData;
 public class UltraDNSFunctionsTest {
 
     ResourceRecord a = ResourceRecord.rrBuilder().name("www.foo.com.")
-                                                 .type("A")
+                                                 .type(1)
                                                  .ttl(3600)
                                                  .rdata("1.1.1.1").build();
 
@@ -39,11 +39,11 @@ public class UltraDNSFunctionsTest {
     @DataProvider(name = "records")
     public Object[][] createData() {
         Object[][] data = new Object[3][2];
-        data[0][0] = rrBuilder().name("foo.com.").ttl(3600).type("A").rdata("1.1.1.1").build();
+        data[0][0] = rrBuilder().name("foo.com.").ttl(3600).type(1).rdata("1.1.1.1").build();
         data[0][1] = AData.create("1.1.1.1");
-        data[1][0] = rrBuilder().name("foo.com.").ttl(3600).type("AAAA").rdata("2001:0DB8:85A3:0000:0000:8A2E:0370:7334").build();
+        data[1][0] = rrBuilder().name("foo.com.").ttl(3600).type(28).rdata("2001:0DB8:85A3:0000:0000:8A2E:0370:7334").build();
         data[1][1] = AAAAData.create("2001:0DB8:85A3:0000:0000:8A2E:0370:7334");
-        data[2][0] = rrBuilder().name("foo.com.").ttl(3600).type("CNAME").rdata("www.foo.com.").build();
+        data[2][0] = rrBuilder().name("foo.com.").ttl(3600).type(5).rdata("www.foo.com.").build();
         data[2][1] = CNAMEData.create("www.foo.com.");
         return data;
     }

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSPredicatesTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSPredicatesTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 public class UltraDNSPredicatesTest {
 
     ResourceRecord a = ResourceRecord.rrBuilder().name("www.foo.com.")
-                                                 .type("A")
+                                                 .type(1)
                                                  .ttl(3600)
                                                  .rdata("1.1.1.1").build();
 
@@ -39,7 +39,7 @@ public class UltraDNSPredicatesTest {
     }
 
     public void resourceTypeEqualToTrueOnSameType() {
-        assertTrue(UltraDNSPredicates.resourceTypeEqualTo(a.getType().intValue()).apply(a));
+        assertTrue(UltraDNSPredicates.resourceTypeEqualTo(a.getType()).apply(a));
     }
 
     public void recordGuidEqualToFalseOnDifferentGuid() {


### PR DESCRIPTION
updated to jclouds snapshots so that we can remove integer workarounds for ttl, and so that we can start working on load balanced records.
