### PR TITLE
update to jclouds 1.6.0

### DIFF
--- a/providers/denominator-clouddns/build.gradle
+++ b/providers/denominator-clouddns/build.gradle
@@ -20,7 +20,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.labs:rackspace-clouddns-us:1.6.0-rc.5'
-  compile     'org.jclouds.labs:rackspace-clouddns-uk:1.6.0-rc.5'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.5'
+  compile     'org.jclouds.provider:rackspace-clouddns-us:1.6.0'
+  compile     'org.jclouds.provider:rackspace-clouddns-uk:1.6.0'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0'
 }

--- a/providers/denominator-dynect/build.gradle
+++ b/providers/denominator-dynect/build.gradle
@@ -21,7 +21,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:dynect:1.6.0-rc.5'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.5'
+  compile     'org.jclouds.provider:dynect:1.6.0'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0'
 }
 

--- a/providers/denominator-route53/build.gradle
+++ b/providers/denominator-route53/build.gradle
@@ -20,7 +20,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:aws-route53:1.6.0-rc.5'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.5'
+  compile     'org.jclouds.provider:aws-route53:1.6.0'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0'
 }
 

--- a/providers/denominator-ultradns/build.gradle
+++ b/providers/denominator-ultradns/build.gradle
@@ -20,7 +20,7 @@ test {
 dependencies {
   compile      project(':denominator-core')
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:ultradns-ws:1.6.0-rc.5'
-  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0-rc.5'
+  compile     'org.jclouds.provider:ultradns-ws:1.6.0'
+  compile     'org.jclouds.driver:jclouds-slf4j:1.6.0'
 }
 


### PR DESCRIPTION
jclouds 1.6.0 is final; let's move off release candidates.
