### PR TITLE
UltraDNS: Use poolRecordType=0 to return all Directional DNS records for the host

### DIFF
--- a/providers/denominator-ultradns/src/test/resources/getDirectionalPoolsOfZoneResponse.xml
+++ b/providers/denominator-ultradns/src/test/resources/getDirectionalPoolsOfZoneResponse.xml
@@ -1,0 +1,12 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+	<soap:Body>
+		<ns1:getDirectionalPoolsOfZoneResponse
+			xmlns:ns1="http://webservice.api.ultra.neustar.com/v01/">
+			<DirectionalPoolList xmlns:ns2="http://schema.ultraservice.neustar.com/v01/">
+				<ns2:DirectionalPoolData dirpoolid="D000000000000001"
+					Zoneid="Z000000000000001" Pooldname="srv.denominator.io."
+					DirPoolType="GEOLOCATION" Description="test with ips and cnames" />
+			</DirectionalPoolList>
+		</ns1:getDirectionalPoolsOfZoneResponse>
+	</soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
UltraDNS: Use poolRecordType=0 to return all Directional DNS records for the host. UMP-5873

This cut the time to run live tests in ultradns in half.
