### PR TITLE
The Rackspace Cloud DNS provider for Denominator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,9 @@ Thumbs.db
 
 # Build output directies
 /target
-*/test-output
-*/target
-*/bin
+**/test-output
+**/target
+**/bin
 build
 */build
 .m2

--- a/denominator-cli/build.gradle
+++ b/denominator-cli/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   compile      project(':providers:denominator-dynect')
   compile      project(':providers:denominator-ultradns')
   compile      project(':providers:denominator-route53')
+  compile      project(':providers:denominator-clouddns')
   // to quiet error messages, not as we are using it
   compile     'org.slf4j:slf4j-jdk14:1.7.2'
   compile     'io.airlift:airline:0.5'

--- a/providers/denominator-clouddns/build.gradle
+++ b/providers/denominator-clouddns/build.gradle
@@ -1,0 +1,26 @@
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
+
+eclipse {
+  classpath {
+    downloadSources = true
+    downloadJavadoc = true
+  }
+}
+
+test {
+  systemProperty 'clouddns.username', System.getProperty('clouddns.username', '')
+  systemProperty 'clouddns.apiKey', System.getProperty('clouddns.apiKey', '')
+  systemProperty 'clouddns.zone', System.getProperty('clouddns.zone', '')
+}
+
+dependencies {
+  compile      project(':denominator-core')
+  testCompile  project(':denominator-core').sourceSets.test.output
+  compile     'org.jclouds.labs:rackspace-clouddns-us:1.6.0-rc.5'
+  compile     'org.jclouds.labs:rackspace-clouddns-uk:1.6.0-rc.5'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.5'
+}

--- a/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
+++ b/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
@@ -1,0 +1,81 @@
+package denominator.clouddns;
+
+import static com.google.common.base.Suppliers.compose;
+
+import java.io.Closeable;
+import java.util.List;
+
+import javax.inject.Singleton;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.domain.Credentials;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import org.jclouds.rackspace.clouddns.v1.CloudDNSApi;
+import org.jclouds.rackspace.clouddns.v1.CloudDNSApiMetadata;
+
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+
+import dagger.Module;
+import dagger.Provides;
+import denominator.CredentialsConfiguration.CredentialsAsList;
+import denominator.DNSApiManager;
+import denominator.Provider;
+import denominator.ResourceRecordSetApi;
+import denominator.ZoneApi;
+
+@Module(entryPoints = DNSApiManager.class)
+public class CloudDNSProvider extends Provider {
+
+    @Provides
+    protected Provider provideThis() {
+        return this;
+    }
+
+    @Provides
+    @Singleton
+    Supplier<Credentials> toJcloudsCredentials(CredentialsAsList supplier) {
+        return compose(new ToJcloudsCredentials(), supplier);
+    }
+
+    @Override
+    public Multimap<String, String> getCredentialTypeToParameterNames() {
+        return ImmutableMultimap.<String, String> builder().putAll("apiKey", "username", "apiKey").build();
+    }
+
+    private static class ToJcloudsCredentials implements Function<List<Object>, Credentials> {
+        public Credentials apply(List<Object> creds) {
+            return new Credentials(creds.get(0).toString(), creds.get(1).toString());
+        }
+    }
+
+    @Provides
+    @Singleton
+    ZoneApi provideZoneApi(CloudDNSApi api) {
+        return new CloudDNSZoneApi(api);
+    }
+
+    @Provides
+    @Singleton
+    ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(CloudDNSApi api) {
+        return new CloudDNSResourceRecordSetApi.Factory(api);
+    }
+
+    @Provides
+    @Singleton
+    CloudDNSApi provideCloudDNSApi(Supplier<Credentials> credentials) {
+        return ContextBuilder.newBuilder(new CloudDNSApiMetadata())
+                .credentialsSupplier(credentials)
+                .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule()))
+                .buildApi(CloudDNSApi.class);
+    }
+
+    @Provides
+    @Singleton
+    Closeable provideCloseable(CloudDNSApi api) {
+        return api;
+    }
+}

--- a/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSResourceRecordSetApi.java
+++ b/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSResourceRecordSetApi.java
@@ -1,0 +1,105 @@
+package denominator.clouddns;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static denominator.model.ResourceRecordSets.nameEqualTo;
+
+import java.util.Iterator;
+
+import javax.inject.Inject;
+
+import org.jclouds.rackspace.clouddns.v1.CloudDNSApi;
+import org.jclouds.rackspace.clouddns.v1.domain.Domain;
+import org.jclouds.rackspace.clouddns.v1.features.RecordApi;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterators;
+
+import denominator.ResourceRecordSetApi;
+import denominator.model.ResourceRecordSet;
+
+public final class CloudDNSResourceRecordSetApi implements denominator.ResourceRecordSetApi {
+
+    private final RecordApi api;
+
+    CloudDNSResourceRecordSetApi(RecordApi recordApi) {
+        this.api = recordApi;
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> list() {
+        // assumes these are sorted, which might be bad
+        return new GroupByRecordNameAndTypeIterator(api.list().concat().iterator());
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> listByName(String name) {
+        checkNotNull(name, "name was null");
+        return Iterators.filter(list(), nameEqualTo(name));
+    }
+
+    @Override
+    public Optional<ResourceRecordSet<?>> getByNameAndType(String name, String type) {
+        checkNotNull(name, "name was null");
+        checkNotNull(type, "type was null");
+        GroupByRecordNameAndTypeIterator it = new GroupByRecordNameAndTypeIterator(api.listByNameAndType(name, type)
+                .concat().iterator());
+        return it.hasNext() ? Optional.<ResourceRecordSet<?>> of(it.next()) : Optional.<ResourceRecordSet<?>> absent();
+    }
+
+    static final class Factory implements denominator.ResourceRecordSetApi.Factory {
+
+        private final CloudDNSApi api;
+
+        @Inject
+        Factory(CloudDNSApi api) {
+            this.api = api;
+        }
+
+        @Override
+        public ResourceRecordSetApi create(final String domainName) {
+            Optional<Domain> domain = api.getDomainApi().list().concat().firstMatch(domainNameEquals(domainName));
+            checkArgument(domain.isPresent(), "domain %s not found", domainName);
+            return new CloudDNSResourceRecordSetApi(api.getRecordApiForDomain(domain.get().getId()));
+        }
+    }
+
+    /**
+     * Rackspace domains are addressed by id, not by name.
+     */
+    private static final Predicate<Domain> domainNameEquals(final String domainName) {
+        checkNotNull(domainName, "domainName");
+        return new Predicate<Domain>() {
+            @Override
+            public boolean apply(Domain input) {
+                return input.getName().equals(domainName);
+            }
+        };
+    }
+
+    @Override
+    public void add(ResourceRecordSet<?> rrset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void applyTTLToNameAndType(int ttl, String name, String type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void replace(ResourceRecordSet<?> rrset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void remove(ResourceRecordSet<?> rrset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteByNameAndType(String name, String type) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSZoneApi.java
+++ b/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSZoneApi.java
@@ -1,0 +1,30 @@
+package denominator.clouddns;
+
+import java.util.Iterator;
+
+import javax.inject.Inject;
+
+import org.jclouds.rackspace.clouddns.v1.CloudDNSApi;
+import org.jclouds.rackspace.clouddns.v1.domain.Domain;
+
+import com.google.common.base.Function;
+
+public final class CloudDNSZoneApi implements denominator.ZoneApi {
+    private final CloudDNSApi api;
+
+    @Inject
+    CloudDNSZoneApi(CloudDNSApi api) {
+        this.api = api;
+    }
+
+    public Iterator<String> list() {
+        return api.getDomainApi().list().concat().transform(DomainName.INSTANCE).iterator();
+    }
+
+    private static enum DomainName implements Function<Domain, String> {
+        INSTANCE;
+        public String apply(Domain input) {
+            return input.getName();
+        }
+    }
+}

--- a/providers/denominator-clouddns/src/main/java/denominator/clouddns/GroupByRecordNameAndTypeIterator.java
+++ b/providers/denominator-clouddns/src/main/java/denominator/clouddns/GroupByRecordNameAndTypeIterator.java
@@ -1,0 +1,105 @@
+package denominator.clouddns;
+
+import static com.google.common.collect.Iterators.peekingIterator;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.jclouds.rackspace.clouddns.v1.domain.Record;
+import org.jclouds.rackspace.clouddns.v1.domain.RecordDetail;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.PeekingIterator;
+
+import denominator.model.ResourceRecordSet;
+import denominator.model.ResourceRecordSet.Builder;
+import denominator.model.rdata.AAAAData;
+import denominator.model.rdata.AData;
+import denominator.model.rdata.CNAMEData;
+import denominator.model.rdata.MXData;
+import denominator.model.rdata.NSData;
+import denominator.model.rdata.PTRData;
+import denominator.model.rdata.SRVData;
+import denominator.model.rdata.TXTData;
+
+class GroupByRecordNameAndTypeIterator implements Iterator<ResourceRecordSet<?>> {
+
+    private final PeekingIterator<RecordDetail> peekingIterator;
+
+    public GroupByRecordNameAndTypeIterator(Iterator<RecordDetail> sortedIterator) {
+        this.peekingIterator = peekingIterator(sortedIterator);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return peekingIterator.hasNext();
+    }
+
+    @Override
+    public ResourceRecordSet<?> next() {
+        RecordDetail recordDetail = peekingIterator.next();
+        // it is possible that the record was deleted between the list and the get
+        if (recordDetail == null)
+            return null;
+
+        Builder<Map<String, Object>> builder = ResourceRecordSet.builder()
+                                                                .name(recordDetail.getName())
+                                                                .type(recordDetail.getType())
+                                                                .ttl(recordDetail.getTTL())
+                                                                .add(toRData(recordDetail.getRecord()));
+        while (hasNext()) {
+            RecordDetail next = peekingIterator.peek();
+            if (next == null)
+                continue;
+            if (nameAndTypeEquals(next, recordDetail)) {
+                builder.add(toRData(peekingIterator.next().getRecord()));
+            } else {
+                break;
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static boolean nameAndTypeEquals(RecordDetail actual, RecordDetail expected) {
+        return actual.getName().equals(expected.getName()) && actual.getType().equals(expected.getType());
+    }
+
+    static Map<String, Object> toRData(Record record) {
+        if ("A".equals(record.getType())) {
+            return AData.create(record.getData());
+        } else if ("AAAA".equals(record.getType())) {
+            return AAAAData.create(record.getData());
+        } else if ("CNAME".equals(record.getType())) {
+            return CNAMEData.create(record.getData());
+        } else if ("MX".equals(record.getType())) {
+            return MXData.create(record.getPriority(), record.getData());
+        } else if ("NS".equals(record.getType())) {
+            return NSData.create(record.getData());
+        } else if ("PTR".equals(record.getType())) {
+            return PTRData.create(record.getData());
+        } else if ("SRV".equals(record.getType())) {
+            ImmutableList<String> parts = split(record.getData());
+            
+            return SRVData.builder()
+                          .priority(record.getPriority())
+                          .weight(Integer.valueOf(parts.get(0)))
+                          .port(Integer.valueOf(parts.get(1)))
+                          .target(parts.get(2)).build();
+        } else if ("TXT".equals(record.getType())) {
+            return TXTData.create(record.getData());
+        } else {
+            return ImmutableMap.<String, Object> of("rdata", record.getData());
+        }
+    }
+
+    private static ImmutableList<String> split(String rdata) {
+        return ImmutableList.copyOf(Splitter.on(' ').split(rdata));
+    }
+}

--- a/providers/denominator-clouddns/src/main/resources/META-INF/services/denominator.Provider
+++ b/providers/denominator-clouddns/src/main/resources/META-INF/services/denominator.Provider
@@ -1,0 +1,1 @@
+denominator.clouddns.CloudDNSProvider

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSConnection.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSConnection.java
@@ -1,0 +1,25 @@
+package denominator.clouddns;
+
+
+import static com.google.common.base.Strings.emptyToNull;
+import static denominator.CredentialsConfiguration.credentials;
+import static java.lang.System.getProperty;
+import denominator.DNSApiManager;
+import denominator.Denominator;
+
+public class CloudDNSConnection {
+
+    final DNSApiManager manager;
+    final String mutableZone;
+
+    CloudDNSConnection() {
+        String username = emptyToNull(getProperty("clouddns.username"));
+        String apiKey = emptyToNull(getProperty("clouddns.apiKey"));
+        if (username != null && apiKey != null) {
+            manager = Denominator.create(new CloudDNSProvider(), credentials(username, apiKey));
+        } else {
+            manager = null;
+        }
+        mutableZone = emptyToNull(getProperty("clouddns.zone"));
+    }
+}

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
@@ -1,0 +1,49 @@
+package denominator.clouddns;
+
+import static denominator.CredentialsConfiguration.credentials;
+import static denominator.Denominator.create;
+import static denominator.Denominator.listProviders;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+import denominator.DNSApiManager;
+import denominator.Provider;
+import denominator.clouddns.CloudDNSProvider;
+import denominator.clouddns.CloudDNSZoneApi;
+
+public class CloudDNSProviderTest {
+    private static final Provider PROVIDER = new CloudDNSProvider();
+
+    @Test
+    public void testMockMetadata() {
+        assertEquals(PROVIDER.getName(), "clouddns");
+        assertEquals(PROVIDER.getCredentialTypeToParameterNames(), ImmutableMultimap.<String, String> builder()
+                .putAll("apiKey", "username", "apiKey").build());
+    }
+
+    @Test
+    public void testCloudDNSRegistered() {
+        Set<Provider> allProviders = ImmutableSet.copyOf(listProviders());
+        assertTrue(allProviders.contains(PROVIDER));
+    }
+
+    @Test
+    public void testProviderWiresCloudDNSZoneApi() {
+        DNSApiManager manager = create(PROVIDER, credentials("username", "apiKey"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), CloudDNSZoneApi.class);
+        manager = create("clouddns", credentials("username", "apiKey"));
+        assertEquals(manager.getApi().getZoneApi().getClass(), CloudDNSZoneApi.class);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "no credentials supplied. clouddns requires username, apiKey")
+    public void testCredentialsRequired() {
+        create(PROVIDER).getApi().getZoneApi().list();
+    }
+}

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSReadOnlyLiveTest.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSReadOnlyLiveTest.java
@@ -1,0 +1,14 @@
+package denominator.clouddns;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseReadOnlyLiveTest;
+
+@Test
+public class CloudDNSReadOnlyLiveTest extends BaseReadOnlyLiveTest {
+    @BeforeClass
+    private void setUp() {
+        manager = new CloudDNSConnection().manager;
+    }
+}

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
@@ -1,0 +1,184 @@
+package denominator.clouddns;
+
+import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
+import static denominator.model.ResourceRecordSets.a;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.jclouds.Constants.PROPERTY_MAX_RETRIES;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.concurrent.config.ExecutorServiceModule;
+import org.jclouds.rackspace.clouddns.us.CloudDNSUSProviderMetadata;
+import org.jclouds.rackspace.clouddns.v1.CloudDNSApi;
+import org.jclouds.rackspace.clouddns.v1.features.RecordApi;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+import com.google.mockwebserver.QueueDispatcher;
+import com.google.mockwebserver.RecordedRequest;
+
+import denominator.model.ResourceRecordSet;
+
+@Test(singleThreaded = true)
+public class CloudDNSResourceRecordSetApiMockTest {
+    static Set<Module> modules = ImmutableSet.<Module> of(new ExecutorServiceModule(sameThreadExecutor(),
+            sameThreadExecutor()));
+
+    static RecordApi mockCloudDNSApi(String uri, int domainId) {
+        Properties overrides = new Properties();
+        overrides.setProperty(PROPERTY_MAX_RETRIES, "1");
+        
+        CloudDNSApi cloudDNSApi = ContextBuilder.newBuilder(new CloudDNSUSProviderMetadata())
+                .credentials("jclouds-joe", "letmein")
+                .modules(modules)
+                .endpoint(uri)
+                .overrides(overrides)
+        		.buildApi(CloudDNSApi.class);
+        
+        return cloudDNSApi.getRecordApiForDomain(domainId);
+    }
+
+    String session = "{\"access\":{\"token\":{\"id\":\"b84f4a37-5126-4603-9521-ccd0665fbde1\",\"expires\":\"2013-04-13T16:49:57.000-05:00\",\"tenant\":{\"id\":\"123123\",\"name\":\"123123\"}},\"serviceCatalog\":[{\"endpoints\":[{\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\"}],\"name\":\"cloudMonitoring\",\"type\":\"rax:monitor\"},{\"endpoints\":[{\"region\":\"DFW\",\"tenantId\":\"MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\",\"publicURL\":\"URL/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\"},{\"region\":\"ORD\",\"tenantId\":\"MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\",\"publicURL\":\"URL/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\"}],\"name\":\"cloudFilesCDN\",\"type\":\"rax:object-cdn\"},{\"endpoints\":[{\"region\":\"ORD\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\"},{\"region\":\"DFW\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\"}],\"name\":\"cloudLoadBalancers\",\"type\":\"rax:load-balancer\"},{\"endpoints\":[{\"region\":\"DFW\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\"},{\"region\":\"ORD\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\"}],\"name\":\"cloudDatabases\",\"type\":\"rax:database\"},{\"endpoints\":[{\"region\":\"DFW\",\"tenantId\":\"MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\",\"publicURL\":\"URL/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\",\"internalURL\":\"URL/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\"},{\"region\":\"ORD\",\"tenantId\":\"MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\",\"publicURL\":\"URL/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\",\"internalURL\":\"URL/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9\"}],\"name\":\"cloudFiles\",\"type\":\"object-store\"},{\"endpoints\":[{\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\",\"versionInfo\":\"URL/v1.0\",\"versionList\":\"URL/\",\"versionId\":\"1.0\"}],\"name\":\"cloudServers\",\"type\":\"compute\"},{\"endpoints\":[{\"region\":\"DFW\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v2/123123\",\"versionInfo\":\"URL/v2\",\"versionList\":\"URL/\",\"versionId\":\"2\"},{\"region\":\"ORD\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v2/123123\",\"versionInfo\":\"URL/v2\",\"versionList\":\"URL/\",\"versionId\":\"2\"}],\"name\":\"cloudServersOpenStack\",\"type\":\"compute\"},{\"endpoints\":[{\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\"}],\"name\":\"cloudDNS\",\"type\":\"rax:dns\"},{\"endpoints\":[{\"tenantId\":\"123123\",\"publicURL\":\"URL/v1.0/123123\"}],\"name\":\"cloudBackup\",\"type\":\"rax:backup\"},{\"endpoints\":[{\"region\":\"DFW\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v1/123123\"},{\"region\":\"ORD\",\"tenantId\":\"123123\",\"publicURL\":\"URL/v1/123123\"}],\"name\":\"cloudBlockStorage\",\"type\":\"volume\"}],\"user\":{\"id\":\"1234\",\"roles\":[{\"id\":\"3\",\"description\":\"User Admin Role.\",\"name\":\"identity:user-admin\"}],\"name\":\"jclouds-joe\",\"RAX-AUTH:defaultRegion\":\"DFW\"}}}";
+    String recordsByName = "{\"records\":[{\"name\":\"www.foo.com\",\"id\":\"A-9872761\",\"type\":\"A\",\"data\":\"1.2.3.4\",\"ttl\":600000,\"updated\":\"2013-04-13T14:42:00.000+0000\",\"created\":\"2013-04-13T14:42:00.000+0000\"},{\"name\":\"www.foo.com\",\"id\":\"NS-8703385\",\"type\":\"NS\",\"data\":\"dns1.stabletransit.com\",\"ttl\":600000,\"updated\":\"2013-04-13T14:42:00.000+0000\",\"created\":\"2013-04-13T14:42:00.000+0000\"},{\"name\":\"www.foo.com\",\"id\":\"NS-8703386\",\"type\":\"NS\",\"data\":\"dns2.stabletransit.com\",\"ttl\":600000,\"updated\":\"2013-04-13T14:42:00.000+0000\",\"created\":\"2013-04-13T14:42:00.000+0000\"}],\"totalEntries\":3}";
+
+    @Test
+    public void listByNameWhenPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("/");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(recordsByName));
+
+        try {
+            CloudDNSResourceRecordSetApi api = new CloudDNSResourceRecordSetApi(mockCloudDNSApi(url.toString(), 1234));
+            
+            Iterator<ResourceRecordSet<?>> records = api.listByName("www.foo.com");
+            
+            while (records.hasNext()) {
+            	ResourceRecordSet<?> record = records.next();
+            	
+            	assertEquals(record.getName(), "www.foo.com");
+            	assertEquals(record.getTTL().get().intValue(), 600000);
+            }
+
+            assertEquals(server.takeRequest().getRequestLine(), "POST /tokens HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(), "GET /domains/1234/records HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void listByNameWhenAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("/");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(NOT_FOUND.getStatusCode())); // no existing records
+
+        try {
+            CloudDNSResourceRecordSetApi api = new CloudDNSResourceRecordSetApi(mockCloudDNSApi(url.toString(), 1234));
+            
+            assertFalse(api.listByName("www.foo.com").hasNext());
+            assertEquals(server.takeRequest().getRequestLine(), "POST /tokens HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(), "GET /domains/1234/records HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    String recordsByNameAndType = "{\"records\":[{\"name\":\"www.foo.com\",\"id\":\"A-9872761\",\"type\":\"A\",\"data\":\"1.2.3.4\",\"ttl\":600000,\"updated\":\"2013-04-13T14:42:00.000+0000\",\"created\":\"2013-04-13T14:42:00.000+0000\"},{\"name\":\"www.foo.com\",\"id\":\"A-9883329\",\"type\":\"A\",\"data\":\"5.6.7.8\",\"ttl\":600000,\"updated\":\"2013-04-16T22:09:09.000+0000\",\"created\":\"2013-04-16T22:09:09.000+0000\"}]}";
+
+    @Test
+    public void getByNameAndTypeWhenPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("/");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(recordsByNameAndType));
+
+        try {
+            CloudDNSResourceRecordSetApi api = new CloudDNSResourceRecordSetApi(mockCloudDNSApi(url.toString(), 1234));
+            
+            assertEquals(api.getByNameAndType("www.foo.com", "A").get(),
+                    a("www.foo.com", 600000, ImmutableList.of("1.2.3.4", "5.6.7.8")));
+            assertEquals(server.takeRequest().getRequestLine(), "POST /tokens HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(), "GET /domains/1234/records?name=www.foo.com&type=A HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void getByNameAndTypeWhenAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("/");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(session));
+        server.enqueue(new MockResponse().setResponseCode(NOT_FOUND.getStatusCode())); // no existing records
+        
+        try {
+            CloudDNSResourceRecordSetApi api = new CloudDNSResourceRecordSetApi(mockCloudDNSApi(url.toString(), 1234));
+            
+            assertEquals(api.getByNameAndType("www.foo.com", "A"), Optional.absent());
+            assertEquals(server.takeRequest().getRequestLine(), "POST /tokens HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(), "GET /domains/1234/records?name=www.foo.com&type=A HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    /**
+     * there's no built-in way to defer evaluation of a response header, hence this
+     * method, which allows us to send back links to the mock server.
+     */
+    private QueueDispatcher getURLReplacingQueueDispatcher(final URL url) {
+       final QueueDispatcher dispatcher = new QueueDispatcher() {
+          protected final BlockingQueue<MockResponse> responseQueue = new LinkedBlockingQueue<MockResponse>();
+
+          @Override
+          public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+             MockResponse response = responseQueue.take();
+             if (response.getBody() != null) {
+                String newBody = new String(response.getBody()).replace("URL", url.toString());
+                response = response.setBody(newBody);
+             }
+             return response;
+          }
+
+          @Override
+          public void enqueueResponse(MockResponse response) {
+             responseQueue.add(response);
+          }
+       };
+
+       return dispatcher;
+    }
+ }

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/ToRDataTest.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/ToRDataTest.java
@@ -1,0 +1,36 @@
+package denominator.clouddns;
+
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.rackspace.clouddns.v1.domain.Record;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+@Test
+public class ToRDataTest {
+
+    public void transformsNSRecordSet() {
+        Record input = Record.builder()
+                .name("denominator.io")
+                .type("NS")
+                .ttl(3600)
+                .data("dns1.stabletransit.com")                
+                .build();
+
+        assertEquals(GroupByRecordNameAndTypeIterator.toRData(input), ImmutableMap.<String, String> of(
+        		"nsdname", "dns1.stabletransit.com"));
+    }
+
+    public void transformsTXTRecordSet() {
+        Record input = Record.builder()
+                .name("denominator.io")
+                .type("TXT")
+                .ttl(3600)
+                .data("Hello DNS")                
+                .build();
+
+        assertEquals(GroupByRecordNameAndTypeIterator.toRData(input), ImmutableMap.<String, String> of(
+        		"txtdata", "Hello DNS"));
+    }
+}

--- a/providers/denominator-clouddns/src/test/resources/logback.xml
+++ b/providers/denominator-clouddns/src/test/resources/logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/denominator.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/http-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+    
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="denominator">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,4 +4,5 @@ include 'denominator-model', \
 'providers:denominator-route53', \
 'providers:denominator-ultradns', \
 'providers:denominator-dynect', \
+'providers:denominator-clouddns', \
 'denominator-cli'


### PR DESCRIPTION
Here's initial support of the Rackspace Cloud DNS provider for Denominator. It's pretty much read only at this point but I wanted to get feedback before going any further.

Right now it's working with org.jclouds.labs:rackspace-clouddns-us:1.7.0-SNAPSHOT ( there is no 1.6.0-SNAPSHOT, see https://oss.sonatype.org/content/repositories/snapshots/org/jclouds/labs/rackspace-clouddns/ ) but when jclouds-1.6.0-rc.5 is out, I'll test it against that. Eventually it will depend on jclouds-1.6.0.

Let me know what you think.
