### PR TITLE
remove extraneous dependencies from clouddns

### DIFF
--- a/providers/denominator-clouddns/build.gradle
+++ b/providers/denominator-clouddns/build.gradle
@@ -21,7 +21,6 @@ dependencies {
   compile      project(':denominator-core')
   provided    'com.squareup.dagger:dagger-compiler:1.0.0'
   testCompile  project(':denominator-core').sourceSets.test.output
-  compile     'org.jclouds.provider:rackspace-clouddns-us:1.6.0'
-  compile     'org.jclouds.provider:rackspace-clouddns-uk:1.6.0'
+  compile     'org.jclouds.api:rackspace-clouddns:1.6.0'
   compile     'org.jclouds.driver:jclouds-slf4j:1.6.0'
 }

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
@@ -18,8 +18,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.jclouds.ContextBuilder;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
-import org.jclouds.rackspace.clouddns.us.CloudDNSUSProviderMetadata;
 import org.jclouds.rackspace.clouddns.v1.CloudDNSApi;
+import org.jclouds.rackspace.clouddns.v1.CloudDNSApiMetadata;
 import org.jclouds.rackspace.clouddns.v1.features.RecordApi;
 import org.testng.annotations.Test;
 
@@ -43,7 +43,7 @@ public class CloudDNSResourceRecordSetApiMockTest {
         Properties overrides = new Properties();
         overrides.setProperty(PROPERTY_MAX_RETRIES, "1");
         
-        CloudDNSApi cloudDNSApi = ContextBuilder.newBuilder(new CloudDNSUSProviderMetadata())
+        CloudDNSApi cloudDNSApi = ContextBuilder.newBuilder(new CloudDNSApiMetadata())
                 .credentials("jclouds-joe", "letmein")
                 .modules(modules)
                 .endpoint(uri)


### PR DESCRIPTION
We are only using the default endpoint so we don't need the extra 2 jars in our graph.

Once merged, issue #145 can be rebased and simplified.
