### PR TITLE
extract Module from Provider into an interface

### DIFF
--- a/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -32,7 +32,7 @@ public class DenominatorTest {
 
     @Test(description = "denominator -p mock providers")
     public void listsAllProvidersWithCredentials() {
-        ImmutableList<Provider> providers = ImmutableList.of(new MockProvider(), new DynECTProvider(),
+        ImmutableList<Provider> providers = ImmutableList.<Provider> of(new MockProvider(), new DynECTProvider(),
                 new Route53Provider(), new UltraDNSProvider());
         assertEquals(ListProviders.providerAndCredentialsTable(providers), Joiner.on('\n').join(
                 "provider             credential type  credential arguments",

--- a/denominator-core/src/main/java/denominator/BasicProvider.java
+++ b/denominator-core/src/main/java/denominator/BasicProvider.java
@@ -1,0 +1,76 @@
+package denominator;
+
+import static com.google.common.base.Objects.equal;
+import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * base implementation of {@link Provider}, which sets defaults and properly
+ * implements {@code equals} and {@code hashCode}.
+ */
+@Beta
+public abstract class BasicProvider implements Provider {
+
+    // protected to ensure subclassed
+    protected BasicProvider() {
+        checkLowerCamel(getCredentialTypeToParameterNames());
+    }
+
+    /**
+     * if we choose to support numbers, this will need to be updated
+     */
+    private static Pattern lowerCamel = Pattern.compile("^[a-z]+([A-Z][a-z]+)*$");
+
+    private void checkLowerCamel(Multimap<String, String> credentialTypeToParameterNames) {
+        for (Entry<String, String> entry : credentialTypeToParameterNames.entries()) {
+            checkArgument(lowerCamel.matcher(entry.getKey()).matches(),
+                    "please correct credential type %s to lowerCamel case", entry.getKey());
+            checkArgument(lowerCamel.matcher(entry.getValue()).matches(),
+                    "please correct %s credential parameter %s to lowerCamel case", entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName().toLowerCase().replace("provider", "");
+    }
+
+    @Override
+    public Multimap<String, String> getCredentialTypeToParameterNames() {
+        return ImmutableMultimap.of();
+    }
+
+    @Override
+    public Optional<Supplier<Credentials>> defaultCredentialSupplier() {
+        return Optional.absent();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getName());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        return equal(this.getName(), BasicProvider.class.cast(obj).getName());
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this).add("name", getName()).toString();
+    }
+}

--- a/denominator-core/src/main/java/denominator/Denominator.java
+++ b/denominator-core/src/main/java/denominator/Denominator.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList.Builder;
 import dagger.ObjectGraph;
 import denominator.Credentials.AnonymousCredentials;
 import denominator.CredentialsConfiguration.CredentialsSupplier;
-import denominator.mock.MockProvider;
 
 public final class Denominator {
 
@@ -48,7 +47,7 @@ public final class Denominator {
 
     /**
      * creates a new manager for a provider using its type, such as
-     * {@link MockProvider}.
+     * {@link denominator.mock.MockProvider}.
      * 
      * ex.
      * 
@@ -60,7 +59,7 @@ public final class Denominator {
      * @see #listProviders
      */
     public static DNSApiManager create(Provider in, Object... modules) {
-        Builder<Object> modulesForGraph = ImmutableList.builder().add(in);
+        Builder<Object> modulesForGraph = ImmutableList.builder().add(in.module());
         List<Object> inputModules;
         if (modules == null || modules.length == 0) {
             inputModules = ImmutableList.of();

--- a/denominator-core/src/main/java/denominator/Provider.java
+++ b/denominator-core/src/main/java/denominator/Provider.java
@@ -1,106 +1,25 @@
 package denominator;
 
-import static com.google.common.base.Objects.equal;
-import static com.google.common.base.Objects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.lang.reflect.Method;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
-
 import com.google.common.annotations.Beta;
 import com.google.common.base.CaseFormat;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.io.Closer;
 
-import dagger.Module;
 import dagger.Provides;
 
 /**
- * provides components that implement the {@link DNSApi}.
- * 
- * subclass this, and annotate with the following:
- * 
- * {@code  @Module(entryPoints = DNSApiManager.class) }
- * 
- * make sure your subclass has {@link Provides} methods for {@code String} (used
- * for toString), {@link DNSApi} and {@link Closer}
+ * components that all providers of {@link DNSApi} must expose.
  */
 @Beta
-public abstract class Provider {
-
-    // protected to ensure subclassed
-    protected Provider() {
-        checkProvideThis();
-        checkModuleAnnotation();
-        checkLowerCamel(getCredentialTypeToParameterNames());
-    }
-
-    private void checkProvideThis() {
-        Method provideThis;
-        try {
-            provideThis = getClass().getDeclaredMethod("provideThis");
-        } catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
-        } catch (SecurityException e) {
-            throw Throwables.propagate(e);
-        }
-        checkArgument(provideThis.isAnnotationPresent(Provides.class), "add @Provides to %s()", provideThis.getName());
-    }
-
-    private void checkModuleAnnotation() {
-        checkArgument(
-                getClass().isAnnotationPresent(Module.class)
-                        && ImmutableSet.copyOf(getClass().getAnnotation(Module.class).entryPoints()).contains(
-                                DNSApiManager.class), "add @Module(entryPoints = DNSApiManager.class) to %s",
-                getClass().getName());
-    }
-
-    /**
-     * if we choose to support numbers, this will need to be updated
-     */
-    private static Pattern lowerCamel = Pattern.compile("^[a-z]+([A-Z][a-z]+)*$");
-
-    private void checkLowerCamel(Multimap<String, String> credentialTypeToParameterNames) {
-        for (Entry<String, String> entry : credentialTypeToParameterNames.entries()) {
-            checkArgument(lowerCamel.matcher(entry.getKey()).matches(),
-                    "please correct credential type %s to lowerCamel case", entry.getKey());
-            checkArgument(lowerCamel.matcher(entry.getValue()).matches(),
-                    "please correct %s credential parameter %s to lowerCamel case", entry.getKey(), entry.getValue());
-        }
-    }
+public interface Provider {
 
     /**
      * configuration key associated with this {@link DNSApi}. For example,
      * {@code hopper}.
      */
-    public String getName() {
-        return getClass().getSimpleName().toLowerCase().replace("provider", "");
-    }
-
-    /**
-     * binds the current provider, which is useful for injecting its name or
-     * {@link #getCredentialTypeToParameterNames}.
-     * 
-     * <h4>to implement</h4>
-     * 
-     * <pre>
-     * &#064;Provides
-     * protected Provider provideThis() {
-     *     return this;
-     * }
-     * </pre>
-     */
-    @Beta
-    // TODO: see if dagger will support Provides for abstract classes to remove
-    // boilerplate.
-    protected abstract Provider provideThis();
+    String getName();
 
     /**
      * Description of the credential parameters needed for this provider by
@@ -160,34 +79,49 @@ public abstract class Provider {
      * @return credential types to the labels of each part required. An empty
      *         multimap suggests the provider doesn't authenticate.
      */
-    public Multimap<String, String> getCredentialTypeToParameterNames() {
-        return ImmutableMultimap.of();
-    }
+    Multimap<String, String> getCredentialTypeToParameterNames();
     
     /**
      * present when there is a provider-specific means to supply credentials,
      * such as {@code IAM Instance Profile}
      */
-    public Optional<Supplier<Credentials>> defaultCredentialSupplier() {
-        return Optional.absent();
-    }
+    Optional<Supplier<Credentials>> defaultCredentialSupplier();
 
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getName());
-    }
+    
+    /**
+     * how this provider is configured
+     * @see Module
+     */
+    Module module();
+    
+    /**
+     * provides components that implement the {@link DNSApi}.
+     * 
+     * implement this, and annotate with the following:
+     * 
+     * {@code  @dagger.Module(entryPoints = DNSApiManager.class) }
+     * 
+     * make sure your subclass has {@link Provides} methods for {@code String} (used
+     * for toString), {@link DNSApi} and {@link Closer}
+     */
+    @Beta
+    public static interface Module {
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null || getClass() != obj.getClass())
-            return false;
-        return equal(this.getName(), Provider.class.cast(obj).getName());
-    }
-
-    @Override
-    public String toString() {
-        return toStringHelper(this).add("name", getName()).toString();
+        /**
+         * binds the current provider, which is useful for injecting its name or
+         * {@link #getCredentialTypeToParameterNames}.
+         * 
+         * <h4>to implement</h4>
+         * 
+         * <pre>
+         * &#064;Override
+         * &#064;Provides
+         * public Provider provider() {
+         *     return MyProvider.this;
+         * }
+         * </pre>
+         * @see Provides
+         */
+        Provider provider();
     }
 }

--- a/denominator-core/src/test/java/denominator/CredentialsTest.java
+++ b/denominator-core/src/test/java/denominator/CredentialsTest.java
@@ -10,7 +10,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
-import dagger.Module;
 import dagger.Provides;
 import denominator.Credentials.AnonymousCredentials;
 import denominator.Credentials.ListCredentials;
@@ -29,139 +28,178 @@ public class CredentialsTest {
         assertEquals(ListCredentials.from("user", "pass").hashCode(), ListCredentials.from("user", "pass").hashCode());
     }
 
-    @Module(entryPoints = DNSApiManager.class,
-               includes = { NothingToClose.class,
-                            GeoUnsupported.class,
-                            OnlyNormalResourceRecordSets.class } )
-    static final class OptionalProvider extends Provider {
-        @Provides
-        protected Provider provideThis() {
-            return this;
+    static final class OptionalProvider extends BasicProvider {
+
+        @Override
+        public Module module() {
+            return new Module();
         }
 
-        public Multimap<String, String> getCredentialTypeToParameterNames() {
-            return ImmutableMultimap.<String, String> of();
-        }
+        @dagger.Module(entryPoints = DNSApiManager.class,
+                       includes = { NothingToClose.class,
+                                    GeoUnsupported.class,
+                                    OnlyNormalResourceRecordSets.class } )
+        final class Module implements Provider.Module {
 
-        @Provides
-        ZoneApi provideZoneApi(MockZoneApi zoneApi) {
-            return zoneApi;
-        }
-
-        @Provides
-        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
-            return in;
-        }
-
-        // wildcard types are not currently injectable in dagger
-        @SuppressWarnings("rawtypes")
-        @Provides
-        @Singleton
-        Multimap<String, ResourceRecordSet> provideData() {
-            return ImmutableMultimap.of();
+            @Override
+            @Provides
+            public Provider provider() {
+                return OptionalProvider.this;
+            }
+    
+            @Provides
+            ZoneApi provideZoneApi(MockZoneApi zoneApi) {
+                return zoneApi;
+            }
+    
+            @Provides
+            ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
+                return in;
+            }
+    
+            // wildcard types are not currently injectable in dagger
+            @SuppressWarnings("rawtypes")
+            @Provides
+            @Singleton
+            Multimap<String, ResourceRecordSet> provideData() {
+                return ImmutableMultimap.of();
+            }
         }
     }
 
-    @Module(entryPoints = DNSApiManager.class,
-               includes = { NothingToClose.class,
-                            GeoUnsupported.class,
-                            OnlyNormalResourceRecordSets.class } )
-    static final class TwoPartProvider extends Provider {
-        @Provides
-        protected Provider provideThis() {
-            return this;
-        }
+    static final class TwoPartProvider extends BasicProvider {
 
+        @Override
         public Multimap<String, String> getCredentialTypeToParameterNames() {
             return ImmutableMultimap.<String, String> builder()
                     .putAll("password", "username", "password").build();
         }
 
-        @Provides
-        ZoneApi provideZoneApi(MockZoneApi zoneApi) {
-            return zoneApi;
+        @Override
+        public Module module() {
+            return new Module();
         }
 
-        @Provides
-        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
-            return in;
-        }
+        @dagger.Module(entryPoints = DNSApiManager.class,
+                       includes = { NothingToClose.class,
+                                    GeoUnsupported.class,
+                                    OnlyNormalResourceRecordSets.class } )
+        final class Module implements Provider.Module {
 
-        // wildcard types are not currently injectable in dagger
-        @SuppressWarnings("rawtypes")
-        @Provides
-        @Singleton
-        Multimap<String, ResourceRecordSet> provideData() {
-            return ImmutableMultimap.of();
+            @Override
+            @Provides
+            public Provider provider() {
+                return TwoPartProvider.this;
+            }
+    
+            @Provides
+            ZoneApi provideZoneApi(MockZoneApi zoneApi) {
+                return zoneApi;
+            }
+    
+            @Provides
+            ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
+                return in;
+            }
+    
+            // wildcard types are not currently injectable in dagger
+            @SuppressWarnings("rawtypes")
+            @Provides
+            @Singleton
+            Multimap<String, ResourceRecordSet> provideData() {
+                return ImmutableMultimap.of();
+            }
         }
     }
 
-    @Module(entryPoints = DNSApiManager.class,
-               includes = { NothingToClose.class,
-                            GeoUnsupported.class,
-                            OnlyNormalResourceRecordSets.class } )
-    static final class ThreePartProvider extends Provider {
-        @Provides
-        protected Provider provideThis() {
-            return this;
-        }
+    static final class ThreePartProvider extends BasicProvider {
 
+        @Override
         public Multimap<String, String> getCredentialTypeToParameterNames() {
             return ImmutableMultimap.<String, String> builder()
                     .putAll("password", "customer", "username", "password").build();
         }
 
-        @Provides
-        ZoneApi provideZoneApi(MockZoneApi zoneApi) {
-            return zoneApi;
+        @Override
+        public Module module() {
+            return new Module();
         }
 
-        @Provides
-        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
-            return in;
-        }
+        @dagger.Module(entryPoints = DNSApiManager.class,
+                       includes = { NothingToClose.class,
+                                    GeoUnsupported.class,
+                                    OnlyNormalResourceRecordSets.class } )
+        final class Module implements Provider.Module {
 
-        // wildcard types are not currently injectable in dagger
-        @SuppressWarnings("rawtypes")
-        @Provides
-        @Singleton
-        Multimap<String, ResourceRecordSet> provideData() {
-            return ImmutableMultimap.of();
+            @Override
+            @Provides
+            public Provider provider() {
+                return ThreePartProvider.this;
+            }
+    
+            @Provides
+            ZoneApi provideZoneApi(MockZoneApi zoneApi) {
+                return zoneApi;
+            }
+    
+            @Provides
+            ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
+                return in;
+            }
+    
+            // wildcard types are not currently injectable in dagger
+            @SuppressWarnings("rawtypes")
+            @Provides
+            @Singleton
+            Multimap<String, ResourceRecordSet> provideData() {
+                return ImmutableMultimap.of();
+            }
         }
     }
 
-    @Module(entryPoints = DNSApiManager.class,
-               includes = { NothingToClose.class,
-                            GeoUnsupported.class,
-                            OnlyNormalResourceRecordSets.class } )
-    static final class MultiPartProvider extends Provider {
-        @Provides
-        protected Provider provideThis() {
-            return this;
-        }
+    static final class MultiPartProvider extends BasicProvider {
 
+        @Override
         public Multimap<String, String> getCredentialTypeToParameterNames() {
             return ImmutableMultimap.<String, String> builder()
                     .putAll("accessKey", "accessKey", "secretKey")
                     .putAll("session", "accessKey", "secretKey", "sessionToken").build();
         }
 
-        @Provides
-        ZoneApi provideZoneApi(MockZoneApi zoneApi) {
-            return zoneApi;
+        @Override
+        public Module module() {
+            return new Module();
         }
 
-        @Provides
-        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
-            return in;
-        }
-
-        // wildcard types are not currently injectable in dagger
-        @SuppressWarnings("rawtypes")
-        @Provides
-        @Singleton
-        Multimap<String, ResourceRecordSet> provideData() {
-            return ImmutableMultimap.of();
+        @dagger.Module(entryPoints = DNSApiManager.class,
+                       includes = { NothingToClose.class,
+                                    GeoUnsupported.class,
+                                    OnlyNormalResourceRecordSets.class } )
+        final class Module implements Provider.Module {
+    
+            @Override
+            @Provides
+            public Provider provider() {
+                return MultiPartProvider.this;
+            }
+    
+            @Provides
+            ZoneApi provideZoneApi(MockZoneApi zoneApi) {
+                return zoneApi;
+            }
+    
+            @Provides
+            ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(MockResourceRecordSetApi.Factory in) {
+                return in;
+            }
+    
+            // wildcard types are not currently injectable in dagger
+            @SuppressWarnings("rawtypes")
+            @Provides
+            @Singleton
+            Multimap<String, ResourceRecordSet> provideData() {
+                return ImmutableMultimap.of();
+            }
         }
     }
 

--- a/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
+++ b/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
@@ -19,8 +19,8 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
-import dagger.Module;
 import dagger.Provides;
+import denominator.BasicProvider;
 import denominator.CredentialsConfiguration.CredentialsAsList;
 import denominator.DNSApiManager;
 import denominator.Provider;
@@ -28,58 +28,66 @@ import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
 import denominator.config.GeoUnsupported;
 import denominator.config.OnlyNormalResourceRecordSets;
-
-@Module(entryPoints = DNSApiManager.class,
-           includes = { GeoUnsupported.class, 
-                        OnlyNormalResourceRecordSets.class } )
-public class CloudDNSProvider extends Provider {
-
-    @Provides
-    protected Provider provideThis() {
-        return this;
-    }
-
-    @Provides
-    @Singleton
-    Supplier<Credentials> toJcloudsCredentials(CredentialsAsList supplier) {
-        return compose(new ToJcloudsCredentials(), supplier);
-    }
+public class CloudDNSProvider extends BasicProvider {
 
     @Override
     public Multimap<String, String> getCredentialTypeToParameterNames() {
         return ImmutableMultimap.<String, String> builder().putAll("apiKey", "username", "apiKey").build();
     }
 
+    @Override
+    public Module module() {
+        return new Module();
+    }
+
+    @dagger.Module(entryPoints = DNSApiManager.class,
+                   includes = { GeoUnsupported.class, 
+                                OnlyNormalResourceRecordSets.class } )
+    final class Module implements Provider.Module {
+
+        @Override
+        @Provides
+        public Provider provider() {
+            return CloudDNSProvider.this;
+        }
+
+        @Provides
+        @Singleton
+        Supplier<Credentials> toJcloudsCredentials(CredentialsAsList supplier) {
+            return compose(new ToJcloudsCredentials(), supplier);
+        }
+
+        @Provides
+        @Singleton
+        ZoneApi provideZoneApi(CloudDNSApi api) {
+            return new CloudDNSZoneApi(api);
+        }
+
+        @Provides
+        @Singleton
+        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(CloudDNSApi api) {
+            return new CloudDNSResourceRecordSetApi.Factory(api);
+        }
+
+        @Provides
+        @Singleton
+        CloudDNSApi provideCloudDNSApi(Supplier<Credentials> credentials) {
+            return ContextBuilder.newBuilder(new CloudDNSApiMetadata())
+                    .credentialsSupplier(credentials)
+                    .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule()))
+                    .buildApi(CloudDNSApi.class);
+        }
+
+        @Provides
+        @Singleton
+        Closeable provideCloseable(CloudDNSApi api) {
+            return api;
+        }
+    }
+
     private static class ToJcloudsCredentials implements Function<List<Object>, Credentials> {
         public Credentials apply(List<Object> creds) {
             return new Credentials(creds.get(0).toString(), creds.get(1).toString());
         }
-    }
-
-    @Provides
-    @Singleton
-    ZoneApi provideZoneApi(CloudDNSApi api) {
-        return new CloudDNSZoneApi(api);
-    }
-
-    @Provides
-    @Singleton
-    ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(CloudDNSApi api) {
-        return new CloudDNSResourceRecordSetApi.Factory(api);
-    }
-
-    @Provides
-    @Singleton
-    CloudDNSApi provideCloudDNSApi(Supplier<Credentials> credentials) {
-        return ContextBuilder.newBuilder(new CloudDNSApiMetadata())
-                .credentialsSupplier(credentials)
-                .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule()))
-                .buildApi(CloudDNSApi.class);
-    }
-
-    @Provides
-    @Singleton
-    Closeable provideCloseable(CloudDNSApi api) {
-        return api;
     }
 }

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
@@ -21,8 +21,8 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
-import dagger.Module;
 import dagger.Provides;
+import denominator.BasicProvider;
 import denominator.CredentialsConfiguration.CredentialsAsList;
 import denominator.DNSApiManager;
 import denominator.Provider;
@@ -30,74 +30,83 @@ import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
 import denominator.config.ConcatNormalAndGeoResourceRecordSets;
 
-@Module(entryPoints = DNSApiManager.class,
-           includes = { UltraDNSGeoSupport.class,
-                        ConcatNormalAndGeoResourceRecordSets.class })
-public class UltraDNSProvider extends Provider {
-
-    @Provides
-    protected Provider provideThis() {
-        return this;
-    }
-
-    @Provides
-    @Singleton
-    Supplier<Credentials> toJcloudsCredentials(CredentialsAsList supplier) {
-        return compose(new ToJcloudsCredentials(), supplier);
-    }
+public class UltraDNSProvider extends BasicProvider {
 
     @Override
     public Multimap<String, String> getCredentialTypeToParameterNames() {
         return ImmutableMultimap.<String, String> builder().putAll("password", "username", "password").build();
     }
 
+    @Override
+    public Module module() {
+        return new Module();
+    }
+    
+    @dagger.Module(entryPoints = DNSApiManager.class,
+                   includes = { UltraDNSGeoSupport.class,
+                                ConcatNormalAndGeoResourceRecordSets.class })
+    final class Module implements Provider.Module {
+
+        @Override
+        @Provides
+        public Provider provider() {
+            return UltraDNSProvider.this;
+        }
+
+        @Provides
+        @Singleton
+        Supplier<Credentials> toJcloudsCredentials(CredentialsAsList supplier) {
+            return compose(new ToJcloudsCredentials(), supplier);
+        }
+
+        @Provides
+        @Singleton
+        UltraDNSWSApi provideApi(Supplier<Credentials> credentials) {
+            return ContextBuilder.newBuilder(new UltraDNSWSProviderMetadata())
+                                 .credentialsSupplier(credentials)
+                                 .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule()))
+                                 .buildApi(UltraDNSWSApi.class);
+        }
+
+        @Provides
+        @Singleton
+        ZoneApi provideZoneApi(UltraDNSWSApi api, Supplier<IdAndName> account) {
+            return new UltraDNSZoneApi(api, account);
+        }
+
+        @Provides
+        @Singleton
+        Supplier<IdAndName> account(final UltraDNSWSApi api) {
+            return Suppliers.memoize(new Supplier<IdAndName>() {
+    
+                @Override
+                public IdAndName get() {
+                    return api.getCurrentAccount();
+                }
+    
+                @Override
+                public String toString() {
+                    return "accountOf(" + api + ")";
+                }
+            });
+        }
+
+        @Provides
+        @Singleton
+        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(UltraDNSWSApi api) {
+            return new UltraDNSResourceRecordSetApi.Factory(api);
+        }
+
+        @Provides
+        @Singleton
+        Closeable provideCloser(UltraDNSWSApi api) {
+            return api;
+        }
+    }
+
     private static class ToJcloudsCredentials implements Function<List<Object>, Credentials> {
         public Credentials apply(List<Object> creds) {
             return new Credentials(creds.get(0).toString(), creds.get(1).toString());
         }
-    }
-
-    @Provides
-    @Singleton
-    UltraDNSWSApi provideApi(Supplier<Credentials> credentials) {
-        return ContextBuilder.newBuilder(new UltraDNSWSProviderMetadata())
-                             .credentialsSupplier(credentials)
-                             .modules(ImmutableSet.<com.google.inject.Module> of(new SLF4JLoggingModule()))
-                             .buildApi(UltraDNSWSApi.class);
-    }
-
-    @Provides
-    @Singleton
-    ZoneApi provideZoneApi(UltraDNSWSApi api, Supplier<IdAndName> account) {
-        return new UltraDNSZoneApi(api, account);
-    }
-
-    @Provides
-    @Singleton
-    Supplier<IdAndName> account(final UltraDNSWSApi api) {
-        return Suppliers.memoize(new Supplier<IdAndName>() {
-
-            @Override
-            public IdAndName get() {
-                return api.getCurrentAccount();
-            }
-
-            @Override
-            public String toString() {
-                return "accountOf(" + api + ")";
-            }
-        });
-    }
-
-    @Provides
-    @Singleton
-    ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(UltraDNSWSApi api) {
-        return new UltraDNSResourceRecordSetApi.Factory(api);
-    }
-
-    @Provides
-    @Singleton
-    Closeable provideCloser(UltraDNSWSApi api) {
-        return api;
     }
 }


### PR DESCRIPTION
The attached code fixes issue #29 and prepares us for the upgrade to Dagger 1.0.

`denominator.Provider` can no longer be a base implementation of `dagger.Module` as starting in Dagger 1.0, this pattern no longer compiles.  The better way to accomplish the task is to have `denominator.Provider` reference its configuration, which is the essence of this change.
