### PR TITLE
Use RFC5735/RFC5156 IP addresses in tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ netflix.com.
 --snip--
 $ denominator -p ultradns -c my_user -c my_password record --zone netflix.com. list
 --snip--
-email.netflix.com.                                 A     3600   69.53.237.168
+email.netflix.com.                                 A     3600   192.0.2.1
 --snip--
 ```
 

--- a/denominator-cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
+++ b/denominator-cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
@@ -118,7 +118,7 @@ class ResourceRecordSetCommands {
         @Option(type = OptionType.COMMAND, required = true, name = { "-t", "--type" }, description = "type of the record set. ex. CNAME")
         public String type;
 
-        @Option(type = OptionType.COMMAND, required = false, name = { "-d", "--data" }, description = "repeat for each record value (rdata) to add. ex. 1.2.3.4")
+        @Option(type = OptionType.COMMAND, required = false, name = { "-d", "--data" }, description = "repeat for each record value (rdata) to add. ex. 192.0.2.1")
         public List<String> values;
 
         @Option(type = OptionType.COMMAND, required = false, name = "--ec2-public-ipv4", description = "take data from EC2 Instance Metadata public-ipv4")

--- a/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -53,9 +53,9 @@ public class DenominatorTest {
                 "denominator.io.                                   NS     86400 ns1.denominator.io.",
                 "denominator.io.                                   SOA    3600  ns1.denominator.io. admin.denominator.io. 1 3600 600 604800 60",
                 "www.denominator.io.                               CNAME  3600  www1.denominator.io.",
-                "www1.denominator.io.                              A      3600  1.1.1.1",
-                "www1.denominator.io.                              A      3600  1.1.1.2",
-                "www2.denominator.io.                              A      3600  2.2.2.2"));
+                "www1.denominator.io.                              A      3600  192.0.2.1",
+                "www1.denominator.io.                              A      3600  192.0.2.2",
+                "www2.denominator.io.                              A      3600  198.51.100.1"));
     }
 
     @Test(description = "denominator -p mock record -z denominator.io. list -n www1.denominator.io.")
@@ -64,8 +64,8 @@ public class DenominatorTest {
         command.zoneName = "denominator.io.";
         command.name = "www1.denominator.io.";
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
-                "www1.denominator.io.                              A      3600  1.1.1.1",
-                "www1.denominator.io.                              A      3600  1.1.1.2"));
+                "www1.denominator.io.                              A      3600  192.0.2.1",
+                "www1.denominator.io.                              A      3600  192.0.2.2"));
     }
 
     @Test(description = "denominator -p mock record -z denominator.io. get -n www1.denominator.io. -t A ")
@@ -75,8 +75,8 @@ public class DenominatorTest {
         command.name = "www1.denominator.io.";
         command.type = "A";
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
-                "www1.denominator.io.                              A      3600  1.1.1.1",
-                "www1.denominator.io.                              A      3600  1.1.1.2"));
+                "www1.denominator.io.                              A      3600  192.0.2.1",
+                "www1.denominator.io.                              A      3600  192.0.2.2"));
     }
 
     @Test(description = "denominator -p mock record -z denominator.io. get -n www3.denominator.io. -t A ")
@@ -100,65 +100,65 @@ public class DenominatorTest {
                 ";; ok"));
     }
 
-    @Test(description = "denominator -p mock record -z denominator.io. add -n www1.denominator.io. -t A -d 1.1.1.1 -d 1.1.1.2")
+    @Test(description = "denominator -p mock record -z denominator.io. add -n www1.denominator.io. -t A -d 192.0.2.1 -d 192.0.2.2")
     public void testResourceRecordSetAdd() {
         ResourceRecordSetAdd command = new ResourceRecordSetAdd();
         command.zoneName = "denominator.io.";
         command.name = "www1.denominator.io.";
         command.type = "A";
-        command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
+        command.values = ImmutableList.of("192.0.2.1", "192.0.2.2");
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
-                ";; in zone denominator.io. adding to rrset www1.denominator.io. A values: [{address=1.1.1.1},{address=1.1.1.2}]",
+                ";; in zone denominator.io. adding to rrset www1.denominator.io. A values: [{address=192.0.2.1},{address=192.0.2.2}]",
                 ";; ok"));
     }
 
-    @Test(description = "denominator -p mock record -z denominator.io. add -n www1.denominator.io. -t A --ttl 3600 -d 1.1.1.1 -d 1.1.1.2")
+    @Test(description = "denominator -p mock record -z denominator.io. add -n www1.denominator.io. -t A --ttl 3600 -d 192.0.2.1 -d 192.0.2.2")
     public void testResourceRecordSetAddWithTTL() {
         ResourceRecordSetAdd command = new ResourceRecordSetAdd();
         command.zoneName = "denominator.io.";
         command.name = "www1.denominator.io.";
         command.type = "A";
         command.ttl = 3600;
-        command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
+        command.values = ImmutableList.of("192.0.2.1", "192.0.2.2");
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
-                ";; in zone denominator.io. adding to rrset www1.denominator.io. A values: [{address=1.1.1.1},{address=1.1.1.2}] applying ttl 3600",
+                ";; in zone denominator.io. adding to rrset www1.denominator.io. A values: [{address=192.0.2.1},{address=192.0.2.2}] applying ttl 3600",
                 ";; ok"));
     }
 
-    @Test(description = "denominator -p mock record -z denominator.io. replace -n www1.denominator.io. -t A -d 1.1.1.1 -d 1.1.1.2")
+    @Test(description = "denominator -p mock record -z denominator.io. replace -n www1.denominator.io. -t A -d 192.0.2.1 -d 192.0.2.2")
     public void testResourceRecordSetReplace() {
         ResourceRecordSetReplace command = new ResourceRecordSetReplace();
         command.zoneName = "denominator.io.";
         command.name = "www1.denominator.io.";
         command.type = "A";
-        command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
+        command.values = ImmutableList.of("192.0.2.1", "192.0.2.2");
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
-                ";; in zone denominator.io. replacing rrset www1.denominator.io. A with values: [{address=1.1.1.1},{address=1.1.1.2}]",
+                ";; in zone denominator.io. replacing rrset www1.denominator.io. A with values: [{address=192.0.2.1},{address=192.0.2.2}]",
                 ";; ok"));
     }
 
-    @Test(description = "denominator -p mock record -z denominator.io. replace -n www1.denominator.io. -t A --ttl 3600 -d 1.1.1.1 -d 1.1.1.2")
+    @Test(description = "denominator -p mock record -z denominator.io. replace -n www1.denominator.io. -t A --ttl 3600 -d 192.0.2.1 -d 192.0.2.2")
     public void testResourceRecordSetReplaceWithTTL() {
         ResourceRecordSetReplace command = new ResourceRecordSetReplace();
         command.zoneName = "denominator.io.";
         command.name = "www1.denominator.io.";
         command.type = "A";
         command.ttl = 3600;
-        command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
+        command.values = ImmutableList.of("192.0.2.1", "192.0.2.2");
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
-                ";; in zone denominator.io. replacing rrset www1.denominator.io. A with values: [{address=1.1.1.1},{address=1.1.1.2}] and ttl 3600",
+                ";; in zone denominator.io. replacing rrset www1.denominator.io. A with values: [{address=192.0.2.1},{address=192.0.2.2}] and ttl 3600",
                 ";; ok"));
     }
 
-    @Test(description = "denominator -p mock record -z denominator.io. remove -n www1.denominator.io. -t A -d 1.1.1.1 -d 1.1.1.2")
+    @Test(description = "denominator -p mock record -z denominator.io. remove -n www1.denominator.io. -t A -d 192.0.2.1 -d 192.0.2.2")
     public void testResourceRecordSetRemove() {
         ResourceRecordSetRemove command = new ResourceRecordSetRemove();
         command.zoneName = "denominator.io.";
         command.name = "www1.denominator.io.";
         command.type = "A";
-        command.values = ImmutableList.of("1.1.1.1", "1.1.1.2");
+        command.values = ImmutableList.of("192.0.2.1", "192.0.2.2");
         assertEquals(Joiner.on('\n').join(command.doRun(mgr)), Joiner.on('\n').join(
-                ";; in zone denominator.io. removing from rrset www1.denominator.io. A values: [{address=1.1.1.1},{address=1.1.1.2}]",
+                ";; in zone denominator.io. removing from rrset www1.denominator.io. A values: [{address=192.0.2.1},{address=192.0.2.2}]",
                 ";; ok"));
     }
 

--- a/denominator-core/src/main/java/denominator/ResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/ResourceRecordSetApi.java
@@ -53,13 +53,13 @@ public interface ResourceRecordSetApi {
      * {@link ResourceRecordSet} initially comprised of the specified
      * {@code rrset}.
      * 
-     * Example of adding "1.2.3.4" to the {@code A} record set for
+     * Example of adding "192.0.2.1" to the {@code A} record set for
      * {@code www.denominator.io.}
      * 
      * <pre>
      * import static denominator.model.ResourceRecordSets.a;
      * ...
-     * rrsApi.add(a("www.denominator.io.", 3600, "1.2.3.4"));
+     * rrsApi.add(a("www.denominator.io.", 3600, "192.0.2.1"));
      * </pre>
      * 
      * @param rrset
@@ -90,12 +90,12 @@ public interface ResourceRecordSetApi {
      * {@link ResourceRecordSet#getType() type} corresponding to {@code rrset}.
      * 
      * Example of replacing the {@code A} record set for
-     * {@code www.denominator.io.} with "1.2.3.4".
+     * {@code www.denominator.io.} with "192.0.2.1".
      * 
      * <pre>
      * import static denominator.model.ResourceRecordSets.a;
      * ...
-     * rrsApi.replace(a("www.denominator.io.", 3600, "1.2.3.4"));
+     * rrsApi.replace(a("www.denominator.io.", 3600, "192.0.2.1"));
      * </pre>
      * 
      * @param rrset
@@ -112,13 +112,13 @@ public interface ResourceRecordSetApi {
      * remove values corresponding to input {@code rdata}, or removes the set
      * entirely, if this is the only entry.
      * 
-     * Example of removing "1.2.3.4" from the {@code A} record set for
+     * Example of removing "192.0.2.1" from the {@code A} record set for
      * {@code www.denominator.io.}
      * 
      * <pre>
      * import static denominator.model.ResourceRecordSets.a;
      * ...
-     * rrsApi.remove(a("www.denominator.io.", "1.2.3.4"));
+     * rrsApi.remove(a("www.denominator.io.", "192.0.2.1"));
      * </pre>
      * 
      * @param rrset

--- a/denominator-core/src/main/java/denominator/mock/MockProvider.java
+++ b/denominator-core/src/main/java/denominator/mock/MockProvider.java
@@ -64,8 +64,8 @@ public class MockProvider extends Provider {
                                                         .expire(604800)
                                                         .minimum(60).build()).build());
         data.put(zoneName, ns(zoneName, 86400, "ns1." + zoneName));
-        data.put(zoneName, a("www1." + zoneName, 3600, ImmutableSet.of("1.1.1.1", "1.1.1.2")));
-        data.put(zoneName, a("www2." + zoneName, 3600, "2.2.2.2"));
+        data.put(zoneName, a("www1." + zoneName, 3600, ImmutableSet.of("192.0.2.1", "192.0.2.2")));
+        data.put(zoneName, a("www2." + zoneName, 3600, "198.51.100.1"));
         data.put(zoneName, cname("www." + zoneName, 3600, "www1." + zoneName));
         return Multimap.class.cast(data);
     }

--- a/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
@@ -45,8 +45,8 @@ abstract class BaseProviderLiveTest {
         String recordSuffix =  recordPrefix + "." + zoneName;
         Builder<String, ResourceRecordSet<?>> builder = ImmutableMap.<String, ResourceRecordSet<?>> builder();
         builder.put("AAAA", aaaa("ipv6-" + recordSuffix, ImmutableList.of("2001:0DB8:85A3:0000:0000:8A2E:0370:7334",
-                "2002:0DB8:85A3:0000:0000:8A2E:0370:7334", "2003:0DB8:85A3:0000:0000:8A2E:0370:7334")));
-        builder.put("A", a("ipv4-" + recordSuffix, ImmutableList.of("1.1.1.1", "2.2.2.2", "3.3.3.3")));
+                "2001:0DB8:85A3:0000:0000:8A2E:0370:7335", "2001:0DB8:85A3:0000:0000:8A2E:0370:7336")));
+        builder.put("A", a("ipv4-" + recordSuffix, ImmutableList.of("192.0.2.1", "198.51.100.1", "203.0.113.1")));
         builder.put(
                 "CNAME",
                 cname("www-" + recordSuffix,

--- a/denominator-model/src/main/java/denominator/model/ResourceRecordSets.java
+++ b/denominator-model/src/main/java/denominator/model/ResourceRecordSets.java
@@ -127,7 +127,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param address
-     *            ex. {@code 1.1.1.1}
+     *            ex. {@code 192.0.2.1}
      */
     public static ResourceRecordSet<AData> a(String name, String address) {
         return new ABuilder().name(name).add(address).build();
@@ -142,7 +142,7 @@ public class ResourceRecordSets {
      * @param ttl
      *            see {@link ResourceRecordSet#getTTL()}
      * @param address
-     *            ex. {@code 1.1.1.1}
+     *            ex. {@code 192.0.2.1}
      */
     public static ResourceRecordSet<AData> a(String name, int ttl, String address) {
         return new ABuilder().name(name).ttl(ttl).add(address).build();
@@ -155,7 +155,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param addresses
-     *            address values ex. {@code [1.1.1.1, 1.1.1.2]}
+     *            address values ex. {@code [192.0.2.1, 192.0.2.2]}
      */
     public static ResourceRecordSet<AData> a(String name, Iterable<String> addresses) {
         return new ABuilder().name(name).addAll(addresses).build();
@@ -170,7 +170,7 @@ public class ResourceRecordSets {
      * @param ttl
      *            see {@link ResourceRecordSet#getTTL()}
      * @param addresses
-     *            address values ex. {@code [1.1.1.1, 1.1.1.2]}
+     *            address values ex. {@code [192.0.2.1, 192.0.2.2]}
      */
     public static ResourceRecordSet<AData> a(String name, int ttl, Iterable<String> addresses) {
         return new ABuilder().name(name).ttl(ttl).addAll(addresses).build();

--- a/denominator-model/src/main/java/denominator/model/StringRDataBuilder.java
+++ b/denominator-model/src/main/java/denominator/model/StringRDataBuilder.java
@@ -28,7 +28,7 @@ abstract class StringRDataBuilder<D extends Map<String, Object>> extends
      * ex.
      * 
      * <pre>
-     * builder.add(&quot;1.1.1.1&quot;);
+     * builder.add(&quot;192.0.2.1&quot;);
      * </pre>
      */
     public StringRDataBuilder<D> add(String rdata) {
@@ -42,7 +42,7 @@ abstract class StringRDataBuilder<D extends Map<String, Object>> extends
      * ex.
      * 
      * <pre>
-     * builder.addAll(&quot;1.1.1.1&quot;, &quot;1.1.1.2&quot;);
+     * builder.addAll(&quot;192.0.2.1&quot;, &quot;192.0.2.2&quot;);
      * </pre>
      */
     public StringRDataBuilder<D> addAll(String... rdata) {
@@ -56,7 +56,7 @@ abstract class StringRDataBuilder<D extends Map<String, Object>> extends
      * ex.
      * 
      * <pre>
-     * builder.addAll(&quot;1.1.1.1&quot;, &quot;1.1.1.2&quot;);
+     * builder.addAll(&quot;192.0.2.1&quot;, &quot;192.0.2.2&quot;);
      * </pre>
      */
     public StringRDataBuilder<D> addAll(Iterable<String> rdata) {

--- a/denominator-model/src/main/java/denominator/model/rdata/AData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/AData.java
@@ -17,7 +17,7 @@ import com.google.common.net.InetAddresses;
  * <h4>Example</h4>
  * 
  * <pre>
- * AData rdata = AData.create(&quot;1.1.1.1&quot;);
+ * AData rdata = AData.create(&quot;192.0.2.1&quot;);
  * </pre>
  * 
  * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
@@ -27,7 +27,7 @@ public class AData extends ForwardingMap<String, Object> {
     /**
      * 
      * @param ipv4address
-     *            valid ipv4 address. ex. {@code 1.1.1.1}
+     *            valid ipv4 address. ex. {@code 192.0.2.1}
      * @throws IllegalArgumentException
      *             if the address is malformed or not ipv4
      * @see InetAddresses#forString(String)

--- a/denominator-model/src/main/java/denominator/model/rdata/TXTData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/TXTData.java
@@ -15,7 +15,7 @@ import com.google.common.collect.ImmutableMap;
  * <h4>Example</h4>
  * 
  * <pre>
- * TXTData rdata = TXTData.create("=spf1 ip4:1.1.1.1/24 ip4:2.2.2.2/24 -all");
+ * TXTData rdata = TXTData.create("=spf1 ip4:192.0.2.1/24 ip4:198.51.100.1/24 -all");
  * </pre>
  * 
  * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>

--- a/denominator-model/src/test/java/denominator/model/ResourceRecordSetTest.java
+++ b/denominator-model/src/test/java/denominator/model/ResourceRecordSetTest.java
@@ -15,12 +15,12 @@ public class ResourceRecordSetTest {
                                                            .name("www.denominator.io.")
                                                            .type("A")
                                                            .ttl(3600)
-                                                           .add(AData.create("1.1.1.1")).build();
+                                                           .add(AData.create("192.0.2.1")).build();
 
         assertEquals(record.getName(), "www.denominator.io.");
         assertEquals(record.getType(), "A");
         assertEquals(record.getTTL().get(), Integer.valueOf(3600));
-        assertEquals(record.get(0), AData.create("1.1.1.1"));
+        assertEquals(record.get(0), AData.create("192.0.2.1"));
     }
 
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "rdata")
@@ -34,6 +34,6 @@ public class ResourceRecordSetTest {
             .name("www.denominator.io.")
             .type("A")
             .ttl(0xFFFFFFFF)
-            .add(AData.create("1.1.1.1")).build();
+            .add(AData.create("192.0.2.1")).build();
     }
 }

--- a/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -31,7 +31,7 @@ public class ResourceRecordSetsTest {
                                                      .name("www.denominator.io.")
                                                      .type("A")
                                                      .ttl(3600)
-                                                     .add(AData.create("1.1.1.1")).build();
+                                                     .add(AData.create("192.0.2.1")).build();
 
     public void nameEqualToReturnsFalseOnNull() {
         assertFalse(ResourceRecordSets.nameEqualTo(aRRS.getName()).apply(null));
@@ -62,34 +62,34 @@ public class ResourceRecordSetsTest {
     }
 
     public void containsRDataReturnsFalseWhenRDataDifferent() {
-        assertFalse(ResourceRecordSets.containsRData(AData.create("2.2.2.2")).apply(aRRS));
+        assertFalse(ResourceRecordSets.containsRData(AData.create("198.51.100.1")).apply(aRRS));
     }
 
     public void containsRDataReturnsTrueWhenRDataEqual() {
-        assertTrue(ResourceRecordSets.containsRData(AData.create("1.1.1.1")).apply(aRRS));
+        assertTrue(ResourceRecordSets.containsRData(AData.create("192.0.2.1")).apply(aRRS));
     }
 
     public void containsRDataReturnsTrueWhenRDataEqualButDifferentType() {
-        assertTrue(ResourceRecordSets.containsRData(ImmutableMap.of("address", "1.1.1.1")).apply(aRRS));
+        assertTrue(ResourceRecordSets.containsRData(ImmutableMap.of("address", "192.0.2.1")).apply(aRRS));
     }
 
     @DataProvider(name = "a")
     public Object[][] createData() {
         Object[][] data = new Object[28][2];
-        data[0][0] = a("www.denominator.io.", "1.1.1.1");
+        data[0][0] = a("www.denominator.io.", "192.0.2.1");
         data[0][1] = ResourceRecordSet.<AData> builder()
                                       .name("www.denominator.io.")
                                       .type("A")
-                                      .add(AData.create("1.1.1.1")).build();
-        data[1][0] = a("www.denominator.io.", 3600, "1.1.1.1");
+                                      .add(AData.create("192.0.2.1")).build();
+        data[1][0] = a("www.denominator.io.", 3600, "192.0.2.1");
         data[1][1] = ResourceRecordSet.<AData> builder()
                                       .name("www.denominator.io.")
                                       .type("A")
                                       .ttl(3600)
-                                      .add(AData.create("1.1.1.1")).build();
-        data[2][0] = a("www.denominator.io.", ImmutableSet.of("1.1.1.1"));
+                                      .add(AData.create("192.0.2.1")).build();
+        data[2][0] = a("www.denominator.io.", ImmutableSet.of("192.0.2.1"));
         data[2][1] = data[0][1];
-        data[3][0] = a("www.denominator.io.", 3600, ImmutableSet.of("1.1.1.1"));
+        data[3][0] = a("www.denominator.io.", 3600, ImmutableSet.of("192.0.2.1"));
         data[3][1] = data[1][1];
         data[4][0] = cname("www.denominator.io.", "1234:ab00:ff00::6b14:abcd");
         data[4][1] = ResourceRecordSet.<CNAMEData> builder()

--- a/denominator-model/src/test/java/denominator/model/rdata/AAAADataTest.java
+++ b/denominator-model/src/test/java/denominator/model/rdata/AAAADataTest.java
@@ -9,7 +9,7 @@ public class AAAADataTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*should be a ipv6 address.*")
     public void testBadIPv4() {
-        aaaa("www.denominator.io.", "192.168.254.5");
+        aaaa("www.denominator.io.", "192.0.2.1");
     }
     
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*not an IP.*")
@@ -18,6 +18,6 @@ public class AAAADataTest {
     }
     
     public void testGoodIPv6() {
-        aaaa("www.denominator.io.", "2620:0:1cfe:face:b00c::3");
+        aaaa("www.denominator.io.", "2001:db8:1cfe:face:b00c::3");
     }
 }

--- a/denominator-model/src/test/java/denominator/model/rdata/ADataTest.java
+++ b/denominator-model/src/test/java/denominator/model/rdata/ADataTest.java
@@ -9,7 +9,7 @@ public class ADataTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*should be a ipv4 address.*")
     public void testBadIPv6() {
-        a("www.denominator.io.", "2620:0:1cfe:face:b00c::3");
+        a("www.denominator.io.", "2001:db8:1cfe:face:b00c::3");
     }    
     
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*not an IP.*")
@@ -18,6 +18,6 @@ public class ADataTest {
     }
     
     public void testGoodIPv4() {
-        a("www.denominator.io.", "192.168.254.5");
+        a("www.denominator.io.", "192.0.2.1");
     }
 }

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTResourceRecordSetApiMockTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTResourceRecordSetApiMockTest.java
@@ -42,7 +42,7 @@ public class DynECTResourceRecordSetApiMockTest {
     String session = "{\"status\": \"success\", \"data\": {\"token\": \"FFFFFFFFFF\", \"version\": \"3.3.8\"}, \"job_id\": 254417252, \"msgs\": [{\"INFO\": \"login: Login successful\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
     String success = "{\"status\": \"success\", \"data\": {}, \"job_id\": 262989027, \"msgs\": [{\"INFO\": \"thing done\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
 
-    String createRecord1 = "{\"rdata\":{\"address\":\"1.2.3.4\"},\"ttl\":3600}";
+    String createRecord1 = "{\"rdata\":{\"address\":\"192.0.2.1\"},\"ttl\":3600}";
 
     @Test
     public void addFirstRecordPostsAndPublishes() throws IOException, InterruptedException {
@@ -56,7 +56,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.add(a("www.foo.com", 3600, "1.2.3.4"));
+            api.add(a("www.foo.com", 3600, "192.0.2.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -76,7 +76,7 @@ public class DynECTResourceRecordSetApiMockTest {
     }
 
     String recordIdsWithRecord1 = "{\"status\": \"success\", \"data\": [\"/REST/ARecord/foo.com/www.foo.com/1\"], \"job_id\": 273523368, \"msgs\": [{\"INFO\": \"get_tree: Here is your zone tree\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
-    String record1Result = "{\"status\": \"success\", \"data\": {\"zone\": \"foo.com\", \"ttl\": 3600, \"fqdn\": \"www.foo.com\", \"record_type\": \"A\", \"rdata\": {\"address\": \"1.2.3.4\"}, \"record_id\": 1}, \"job_id\": 274279510, \"msgs\": [{\"INFO\": \"get: Found the record\", \"SOURCE\": \"API-B\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+    String record1Result = "{\"status\": \"success\", \"data\": {\"zone\": \"foo.com\", \"ttl\": 3600, \"fqdn\": \"www.foo.com\", \"record_type\": \"A\", \"rdata\": {\"address\": \"192.0.2.1\"}, \"record_id\": 1}, \"job_id\": 274279510, \"msgs\": [{\"INFO\": \"get: Found the record\", \"SOURCE\": \"API-B\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
 
     @Test
     public void addAddExistingRecordDoesNothing() throws IOException, InterruptedException {
@@ -89,7 +89,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.add(a("www.foo.com", 3600, "1.2.3.4"));
+            api.add(a("www.foo.com", 3600, "192.0.2.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -103,7 +103,7 @@ public class DynECTResourceRecordSetApiMockTest {
         }
     }
 
-    String createRecord2 = "{\"rdata\":{\"address\":\"5.6.7.8\"},\"ttl\":3600}";
+    String createRecord2 = "{\"rdata\":{\"address\":\"198.51.100.1\"},\"ttl\":3600}";
 
     @Test
     public void addSecondRecordPostsRecordWithOldTTLAndPublishes() throws IOException, InterruptedException {
@@ -118,7 +118,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.add(a("www.foo.com", "5.6.7.8"));
+            api.add(a("www.foo.com", "198.51.100.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -140,8 +140,8 @@ public class DynECTResourceRecordSetApiMockTest {
         }
     }
     
-    String createRecord1OverriddenTTL = "{\"rdata\":{\"address\":\"1.2.3.4\"},\"ttl\":10000000}";
-    String createRecord2OverriddenTTL = "{\"rdata\":{\"address\":\"5.6.7.8\"},\"ttl\":10000000}";
+    String createRecord1OverriddenTTL = "{\"rdata\":{\"address\":\"192.0.2.1\"},\"ttl\":10000000}";
+    String createRecord2OverriddenTTL = "{\"rdata\":{\"address\":\"198.51.100.1\"},\"ttl\":10000000}";
 
     @Test
     public void addSecondRecordWithNewTTLRecreatesFirstRecordWithTTLAndPublishes() throws IOException, InterruptedException {
@@ -158,7 +158,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.add(a("www.foo.com", 10000000, "5.6.7.8"));
+            api.add(a("www.foo.com", 10000000, "198.51.100.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -200,7 +200,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.remove(a("www.foo.com", "1.2.3.4"));
+            api.remove(a("www.foo.com", "192.0.2.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -222,7 +222,7 @@ public class DynECTResourceRecordSetApiMockTest {
     }
 
     String recordIdsWithRecords1And2 = "{\"status\": \"success\", \"data\": [\"/REST/ARecord/foo.com/www.foo.com/1\",\"/REST/ARecord/foo.com/www.foo.com/2\"], \"job_id\": 273523368, \"msgs\": [{\"INFO\": \"get_tree: Here is your zone tree\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
-    String record2Result = "{\"status\": \"success\", \"data\": {\"zone\": \"foo.com\", \"ttl\": 3600, \"fqdn\": \"www.foo.com\", \"record_type\": \"A\", \"rdata\": {\"address\": \"5.6.7.8\"}, \"record_id\": 2}, \"job_id\": 274279510, \"msgs\": [{\"INFO\": \"get: Found the record\", \"SOURCE\": \"API-B\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
+    String record2Result = "{\"status\": \"success\", \"data\": {\"zone\": \"foo.com\", \"ttl\": 3600, \"fqdn\": \"www.foo.com\", \"record_type\": \"A\", \"rdata\": {\"address\": \"198.51.100.1\"}, \"record_id\": 2}, \"job_id\": 274279510, \"msgs\": [{\"INFO\": \"get: Found the record\", \"SOURCE\": \"API-B\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}";
 
     @Test
     public void removeRecord1ResultReplacesRRSet() throws IOException, InterruptedException {
@@ -238,7 +238,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.remove(a("www.foo.com", "5.6.7.8"));
+            api.remove(a("www.foo.com", "198.51.100.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -371,7 +371,7 @@ public class DynECTResourceRecordSetApiMockTest {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
             assertEquals(api.listByName("www.foo.com").next(),
-                    a("www.foo.com", 3600, ImmutableList.of("1.2.3.4", "5.6.7.8")));
+                    a("www.foo.com", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -422,7 +422,7 @@ public class DynECTResourceRecordSetApiMockTest {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
             assertEquals(api.getByNameAndType("www.foo.com", "A").get(),
-                    a("www.foo.com", 3600, ImmutableList.of("1.2.3.4", "5.6.7.8")));
+                    a("www.foo.com", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -475,7 +475,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.replace(a("www.foo.com", 10000000, ImmutableSet.of("1.2.3.4", "5.6.7.8")));
+            api.replace(a("www.foo.com", 10000000, ImmutableSet.of("192.0.2.1", "198.51.100.1")));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -515,7 +515,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.replace(a("www.foo.com", 3600, "1.2.3.4"));
+            api.replace(a("www.foo.com", 3600, "192.0.2.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 
@@ -540,7 +540,7 @@ public class DynECTResourceRecordSetApiMockTest {
         try {
             DynECTResourceRecordSetApi api = new DynECTResourceRecordSetApi(
                     mockDynECTApi(server.getUrl("/").toString()), "foo.com");
-            api.remove(a("www.foo.com", "5.6.7.8"));
+            api.remove(a("www.foo.com", "198.51.100.1"));
         } finally {
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
 

--- a/providers/denominator-route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
+++ b/providers/denominator-route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
@@ -104,7 +104,7 @@ public class Route53ResourceRecordSetApiMockTest {
     }
 
     String noRecords = "<ListResourceRecordSetsResponse><ResourceRecordSets></ResourceRecordSets></ListResourceRecordSetsResponse>";
-    String createARecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
+    String createARecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
     String changeSynced = "<GetChangeResponse><ChangeInfo><Id>/change/C2682N5HXP0BZ4</Id><Status>INSYNC</Status><SubmittedAt>2011-09-10T01:36:41.958Z</SubmittedAt></ChangeInfo></GetChangeResponse>";
 
     @Test
@@ -117,7 +117,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.add(a("www.foo.com.", 3600, "1.2.3.4"));
+            api.add(a("www.foo.com.", 3600, "192.0.2.1"));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -131,8 +131,8 @@ public class Route53ResourceRecordSetApiMockTest {
         }
     }
 
-    String oneRecord = "<ListResourceRecordSetsResponse><ResourceRecordSets><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets></ListResourceRecordSetsResponse>";
-    String replaceWith2ElementRecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord><ResourceRecord><Value>5.6.7.8</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
+    String oneRecord = "<ListResourceRecordSetsResponse><ResourceRecordSets><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets></ListResourceRecordSetsResponse>";
+    String replaceWith2ElementRecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
 
     @Test
     public void addSecondRecordRecreatesRRSetAndRetainsTTL() throws IOException, InterruptedException {
@@ -144,7 +144,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.add(a("www.foo.com.", "5.6.7.8"));
+            api.add(a("www.foo.com.", "198.51.100.1"));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -158,7 +158,7 @@ public class Route53ResourceRecordSetApiMockTest {
         }
     }
 
-    String replaceWith2ElementRecordSetOverridingTTL = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>10000000</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord><ResourceRecord><Value>5.6.7.8</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
+    String replaceWith2ElementRecordSetOverridingTTL = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>10000000</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
 
     @Test
     public void addSecondRecordRecreatesRRSetAndOverridesTTLWhenPresent() throws IOException, InterruptedException {
@@ -170,7 +170,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.add(a("www.foo.com.", 10000000, "5.6.7.8"));
+            api.add(a("www.foo.com.", 10000000, "198.51.100.1"));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -184,7 +184,7 @@ public class Route53ResourceRecordSetApiMockTest {
         }
     }
 
-    String deleteARecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
+    String deleteARecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
 
     @Test
     public void removeOnlyRecordDoesntAdd() throws IOException, InterruptedException {
@@ -196,7 +196,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.remove(a("www.foo.com.", "1.2.3.4"));
+            api.remove(a("www.foo.com.", "192.0.2.1"));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -210,8 +210,8 @@ public class Route53ResourceRecordSetApiMockTest {
         }
     }
 
-    String twoRecords = "<ListResourceRecordSetsResponse><ResourceRecordSets><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord><ResourceRecord><Value>5.6.7.8</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets></ListResourceRecordSetsResponse>";
-    String replaceWith1ElementRecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord><ResourceRecord><Value>5.6.7.8</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
+    String twoRecords = "<ListResourceRecordSetsResponse><ResourceRecordSets><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets></ListResourceRecordSetsResponse>";
+    String replaceWith1ElementRecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
 
     @Test
     public void removeOneRecordReplacesRRSet() throws IOException, InterruptedException {
@@ -223,7 +223,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.remove(a("www.foo.com.", "5.6.7.8"));
+            api.remove(a("www.foo.com.", "198.51.100.1"));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -273,7 +273,7 @@ public class Route53ResourceRecordSetApiMockTest {
         }
     }
 
-    String recreate2ElementRecordSetWithTTL = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord><ResourceRecord><Value>5.6.7.8</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>10000000</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord><ResourceRecord><Value>5.6.7.8</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
+    String recreate2ElementRecordSetWithTTL = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>10000000</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
 
     @Test
     public void applyTTLRecreatesRecordsWithSameRDataWhenDifferent() throws IOException, InterruptedException {
@@ -308,7 +308,7 @@ public class Route53ResourceRecordSetApiMockTest {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
             assertEquals(api.listByName("www.foo.com.").next(),
-                    a("www.foo.com.", 3600, ImmutableList.of("1.2.3.4", "5.6.7.8")));
+                    a("www.foo.com.", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -347,7 +347,7 @@ public class Route53ResourceRecordSetApiMockTest {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
             assertEquals(api.getByNameAndType("www.foo.com.", "A").get(),
-                    a("www.foo.com.", 3600, ImmutableList.of("1.2.3.4", "5.6.7.8")));
+                    a("www.foo.com.", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -386,7 +386,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.replace(a("www.foo.com.", 10000000, ImmutableSet.of("1.2.3.4", "5.6.7.8")));
+            api.replace(a("www.foo.com.", 10000000, ImmutableSet.of("192.0.2.1", "198.51.100.1")));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -409,7 +409,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.replace(a("www.foo.com.", 3600, "1.2.3.4"));
+            api.replace(a("www.foo.com.", 3600, "192.0.2.1"));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -427,7 +427,7 @@ public class Route53ResourceRecordSetApiMockTest {
         try {
             Route53ResourceRecordSetApi api = new Route53ResourceRecordSetApi(mockRoute53Api(server.getUrl("/")
                     .toString()));
-            api.remove(a("www.foo.com.", "5.6.7.8"));
+            api.remove(a("www.foo.com.", "198.51.100.1"));
         } finally {
             RecordedRequest listNameAndType = server.takeRequest();
             assertEquals(listNameAndType.getRequestLine(),
@@ -436,7 +436,7 @@ public class Route53ResourceRecordSetApiMockTest {
         }
     }
 
-    String delete2ElementRecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>1.2.3.4</Value></ResourceRecord><ResourceRecord><Value>5.6.7.8</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
+    String delete2ElementRecordSet = "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.foo.com.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>";
 
     @Test
     public void deleteRRSet() throws IOException, InterruptedException {

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/GroupByRecordNameAndTypeIteratorTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/GroupByRecordNameAndTypeIteratorTest.java
@@ -42,11 +42,11 @@ public class GroupByRecordNameAndTypeIteratorTest {
 
     public Iterator<ResourceRecordSet<?>> expected() {
         ImmutableList<ResourceRecordSet<?>> rrsetList = ImmutableList.<ResourceRecordSet<?>>builder()
-                .add(a("www.jclouds.org.", 3600, "1.2.3.4"))
+                .add(a("www.jclouds.org.", 3600, "192.0.2.1"))
                 .add(ns("jclouds.org.", 86400,
                         ImmutableList.of("pdns1.ultradns.net.", "pdns2.ultradns.net.", "pdns3.ultradns.org.", 
                                 "pdns4.ultradns.org.", "pdns5.ultradns.info.", "pdns6.ultradns.co.uk.")))
-                .add(a("jclouds.org.", 3000, "1.2.3.4"))
+                .add(a("jclouds.org.", 3000, "192.0.2.1"))
                 .add(ResourceRecordSet.<SOAData>builder()
                         .name("jclouds.org.")
                         .ttl(3600)
@@ -71,7 +71,7 @@ public class GroupByRecordNameAndTypeIteratorTest {
                   .add(builder.guid("04023A2507B6468F")
                           .created(dateService.iso8601DateParse("2010-10-02T16:57:16.000Z"))
                           .modified(dateService.iso8601DateParse("2011-09-27T23:49:21.000Z"))
-                          .record(rrBuilder().type(1).name("www.jclouds.org.").ttl(3600).rdata("1.2.3.4")).build())
+                          .record(rrBuilder().type(1).name("www.jclouds.org.").ttl(3600).rdata("192.0.2.1")).build())
                   .add(builder.guid("0B0338C2023F7969")
                           .created(dateService.iso8601DateParse("2009-10-12T12:02:23.000Z"))
                           .modified(dateService.iso8601DateParse("2009-10-12T12:02:23.000Z"))
@@ -92,7 +92,7 @@ public class GroupByRecordNameAndTypeIteratorTest {
                   .add(builder.guid("0B0338C2023F796E")
                           .created(dateService.iso8601DateParse("2009-10-12T12:02:23.000Z"))
                           .modified(dateService.iso8601DateParse("2011-09-27T23:49:22.000Z"))
-                          .record(rrBuilder().type(1).name("jclouds.org.").ttl(3000).rdata("1.2.3.4")).build())
+                          .record(rrBuilder().type(1).name("jclouds.org.").ttl(3000).rdata("192.0.2.1")).build())
                   .add(builder.guid("0B0338C2023F796C")
                           .created(dateService.iso8601DateParse("2009-10-12T12:02:23.000Z"))
                           .modified(dateService.iso8601DateParse("2009-10-12T12:02:23.000Z"))

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSFunctionsTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSFunctionsTest.java
@@ -22,7 +22,7 @@ public class UltraDNSFunctionsTest {
     ResourceRecord a = ResourceRecord.rrBuilder().name("www.foo.com.")
                                                  .type(1)
                                                  .ttl(3600)
-                                                 .rdata("1.1.1.1").build();
+                                                 .rdata("192.0.2.1").build();
 
     ResourceRecordMetadata aRecord = ResourceRecordMetadata.builder()
                                                            .guid("AAAAAAAAAAAA")
@@ -39,8 +39,8 @@ public class UltraDNSFunctionsTest {
     @DataProvider(name = "records")
     public Object[][] createData() {
         Object[][] data = new Object[3][2];
-        data[0][0] = rrBuilder().name("foo.com.").ttl(3600).type(1).rdata("1.1.1.1").build();
-        data[0][1] = AData.create("1.1.1.1");
+        data[0][0] = rrBuilder().name("foo.com.").ttl(3600).type(1).rdata("192.0.2.1").build();
+        data[0][1] = AData.create("192.0.2.1");
         data[1][0] = rrBuilder().name("foo.com.").ttl(3600).type(28).rdata("2001:0DB8:85A3:0000:0000:8A2E:0370:7334").build();
         data[1][1] = AAAAData.create("2001:0DB8:85A3:0000:0000:8A2E:0370:7334");
         data[2][0] = rrBuilder().name("foo.com.").ttl(3600).type(5).rdata("www.foo.com.").build();

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSPredicatesTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSPredicatesTest.java
@@ -18,7 +18,7 @@ public class UltraDNSPredicatesTest {
     ResourceRecord a = ResourceRecord.rrBuilder().name("www.foo.com.")
                                                  .type(1)
                                                  .ttl(3600)
-                                                 .rdata("1.1.1.1").build();
+                                                 .rdata("192.0.2.1").build();
 
     ResourceRecordMetadata aRecord = ResourceRecordMetadata.builder()
                                                            .guid("AAAAAAAAAAAA")

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSResourceRecordSetApiMockTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSResourceRecordSetApiMockTest.java
@@ -79,8 +79,8 @@ public class UltraDNSResourceRecordSetApiMockTest {
     private String aRecordTTLGuidAddressTemplate = "<ns2:ResourceRecord ZoneName=\"foo.com.\" Type=\"1\" DName=\"www.foo.com.\" TTL=\"%d\" Guid=\"%s\" ZoneId=\"0000000000000001\" LName=\"www.foo.com.\" Created=\"2009-10-12T12:02:23.000Z\" Modified=\"2011-09-27T23:49:22.000Z\"><ns2:InfoValues Info1Value=\"%s\"/></ns2:ResourceRecord>";
 
     private String records1And2 = new StringBuilder(getResourceRecordsOfZoneResponseHeader)
-            .append(format(aRecordTTLGuidAddressTemplate, 3600, "AAAAAAAAAAAA", "1.2.3.4"))
-            .append(format(aRecordTTLGuidAddressTemplate, 3600, "BBBBBBBBBBBB", "5.6.7.8"))
+            .append(format(aRecordTTLGuidAddressTemplate, 3600, "AAAAAAAAAAAA", "192.0.2.1"))
+            .append(format(aRecordTTLGuidAddressTemplate, 3600, "BBBBBBBBBBBB", "198.51.100.1"))
             .append(getResourceRecordsOfZoneResponseFooter).toString();
 
     @Test
@@ -92,7 +92,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
         try {
             UltraDNSResourceRecordSetApi api = mockUltraDNSResourceRecordSetApi(server);
             assertEquals(api.listByName("www.foo.com.").next(),
-                    a("www.foo.com.", 3600, ImmutableList.of("1.2.3.4", "5.6.7.8")));
+                    a("www.foo.com.", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
         } finally {
             RecordedRequest getResourceRecordsOfZone = server.takeRequest();
             assertEquals(getResourceRecordsOfZone.getRequestLine(), "POST / HTTP/1.1");
@@ -129,7 +129,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
         try {
             UltraDNSResourceRecordSetApi api = mockUltraDNSResourceRecordSetApi(server);
             assertEquals(api.getByNameAndType("www.foo.com.", "A").get(),
-                    a("www.foo.com.", 3600, ImmutableList.of("1.2.3.4", "5.6.7.8")));
+                    a("www.foo.com.", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
         } finally {
             RecordedRequest getResourceRecordsOfZone = server.takeRequest();
             assertEquals(getResourceRecordsOfZone.getRequestLine(), "POST / HTTP/1.1");
@@ -166,7 +166,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
 
         try {
             UltraDNSResourceRecordSetApi api = mockUltraDNSResourceRecordSetApi(server);
-            api.add(a("www.foo.com.", 3600, "1.2.3.4"));
+            api.add(a("www.foo.com.", 3600, "192.0.2.1"));
         } finally {
             RecordedRequest getResourceRecordsOfZone = server.takeRequest();
             assertEquals(getResourceRecordsOfZone.getRequestLine(), "POST / HTTP/1.1");
@@ -183,7 +183,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
             RecordedRequest addRecord1 = server.takeRequest();
             assertEquals(addRecord1.getRequestLine(), "POST / HTTP/1.1");
             assertEquals(new String(addRecord1.getBody()),
-                    format(addRecordToRRPoolTemplate, "POOLA", "1.2.3.4", "1", 3600));
+                    format(addRecordToRRPoolTemplate, "POOLA", "192.0.2.1", "1", 3600));
 
             server.shutdown();
         }
@@ -206,7 +206,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
 
         try {
             UltraDNSResourceRecordSetApi api = mockUltraDNSResourceRecordSetApi(server);
-            api.add(a("www.foo.com.", 3600, "1.2.3.4"));
+            api.add(a("www.foo.com.", 3600, "192.0.2.1"));
         } finally {
             RecordedRequest getResourceRecordsOfZone = server.takeRequest();
             assertEquals(getResourceRecordsOfZone.getRequestLine(), "POST / HTTP/1.1");
@@ -219,14 +219,14 @@ public class UltraDNSResourceRecordSetApiMockTest {
             RecordedRequest addRecord1 = server.takeRequest();
             assertEquals(addRecord1.getRequestLine(), "POST / HTTP/1.1");
             assertEquals(new String(addRecord1.getBody()),
-                    format(addRecordToRRPoolTemplate, "POOLA", "1.2.3.4", "1", 3600));
+                    format(addRecordToRRPoolTemplate, "POOLA", "192.0.2.1", "1", 3600));
 
             server.shutdown();
         }
     }
 
     private String record1 = new StringBuilder(getResourceRecordsOfZoneResponseHeader)
-            .append(format(aRecordTTLGuidAddressTemplate, 3600, "AAAAAAAAAAAA", "1.2.3.4"))
+            .append(format(aRecordTTLGuidAddressTemplate, 3600, "AAAAAAAAAAAA", "192.0.2.1"))
             .append(getResourceRecordsOfZoneResponseFooter).toString();
 
     private String getRRPoolRecordsTemplate = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:v01=\"http://webservice.api.ultra.neustar.com/v01/\"><soapenv:Header><wsse:Security soapenv:mustUnderstand=\"1\" xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:UsernameToken><wsse:Username>joe</wsse:Username><wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">letmein</wsse:Password></wsse:UsernameToken></wsse:Security></soapenv:Header><soapenv:Body><v01:getRRPoolRecords><lbPoolId>%s</lbPoolId></v01:getRRPoolRecords></soapenv:Body></soapenv:Envelope>";
@@ -235,7 +235,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
     private String getRRPoolRecordsResponseFooter = "</ResourceRecordList></ns1:getRRPoolRecordsResponse></soap:Body></soap:Envelope>";
 
     private String pooledRecord1 = new StringBuilder(getRRPoolRecordsResponseHeader)
-            .append(format(aRecordTTLGuidAddressTemplate, 3600, "AAAAAAAAAAAA", "1.2.3.4"))
+            .append(format(aRecordTTLGuidAddressTemplate, 3600, "AAAAAAAAAAAA", "192.0.2.1"))
             .append(getRRPoolRecordsResponseFooter).toString();
 
     private String deleteRecordOfRRPoolTemplate = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:v01=\"http://webservice.api.ultra.neustar.com/v01/\"><soapenv:Header><wsse:Security soapenv:mustUnderstand=\"1\" xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:UsernameToken><wsse:Username>joe</wsse:Username><wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">letmein</wsse:Password></wsse:UsernameToken></wsse:Security></soapenv:Header><soapenv:Body><v01:deleteRecordOfRRPool><transactionID /><guid>%s</guid></v01:deleteRecordOfRRPool></soapenv:Body></soapenv:Envelope>";
@@ -257,7 +257,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
 
         try {
             UltraDNSResourceRecordSetApi api = mockUltraDNSResourceRecordSetApi(server);
-            api.remove(a("www.foo.com.", "1.2.3.4"));
+            api.remove(a("www.foo.com.", "192.0.2.1"));
         } finally {
             RecordedRequest getResourceRecordsOfZone = server.takeRequest();
             assertEquals(getResourceRecordsOfZone.getRequestLine(), "POST / HTTP/1.1");
@@ -298,7 +298,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
 
         try {
             UltraDNSResourceRecordSetApi api = mockUltraDNSResourceRecordSetApi(server);
-            api.add(a("www.foo.com.", "5.6.7.8"));
+            api.add(a("www.foo.com.", "198.51.100.1"));
         } finally {
             RecordedRequest getResourceRecordsOfZone = server.takeRequest();
             assertEquals(getResourceRecordsOfZone.getRequestLine(), "POST / HTTP/1.1");
@@ -311,7 +311,7 @@ public class UltraDNSResourceRecordSetApiMockTest {
             RecordedRequest addRecord2 = server.takeRequest();
             assertEquals(addRecord2.getRequestLine(), "POST / HTTP/1.1");
             assertEquals(new String(addRecord2.getBody()),
-                    format(addRecordToRRPoolTemplate, "POOLA", "5.6.7.8", "1", 3600));
+                    format(addRecordToRRPoolTemplate, "POOLA", "198.51.100.1", "1", 3600));
 
             server.shutdown();
         }


### PR DESCRIPTION
RFC5735 defines several ranges of special-use IPv4 addresses, including 3
intended for documentation, examples and testing. Using these IP addresses avoids
copy and paste leaks resulting in errant/nuisance traffic to the unfortunate assignees
of addresses such as 1.2.3.4. Likewise, RFC5156 defines similar ranges for IPv6
addresses.

This change modifies the test-cases, mock-providers and documentation to use
addresses from the TEST-NET ranges. For IPv4, CIDR semantics have been
preserved and the replacement IPs differ in the same levels of specificity
as the original IPs used. For IPv6, all addresses have been updated to
reside in the 2001:db8/32 range.

The EC2 DataFromInstanceMetadataHookTest still contains actual EC2 addresses,
as I'm unsure of the effect of a change here.

All tests pass, and this change contains no functional changes.
