### PR TITLE
adds support for config file

### DIFF
--- a/denominator-cli/README.md
+++ b/denominator-cli/README.md
@@ -12,6 +12,30 @@ Here's how to get denominator-cli `1.1.3` from [bintray](https://bintray.com/pkg
 ## Building
 To build the cli, execute `./gradlew clean test install` from the root of your denominator clone.  The binary will end up at `/denominator-cli/build/denominator`
 
+## Configuring
+
+You may optionally use a configuration file in YAML format to define named providers and credentials for each.
+
+Here's an example of a configuration file:
+
+```
+name: route53-test
+provider: route53
+credentials:
+  accessKey: foo1
+  secretKey: foo2
+---
+name: ultradns-prod
+provider: ultradns
+credentials:
+  username: your_username
+  password: your_password
+```
+
+Then use the `-C` arg to define the path to the configuration file and the `-n` arg to select the named provider.
+
+For example, `./denominator -C /path/to/config.yml -n route53-test zone`
+
 ## Running
 denominator will print out a help statement, but here's the gist.
 

--- a/denominator-cli/build.gradle
+++ b/denominator-cli/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   // to quiet error messages, not as we are using it
   compile     'org.slf4j:slf4j-jdk14:1.7.5'
   compile     'io.airlift:airline:0.5'
+  compile     'org.yaml:snakeyaml:1.12'
 }
 
 // create a self-contained jar that is executable

--- a/denominator-cli/src/test/resources/test-config.yml
+++ b/denominator-cli/src/test/resources/test-config.yml
@@ -1,0 +1,13 @@
+name: blah1
+provider: route53
+credentials:
+  accessKey: foo1
+  secretKey: foo2
+---
+name: blah2
+provider: mock
+credentials:
+  accessKey: foo3
+  secretKey: foo4
+  sessionToken: foo5
+


### PR DESCRIPTION
Fixes #46

I've taken a look at issue #46 for adding a config file to denominator.

Here's the syntax we've been kicking around on IRC:

```
./denominator -C /path/to/config.yml -n route53-test zone
```

For example, you could configure both route53 and ultradns like above then using only -n arg, run zone list.

The proposed config file format is a list of providers and relative credentials:

```
name: route53-test
provider: route53
credentials:
  accessKey: foo1
  secretKey: foo2

---
name: ultradns-prod
provider: ultradns
credentials:
  username: your_username
  password: your_password
```
