### PR TITLE
Deprecated remaining naming conventions in preparation for denominator 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Version 1.3.0
+* Deprecated remaining naming conventions that use syntax like `getUrl` or `listByName` to `url` or `iterateByName` to support migration to denominator 2.0.
+* ResourceRecordSet no longer implements `List<D>`.  Please access rdata via the `rdata()` accessor.
+
 ### Version 1.2.1
 * remove strict zone name checks on deprecated `DNSApi.get..Api` methods as often the backend will accept zone names with or without a trailing dot.
 

--- a/denominator-cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
+++ b/denominator-cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
@@ -41,7 +41,7 @@ class GeoResourceRecordSetCommands {
     public static class GeoTypeList extends GeoResourceRecordSetCommand {
         @Override
         protected Iterator<String> doRun(DNSApiManager mgr) {
-            return mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().getSupportedTypes().iterator();
+            return mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().supportedTypes().iterator();
         }
     }
 
@@ -50,7 +50,7 @@ class GeoResourceRecordSetCommands {
         @Override
         protected Iterator<String> doRun(DNSApiManager mgr) {
             return FluentIterable
-                    .from(mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().getSupportedRegions().asMap()
+                    .from(mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().supportedRegions().asMap()
                             .entrySet()).transform(new Function<Map.Entry<String, Collection<String>>, String>() {
                         @Override
                         public String apply(Entry<String, Collection<String>> input) {
@@ -71,9 +71,9 @@ class GeoResourceRecordSetCommands {
         public Iterator<String> doRun(DNSApiManager mgr) {
             Iterator<ResourceRecordSet<?>> iterator;
             if (name != null && type != null)
-                iterator = mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().listByNameAndType(name, type);
+                iterator = mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().iterateByNameAndType(name, type);
             if (name != null)
-                iterator = mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().listByName(name);
+                iterator = mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().iterateByName(name);
             else
                 iterator = mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName)).get().iterator();
             return transform(iterator, GeoResourceRecordSetToString.INSTANCE);
@@ -144,8 +144,8 @@ class GeoResourceRecordSetCommands {
         @Override
         public String apply(ResourceRecordSet<?> geoRRS) {
             Geo geo = toProfile(Geo.class).apply(geoRRS);
-            StringBuilder suffix = new StringBuilder().append(geo.getGroup()).append(' ')
-                    .append(geo.getRegions());
+            StringBuilder suffix = new StringBuilder().append(geo.group()).append(' ')
+                    .append(geo.regions());
             ImmutableList.Builder<String> lines = ImmutableList.<String> builder();
             for (String line : Splitter.on('\n').split(ResourceRecordSetToString.INSTANCE.apply(geoRRS))) {
                 lines.add(new StringBuilder().append(line).append(' ').append(suffix).toString());

--- a/denominator-cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
+++ b/denominator-cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
@@ -54,7 +54,7 @@ class ResourceRecordSetCommands {
         public Iterator<String> doRun(DNSApiManager mgr) {
             Iterator<ResourceRecordSet<?>> iterator;
             if (name != null)
-                iterator = mgr.api().basicRecordSetsInZone(idOrName(mgr, zoneIdOrName)).listByName(name);
+                iterator = mgr.api().basicRecordSetsInZone(idOrName(mgr, zoneIdOrName)).iterateByName(name);
             else
                 iterator = mgr.api().basicRecordSetsInZone(idOrName(mgr, zoneIdOrName)).iterator();
             return transform(iterator, ResourceRecordSetToString.INSTANCE);
@@ -320,7 +320,7 @@ class ResourceRecordSetCommands {
         public String apply(ResourceRecordSet<?> input) {
             ImmutableList.Builder<String> lines = ImmutableList.<String> builder();
             for (Map<String, Object> rdata : input) {
-                lines.add(format("%-50s%-7s%-6s%s", input.getName(), input.getType(), input.getTTL().orNull(),
+                lines.add(format("%-50s%-7s%-6s%s", input.name(), input.type(), input.ttl().orNull(),
                         flatten(rdata)));
             }
             return Joiner.on('\n').join(lines.build());

--- a/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -399,6 +399,6 @@ public class DenominatorTest {
                 ";; ok"));
         assertEquals(mgr.api().geoRecordSetsInZone(command.zoneIdOrName).get()
                         .getByNameTypeAndGroup(command.name, command.type, command.group).get()
-                        .getTTL().get(), Integer.valueOf(command.ttl));
+                        .ttl().get(), Integer.valueOf(command.ttl));
     }
 }

--- a/denominator-core/src/main/java/denominator/AllProfileResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/AllProfileResourceRecordSetApi.java
@@ -6,7 +6,7 @@ import denominator.model.ResourceRecordSet;
 
 /**
  * list operations that apply to record sets regardless of
- * {@link ResourceRecordSet#getProfiles() profile}.
+ * {@link ResourceRecordSet#profiles() profile}.
  */
 @Beta
 public interface AllProfileResourceRecordSetApi extends ReadOnlyResourceRecordSetApi {

--- a/denominator-core/src/main/java/denominator/Denominator.java
+++ b/denominator-core/src/main/java/denominator/Denominator.java
@@ -68,6 +68,15 @@ public final class Denominator {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #providers}
+     */
+    @Deprecated
+    public static Iterable<Provider> listProviders() {
+        return providers();
+    }
+
+    /**
      * Returns the currently configured {@link Provider providers} from
      * {@link ServiceLoader#load(Class)}.
      * 
@@ -78,7 +87,7 @@ public final class Denominator {
      * jars in your classpath. If you desire speed, it is best to instantiate
      * Providers directly.
      */
-    public static Iterable<Provider> listProviders() {
+    public static Iterable<Provider> providers() {
         return ServiceLoader.load(Provider.class);
     }
 

--- a/denominator-core/src/main/java/denominator/ReadOnlyResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/ReadOnlyResourceRecordSetApi.java
@@ -34,25 +34,44 @@ interface ReadOnlyResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
     Iterator<ResourceRecordSet<?>> iterator();
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #iterateByName(String)}
+     */
+    @Deprecated
+    Iterator<ResourceRecordSet<?>> listByName(String name);
+
+    /**
      * a listing of all resource record sets which have the specified name.
      * 
-     * @return iterator which is lazy where possible, empty if there are no records with that name.
+     * @return iterator which is lazy where possible, empty if there are no
+     *         records with that name.
      * @throws IllegalArgumentException
      *             if the zone {@code idOrName} is not found.
+     * 
+     * @since 1.3
      */
-    Iterator<ResourceRecordSet<?>> listByName(String name);
+    Iterator<ResourceRecordSet<?>> iterateByName(String name);
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #iterateByName(String)}
+     */
+    @Deprecated
+    Iterator<ResourceRecordSet<?>> listByNameAndType(String name, String type);
 
     /**
      * a listing of all resource record sets by name and type.
      * 
      * @param name
-     *            {@link ResourceRecordSet#getName() name} of the rrset
+     *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
-     *            {@link ResourceRecordSet#getType() type} of the rrset
+     *            {@link ResourceRecordSet#type() type} of the rrset
      * 
      * @return iterator which is lazy where possible, empty if there are no records with that name.
      * @throws IllegalArgumentException
      *             if the zone {@code idOrName} is not found.
+     * 
+     * @since 1.3
      */
-    Iterator<ResourceRecordSet<?>> listByNameAndType(String name, String type);
+    Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type);
 }

--- a/denominator-core/src/main/java/denominator/ResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/ResourceRecordSetApi.java
@@ -23,7 +23,7 @@ public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
 
     /**
      * Iterates across all basic record sets in the zone (those with no
-     * {@link ResourceRecordSet#getProfiles() profile}). Implementations are
+     * {@link ResourceRecordSet#profiles() profile}). Implementations are
      * lazy when possible.
      * 
      * @return iterator which is lazy where possible
@@ -34,21 +34,30 @@ public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
     Iterator<ResourceRecordSet<?>> iterator();
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #iterateByName(String)}
+     */
+    @Deprecated
+    Iterator<ResourceRecordSet<?>> listByName(String name);
+
+    /**
      * a listing of all resource record sets which have the specified name.
      * 
-     * @return iterator which is lazy where possible, empty if there are no records with that name.
+     * @return iterator which is lazy where possible, empty if there are no
+     *         records with that name.
      * @throws IllegalArgumentException
      *             if the zone {@code idOrName} is not found.
+     * @since 1.3
      */
-    Iterator<ResourceRecordSet<?>> listByName(String name);
+    Iterator<ResourceRecordSet<?>> iterateByName(String name);
 
     /**
      * retrieve a resource record set by name and type.
      * 
      * @param name
-     *            {@link ResourceRecordSet#getName() name} of the rrset
+     *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
-     *            {@link ResourceRecordSet#getType() type} of the rrset
+     *            {@link ResourceRecordSet#type() type} of the rrset
      * 
      * @return present if a resource record exists with the same {@code name}
      *         and {@code type}
@@ -59,8 +68,8 @@ public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
 
     /**
      * If a {@link ResourceRecordSet} exists with
-     * {@link ResourceRecordSet#getName() name} and
-     * {@link ResourceRecordSet#getType() type} corresponding to {@code rrset},
+     * {@link ResourceRecordSet#name() name} and
+     * {@link ResourceRecordSet#type() type} corresponding to {@code rrset},
      * this adds the {@code rdata} to that set. Otherwise, it creates a
      * {@link ResourceRecordSet} initially comprised of the specified
      * {@code rrset}.
@@ -76,30 +85,30 @@ public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
      * 
      * @param rrset
      *            contains the {@code rdata} elements to be added. If
-     *            {@link ResourceRecordSet#getTTL() ttl} is present, it will
+     *            {@link ResourceRecordSet#ttl() ttl} is present, it will
      *            replace the TTL on all records.
      */
     void add(ResourceRecordSet<?> rrset);
 
     /**
      * Ensures the supplied {@code ttl} is uniform for all record sets with the
-     * supplied {@link ResourceRecordSet#getName() name} and
-     * {@link ResourceRecordSet#getType() type}. Returns without error if there
+     * supplied {@link ResourceRecordSet#name() name} and
+     * {@link ResourceRecordSet#type() type}. Returns without error if there
      * are no record sets of the specified name and type.
      * 
      * @param ttl
      *            ttl to apply to all records in seconds
      * @param name
-     *            {@link ResourceRecordSet#getName() name} of the rrset
+     *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
-     *            {@link ResourceRecordSet#getType() type} of the rrset
+     *            {@link ResourceRecordSet#type() type} of the rrset
      */
     void applyTTLToNameAndType(int ttl, String name, String type);
 
     /**
      * Idempotently replaces any existing records with
-     * {@link ResourceRecordSet#getName() name} and
-     * {@link ResourceRecordSet#getType() type} corresponding to {@code rrset}.
+     * {@link ResourceRecordSet#name() name} and
+     * {@link ResourceRecordSet#type() type} corresponding to {@code rrset}.
      * 
      * Example of replacing the {@code A} record set for
      * {@code www.denominator.io.} with "192.0.2.1".
@@ -112,15 +121,15 @@ public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
      * 
      * @param rrset
      *            contains the {@code rdata} elements ensure exist. If
-     *            {@link ResourceRecordSet#getTTL() ttl} is not present, zone
+     *            {@link ResourceRecordSet#ttl() ttl} is not present, zone
      *            default is used.
      */
     void replace(ResourceRecordSet<?> rrset);
 
     /**
      * If a {@link ResourceRecordSet} exists with
-     * {@link ResourceRecordSet#getName() name} and
-     * {@link ResourceRecordSet#getType() type} corresponding to {@code rrset},
+     * {@link ResourceRecordSet#name() name} and
+     * {@link ResourceRecordSet#type() type} corresponding to {@code rrset},
      * remove values corresponding to input {@code rdata}, or removes the set
      * entirely, if this is the only entry.
      * 
@@ -135,7 +144,7 @@ public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
      * 
      * @param rrset
      *            contains the {@code rdata} elements to be removed. The
-     *            {@link ResourceRecordSet#getTTL() ttl} is ignored.
+     *            {@link ResourceRecordSet#ttl() ttl} is ignored.
      */
     void remove(ResourceRecordSet<?> rrset);
 
@@ -144,9 +153,9 @@ public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
      * not error if the record set doesn't exist.
      * 
      * @param name
-     *            {@link ResourceRecordSet#getName() name} of the rrset
+     *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
-     *            {@link ResourceRecordSet#getType() type} of the rrset
+     *            {@link ResourceRecordSet#type() type} of the rrset
      * 
      * @throws IllegalArgumentException
      *             if the zone {@code idOrName} is not found.

--- a/denominator-core/src/main/java/denominator/config/ConcatBasicAndGeoResourceRecordSets.java
+++ b/denominator-core/src/main/java/denominator/config/ConcatBasicAndGeoResourceRecordSets.java
@@ -57,18 +57,30 @@ public class ConcatBasicAndGeoResourceRecordSets {
         }
 
         @Override
+        @Deprecated
         public Iterator<ResourceRecordSet<?>> listByName(String name) {
-            return concat(api.listByName(name), geoApi.listByName(name));
+            return iterateByName(name);
         }
 
         @Override
+        public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
+            return concat(api.iterateByName(name), geoApi.iterateByName(name));
+        }
+
+        @Override
+        @Deprecated
         public Iterator<ResourceRecordSet<?>> listByNameAndType(String name, String type) {
+            return iterateByNameAndType(name, type);
+        }
+
+        @Override
+        public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type) {
             Optional<ResourceRecordSet<?>> rrs = api.getByNameAndType(name, type);
-            if (!geoApi.getSupportedTypes().contains(type))
+            if (!geoApi.supportedTypes().contains(type))
                 return rrs.asSet().iterator();
             if (rrs.isPresent())
-                return concat(rrs.asSet().iterator(), geoApi.listByNameAndType(name, type));
-            return geoApi.listByNameAndType(name, type);
+                return concat(rrs.asSet().iterator(), geoApi.iterateByNameAndType(name, type));
+            return geoApi.iterateByNameAndType(name, type);
         }
     }
 }

--- a/denominator-core/src/main/java/denominator/config/OnlyBasicResourceRecordSets.java
+++ b/denominator-core/src/main/java/denominator/config/OnlyBasicResourceRecordSets.java
@@ -51,18 +51,28 @@ public class OnlyBasicResourceRecordSets {
         }
 
         @Override
+        @Deprecated
         public Iterator<ResourceRecordSet<?>> listByName(String name) {
-            return api.listByName(name);
+            return iterateByName(name);
         }
 
         @Override
+        public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
+            return api.iterateByName(name);
+        }
+
+        @Override
+        @Deprecated
         public Iterator<ResourceRecordSet<?>> listByNameAndType(String name, String type) {
+            return iterateByNameAndType(name, type);
+        }
+
+        @Override
+        public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type) {
             Optional<ResourceRecordSet<?>> rrs = api.getByNameAndType(name, type);
             if (rrs.isPresent())
                 return Iterators.<ResourceRecordSet<?>> forArray(rrs.get());
             return Iterators.emptyIterator();
         }
-
-
     }
 }

--- a/denominator-core/src/main/java/denominator/mock/MockAllProfileResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/mock/MockAllProfileResourceRecordSetApi.java
@@ -44,7 +44,13 @@ public class MockAllProfileResourceRecordSetApi implements denominator.AllProfil
     }
 
     @Override
+    @Deprecated
     public Iterator<ResourceRecordSet<?>> listByName(String name) {
+        return iterateByName(name);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
         checkNotNull(name, "name");
         return from(records.get(zone))
                 .filter(nameEqualTo(name))
@@ -53,7 +59,13 @@ public class MockAllProfileResourceRecordSetApi implements denominator.AllProfil
     }
 
     @Override
+    @Deprecated
     public Iterator<ResourceRecordSet<?>> listByNameAndType(String name, String type) {
+        return iterateByNameAndType(name, type);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type) {
         checkNotNull(name, "name");
         checkNotNull(type, "type");
         return from(records.get(zone))

--- a/denominator-core/src/main/java/denominator/mock/MockGeoResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/mock/MockGeoResourceRecordSetApi.java
@@ -37,12 +37,24 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
     }
 
     @Override
+    @Deprecated
     public Set<String> getSupportedTypes() {
+        return supportedTypes();
+    }
+
+    @Override
+    public Set<String> supportedTypes() {
         return types;
     }
 
     @Override
+    @Deprecated
     public Multimap<String, String> getSupportedRegions() {
+        return supportedRegions();
+    }
+
+    @Override
+    public Multimap<String, String> supportedRegions() {
         return regions;
     }
 
@@ -63,13 +75,13 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
             return;
         ResourceRecordSet<?> rrset = existing.get();
         Geo geo = toProfile(Geo.class).apply(rrset);
-        if (geo.getRegions().equals(regions))
+        if (geo.regions().equals(regions))
             return;
         ResourceRecordSet<Map<String, Object>> rrs  = ResourceRecordSet.<Map<String, Object>> builder()
-                                                                       .name(rrset.getName())
-                                                                       .type(rrset.getType())
-                                                                       .ttl(rrset.getTTL().orNull())
-                                                                       .addProfile(Geo.create(geo.getGroup(), regions))
+                                                                       .name(rrset.name())
+                                                                       .type(rrset.type())
+                                                                       .ttl(rrset.ttl().orNull())
+                                                                       .addProfile(Geo.create(geo.group(), regions))
                                                                        .addAll(rrset).build();
         replace(rrs);
     }
@@ -81,13 +93,13 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
         if (!existing.isPresent())
             return;
         ResourceRecordSet<?> rrset = existing.get();
-        if (rrset.getTTL().isPresent() && rrset.getTTL().get().equals(ttl))
+        if (rrset.ttl().isPresent() && rrset.ttl().get().equals(ttl))
             return;
         ResourceRecordSet<Map<String, Object>> rrs  = ResourceRecordSet.<Map<String, Object>> builder()
-                                                                       .name(rrset.getName())
-                                                                       .type(rrset.getType())
+                                                                       .name(rrset.name())
+                                                                       .type(rrset.type())
                                                                        .ttl(ttl)
-                                                                       .profile(rrset.getProfiles())
+                                                                       .profile(rrset.profiles())
                                                                        .addAll(rrset).build();
         replace(rrs);
     }
@@ -96,7 +108,7 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
         checkNotNull(rrset, "rrset was null");
         checkArgument(profileContainsType(Geo.class).apply(rrset), "no geo profile found: %s", rrset);
         Geo geo = toProfile(Geo.class).apply(rrset);
-        Optional<ResourceRecordSet<?>> rrsMatch = getByNameTypeAndGroup(rrset.getName(), rrset.getType(), geo.getGroup());
+        Optional<ResourceRecordSet<?>> rrsMatch = getByNameTypeAndGroup(rrset.name(), rrset.type(), geo.group());
         if (rrsMatch.isPresent()) {
             records.remove(zone, rrsMatch.get());
         }
@@ -132,5 +144,4 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
                     new MockGeoResourceRecordSetApi(records, regions, types, zone));
         }
     }
-
 }

--- a/denominator-core/src/main/java/denominator/profile/GeoResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/profile/GeoResourceRecordSetApi.java
@@ -15,11 +15,27 @@ import denominator.model.profile.Geo;
  */
 @Beta
 public interface GeoResourceRecordSetApi extends AllProfileResourceRecordSetApi {
-    
+
     /**
-     * the set of {@link ResourceRecordSet#getType() record types} that support the geo profile.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #supportedTypes()}
      */
+    @Deprecated
     Set<String> getSupportedTypes();
+
+    /**
+     * the set of {@link ResourceRecordSet#type() record types} that support the geo profile.
+     * 
+     * @since 1.3
+     */
+    Set<String> supportedTypes();
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #supportedRegions()}
+     */
+    @Deprecated
+    Multimap<String, String> getSupportedRegions();
 
     /**
      * retrieve an organized list of regions by region. It is often the case
@@ -42,18 +58,20 @@ public interface GeoResourceRecordSetApi extends AllProfileResourceRecordSetApi 
      * <h4>Note</h4>
      * 
      * The values of this are not guaranteed portable across providers.
+     * 
+     * @since 1.3
      */
-    Multimap<String, String> getSupportedRegions();
+    Multimap<String, String> supportedRegions();
 
     /**
      * retrieve a resource record set by name, type, and geo group
      * 
      * @param name
-     *            {@link ResourceRecordSet#getName() name} of the rrset
+     *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
-     *            {@link ResourceRecordSet#getType() type} of the rrset
+     *            {@link ResourceRecordSet#type() type} of the rrset
      * @param group
-     *            {@link Geo#getGroup() group} of the rrset
+     *            {@link Geo#group() group} of the rrset
      * 
      * @return present if a resource record exists with the same {@code name},
      *         {@code type}, and {@code group}
@@ -64,39 +82,39 @@ public interface GeoResourceRecordSetApi extends AllProfileResourceRecordSetApi 
 
     /**
      * Ensures the supplied {@code regions} are uniform for all record sets with
-     * the supplied {@link ResourceRecordSet#getName() name},
-     * {@link ResourceRecordSet#getType() type}, and {@link Geo#toName() group}
+     * the supplied {@link ResourceRecordSet#name() name},
+     * {@link ResourceRecordSet#type() type}, and {@link Geo#toName() group}
      * . Returns without error if there are no record sets of the specified
      * name, type, and group.
      * 
      * @param regions
-     *            corresponds to {@link Geo#getRegions() regions} you want this
+     *            corresponds to {@link Geo#regions() regions} you want this
      *            {@code group} to represent. Should be a sub-map of
      *            {@link #getSupportedRegions()}.
      * @param name
-     *            {@link ResourceRecordSet#getName() name} of the rrset
+     *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
-     *            {@link ResourceRecordSet#getType() type} of the rrset
+     *            {@link ResourceRecordSet#type() type} of the rrset
      * @param group
-     *            {@link Geo#getGroup() group} of the rrset
+     *            {@link Geo#group() group} of the rrset
      */
     void applyRegionsToNameTypeAndGroup(Multimap<String, String> regions, String name, String type, String group);
 
     /**
      * Ensures the supplied {@code ttl} is uniform for all record sets with the
-     * supplied {@link ResourceRecordSet#getName() name},
-     * {@link ResourceRecordSet#getType() type}, and {@link Geo#toName() group}
+     * supplied {@link ResourceRecordSet#name() name},
+     * {@link ResourceRecordSet#type() type}, and {@link Geo#toName() group}
      * . Returns without error if there are no record sets of the specified
      * name, type, and group.
      * 
      * @param ttl
      *            ttl to apply to all records in seconds
      * @param name
-     *            {@link ResourceRecordSet#getName() name} of the rrset
+     *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
-     *            {@link ResourceRecordSet#getType() type} of the rrset
+     *            {@link ResourceRecordSet#type() type} of the rrset
      * @param group
-     *            {@link Geo#getGroup() group} of the rrset
+     *            {@link Geo#group() group} of the rrset
      */
     void applyTTLToNameTypeAndGroup(int ttl, String name, String type, String group);
 

--- a/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
@@ -100,10 +100,10 @@ public abstract class BaseProviderLiveTest {
     protected Zone mutableZone;
 
     protected void checkRRS(ResourceRecordSet<?> rrs) {
-        checkNotNull(rrs.getName(), "Name: ResourceRecordSet %s", rrs);
-        checkNotNull(rrs.getType(), "Type: ResourceRecordSet %s", rrs);
-        checkNotNull(rrs.getTTL(), "TTL: ResourceRecordSet %s", rrs);
-        assertTrue(!rrs.isEmpty(), "Values absent on ResourceRecordSet: " + rrs);
+        checkNotNull(rrs.name(), "Name: ResourceRecordSet %s", rrs);
+        checkNotNull(rrs.type(), "Type: ResourceRecordSet %s", rrs);
+        checkNotNull(rrs.ttl(), "TTL: ResourceRecordSet %s", rrs);
+        assertTrue(!rrs.rdata().isEmpty(), "Values absent on ResourceRecordSet: " + rrs);
     }
 
     protected void skipIfRRSetExists(Zone zone, String name, String type) {

--- a/denominator-core/src/test/java/denominator/BaseReadOnlyLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseReadOnlyLiveTest.java
@@ -35,7 +35,7 @@ public abstract class BaseReadOnlyLiveTest extends BaseProviderLiveTest {
         for (Zone zone : zones()) {
             for (Iterator<ResourceRecordSet<?>> rrsIterator = roApi(zone).iterator(); rrsIterator.hasNext();) {
                 ResourceRecordSet<?> rrs = rrsIterator.next();
-                recordTypeCounts.getUnchecked(rrs.getType()).addAndGet(rrs.size());
+                recordTypeCounts.getUnchecked(rrs.type()).addAndGet(rrs.rdata().size());
                 checkRRS(rrs);
                 checkListByNameAndTypeConsistent(zone, rrs);
             }
@@ -45,7 +45,7 @@ public abstract class BaseReadOnlyLiveTest extends BaseProviderLiveTest {
 
     protected void checkListByNameAndTypeConsistent(Zone zone, ResourceRecordSet<?> rrs) {
         List<ResourceRecordSet<?>> byNameAndType = ImmutableList.copyOf(roApi(zone)
-                .listByNameAndType(rrs.getName(), rrs.getType()));
+                .iterateByNameAndType(rrs.name(), rrs.type()));
         assertFalse(byNameAndType.isEmpty(), "could not lookup by name and type: " + rrs);
         assertTrue(byNameAndType.contains(rrs), rrs + " not found in list by name and type: " + byNameAndType);
     }
@@ -58,16 +58,16 @@ public abstract class BaseReadOnlyLiveTest extends BaseProviderLiveTest {
             if (!rrsIterator.hasNext())
                 continue;
             ResourceRecordSet<?> rrset = rrsIterator.next();
-            String name = rrset.getName();
+            String name = rrset.name();
             List<ResourceRecordSet<?>> withName = Lists.newArrayList();
             withName.add(rrset);
             while (rrsIterator.hasNext()) {
                 rrset = rrsIterator.next();
-                if (!name.equalsIgnoreCase(rrset.getName()))
+                if (!name.equalsIgnoreCase(rrset.name()))
                         break;
                 withName.add(rrset);
             }
-            List<ResourceRecordSet<?>> fromApi = Lists.newArrayList(roApi(zone).listByName(name));
+            List<ResourceRecordSet<?>> fromApi = Lists.newArrayList(roApi(zone).iterateByName(name));
             assertEquals(usingToString().immutableSortedCopy(fromApi), usingToString().immutableSortedCopy(withName));
             break;
         }
@@ -77,7 +77,7 @@ public abstract class BaseReadOnlyLiveTest extends BaseProviderLiveTest {
     private void testListByNameWhenNotFound() {
         skipIfNoCredentials();
         for (Zone zone : zones()) {
-            assertFalse(roApi(zone).listByName("ARGHH." + zone.name()).hasNext());
+            assertFalse(roApi(zone).iterateByName("ARGHH." + zone.name()).hasNext());
             break;
         }
     }
@@ -86,7 +86,7 @@ public abstract class BaseReadOnlyLiveTest extends BaseProviderLiveTest {
     private void testListByNameAndTypeWhenEmpty() {
         skipIfNoCredentials();
         for (Zone zone : zones()) {
-            assertFalse(roApi(zone).listByNameAndType("ARGHH." + zone.name(), "TXT").hasNext());
+            assertFalse(roApi(zone).iterateByNameAndType("ARGHH." + zone.name(), "TXT").hasNext());
             break;
         }
     }

--- a/denominator-core/src/test/java/denominator/BaseRecordSetLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseRecordSetLiveTest.java
@@ -45,7 +45,7 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
             for (Iterator<ResourceRecordSet<?>> rrsIterator = rrsApi(zone).iterator(); rrsIterator.hasNext();) {
                 ResourceRecordSet<?> rrs = rrsIterator.next();
                 checkRRS(rrs);
-                Optional<ResourceRecordSet<?>> byNameAndType = rrsApi(zone).getByNameAndType(rrs.getName(), rrs.getType());
+                Optional<ResourceRecordSet<?>> byNameAndType = rrsApi(zone).getByNameAndType(rrs.name(), rrs.type());
                 assertTrue(byNameAndType.isPresent(), "could not lookup by name and type: " + rrs);
                 assertEquals(byNameAndType.get(), rrs);
             }
@@ -60,16 +60,16 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
             if (!rrsIterator.hasNext())
                 continue;
             ResourceRecordSet<?> rrset = rrsIterator.next();
-            String name = rrset.getName();
+            String name = rrset.name();
             List<ResourceRecordSet<?>> withName = Lists.newArrayList();
             withName.add(rrset);
             while (rrsIterator.hasNext()) {
                 rrset = rrsIterator.next();
-                if (!name.equalsIgnoreCase(rrset.getName()))
+                if (!name.equalsIgnoreCase(rrset.name()))
                         break;
                 withName.add(rrset);
             }
-            List<ResourceRecordSet<?>> fromApi = Lists.newArrayList(rrsApi(zone).listByName(name));
+            List<ResourceRecordSet<?>> fromApi = Lists.newArrayList(rrsApi(zone).iterateByName(name));
             assertEquals(usingToString().immutableSortedCopy(fromApi), usingToString().immutableSortedCopy(withName));
             break;
         }
@@ -79,7 +79,7 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
     private void testListByNameWhenNotFound() {
         skipIfNoCredentials();
         for (Zone zone : zones()) {
-            assertFalse(rrsApi(zone).listByName("ARGHH." + zone.name()).hasNext());
+            assertFalse(rrsApi(zone).iterateByName("ARGHH." + zone.name()).hasNext());
             break;
         }
     }
@@ -110,25 +110,25 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
         skipIfNoCredentials();
         Zone zone = skipIfNoMutableZone();
 
-        skipIfRRSetExists(zone, recordSet.getName(), recordSet.getType());
+        skipIfRRSetExists(zone, recordSet.name(), recordSet.type());
 
         rrsApi(zone).add(ResourceRecordSet.<Map<String, Object>> builder()
-                                              .name(recordSet.getName())
-                                              .type(recordSet.getType())
+                                              .name(recordSet.name())
+                                              .type(recordSet.type())
                                               .ttl(1800)
-                                              .add(recordSet.get(0)).build());
+                                              .add(recordSet.rdata().get(0)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getTTL().get(), Integer.valueOf(1800));
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().size(), 1);
-        assertEquals(rrs.get().get(0), recordSet.get(0));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().ttl().get(), Integer.valueOf(1800));
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().rdata().size(), 1);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
     }
 
     @Test(dependsOnMethods = "createNewRRS", dataProvider = "simpleRecords")
@@ -136,19 +136,19 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
         skipIfNoCredentials();
         Zone zone = skipIfNoMutableZone();
 
-        rrsApi(zone).applyTTLToNameAndType(200000, recordSet.getName(), recordSet.getType());
+        rrsApi(zone).applyTTLToNameAndType(200000, recordSet.name(), recordSet.type());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().getTTL().get(), Integer.valueOf(200000));
-        assertEquals(rrs.get().size(), 1);
-        assertEquals(rrs.get().get(0), recordSet.get(0));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().ttl().get(), Integer.valueOf(200000));
+        assertEquals(rrs.get().rdata().size(), 1);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
     }
 
     @Test(dependsOnMethods = "applyTTL", dataProvider = "simpleRecords")
@@ -157,22 +157,22 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
         Zone zone = skipIfNoMutableZone();
 
         rrsApi(zone).replace(ResourceRecordSet.<Map<String, Object>> builder()
-                                                  .name(recordSet.getName())
-                                                  .type(recordSet.getType())
+                                                  .name(recordSet.name())
+                                                  .type(recordSet.type())
                                                   .ttl(10000)
-                                                  .add(recordSet.get(1)).build());
+                                                  .add(recordSet.rdata().get(1)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().getTTL().get(), Integer.valueOf(10000));
-        assertEquals(rrs.get().size(), 1);
-        assertEquals(rrs.get().get(0), recordSet.get(1));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().ttl().get(), Integer.valueOf(10000));
+        assertEquals(rrs.get().rdata().size(), 1);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(1));
     }
 
     @Test(dependsOnMethods = "replaceExistingRRSUpdatingTTL", dataProvider = "simpleRecords")
@@ -181,42 +181,42 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
         Zone zone = skipIfNoMutableZone();
 
         rrsApi(zone).remove(ResourceRecordSet.<Map<String, Object>> builder()
-                                                 .name(recordSet.getName())
-                                                 .type(recordSet.getType())
-                                                 .add(recordSet.get(1)).build());
+                                                 .name(recordSet.name())
+                                                 .type(recordSet.type())
+                                                 .add(recordSet.rdata().get(1)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
         assertFalse(rrs.isPresent(),
-                format("recordset(%s, %s) still present in %s", recordSet.getName(), recordSet.getType(), zone));
+                format("recordset(%s, %s) still present in %s", recordSet.name(), recordSet.type(), zone));
     }
 
     @Test(dataProvider = "simpleRecords")
     private void deleteRRS(ResourceRecordSet<?> recordSet) {
         skipIfNoCredentials();
         Zone zone = skipIfNoMutableZone();
-        String recordName = recordSet.getName().replace("." + zone.name(), "-delete." + zone.name());
+        String recordName = recordSet.name().replace("." + zone.name(), "-delete." + zone.name());
 
-        skipIfRRSetExists(zone, recordName, recordSet.getType());
+        skipIfRRSetExists(zone, recordName, recordSet.type());
 
         rrsApi(zone).add(ResourceRecordSet.<Map<String, Object>> builder()
                                               .name(recordName)
-                                              .type(recordSet.getType())
-                                              .add(recordSet.get(0)).build());
+                                              .type(recordSet.type())
+                                              .add(recordSet.rdata().get(0)).build());
 
-        Optional<ResourceRecordSet<?>> rrs = rrsApi(zone).getByNameAndType(recordName, recordSet.getType());
+        Optional<ResourceRecordSet<?>> rrs = rrsApi(zone).getByNameAndType(recordName, recordSet.type());
 
-        assertPresent(rrs, zone, recordName, recordSet.getType());
+        assertPresent(rrs, zone, recordName, recordSet.type());
 
-        rrsApi(zone).deleteByNameAndType(recordName, recordSet.getType());
+        rrsApi(zone).deleteByNameAndType(recordName, recordSet.type());
 
-        String failureMessage = format("recordset(%s, %s) still exists in %s", recordName, recordSet.getType(), zone);
-        assertFalse(rrsApi(zone).getByNameAndType(recordName, recordSet.getType()).isPresent(), failureMessage);
-        assertFalse(any(rrsApi(zone).iterator(), and(nameEqualTo(recordName), typeEqualTo(recordSet.getType()))),
+        String failureMessage = format("recordset(%s, %s) still exists in %s", recordName, recordSet.type(), zone);
+        assertFalse(rrsApi(zone).getByNameAndType(recordName, recordSet.type()).isPresent(), failureMessage);
+        assertFalse(any(rrsApi(zone).iterator(), and(nameEqualTo(recordName), typeEqualTo(recordSet.type()))),
                 failureMessage);
 
         // test no exception if re-applied
-        rrsApi(zone).deleteByNameAndType(recordName, recordSet.getType());
+        rrsApi(zone).deleteByNameAndType(recordName, recordSet.type());
     }
 }

--- a/denominator-core/src/test/java/denominator/BaseRoundRobinLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseRoundRobinLiveTest.java
@@ -48,25 +48,25 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         skipIfNoCredentials();
         Zone zone = skipIfNoMutableZone();
 
-        skipIfRRSetExists(zone, recordSet.getName(), recordSet.getType());
+        skipIfRRSetExists(zone, recordSet.name(), recordSet.type());
 
         rrsApi(zone).add(ResourceRecordSet.<Map<String, Object>> builder()
-                                              .name(recordSet.getName())
-                                              .type(recordSet.getType())
+                                              .name(recordSet.name())
+                                              .type(recordSet.type())
                                               .ttl(1800)
-                                              .add(recordSet.get(0)).build());
+                                              .add(recordSet.rdata().get(0)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getTTL().get(), Integer.valueOf(1800));
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().size(), 1);
-        assertEquals(rrs.get().get(0), recordSet.get(0));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().ttl().get(), Integer.valueOf(1800));
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().rdata().size(), 1);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
     }
 
     @Test(dependsOnMethods = "createNewRRS", dataProvider = "roundRobinRecords")
@@ -75,21 +75,21 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         Zone zone = skipIfNoMutableZone();
 
         rrsApi(zone).add(ResourceRecordSet.<Map<String, Object>> builder()
-                                              .name(recordSet.getName())
-                                              .type(recordSet.getType())
-                                              .add(recordSet.get(1)).build());
+                                              .name(recordSet.name())
+                                              .type(recordSet.type())
+                                              .add(recordSet.rdata().get(1)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().size(), 2);
-        assertEquals(rrs.get().get(0), recordSet.get(0));
-        assertEquals(rrs.get().get(1), recordSet.get(1));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().rdata().size(), 2);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
+        assertEquals(rrs.get().rdata().get(1), recordSet.rdata().get(1));
     }
 
     @Test(dependsOnMethods = "addRecordToExistingRRS", dataProvider = "roundRobinRecords")
@@ -97,20 +97,20 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         skipIfNoCredentials();
         Zone zone = skipIfNoMutableZone();
 
-        rrsApi(zone).applyTTLToNameAndType(200000, recordSet.getName(), recordSet.getType());
+        rrsApi(zone).applyTTLToNameAndType(200000, recordSet.name(), recordSet.type());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().getTTL().get(), Integer.valueOf(200000));
-        assertEquals(rrs.get().size(), 2);
-        assertEquals(rrs.get().get(0), recordSet.get(0));
-        assertEquals(rrs.get().get(1), recordSet.get(1));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().ttl().get(), Integer.valueOf(200000));
+        assertEquals(rrs.get().rdata().size(), 2);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
+        assertEquals(rrs.get().rdata().get(1), recordSet.rdata().get(1));
     }
 
     @Test(dependsOnMethods = "applyTTL", dataProvider = "roundRobinRecords")
@@ -119,24 +119,24 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         Zone zone = skipIfNoMutableZone();
 
         rrsApi(zone).replace(ResourceRecordSet.<Map<String, Object>> builder()
-                                                  .name(recordSet.getName())
-                                                  .type(recordSet.getType())
+                                                  .name(recordSet.name())
+                                                  .type(recordSet.type())
                                                   .ttl(10000)
-                                                  .add(recordSet.get(0))
-                                                  .add(recordSet.get(2)).build());
+                                                  .add(recordSet.rdata().get(0))
+                                                  .add(recordSet.rdata().get(2)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().getTTL().get(), Integer.valueOf(10000));
-        assertEquals(rrs.get().size(), 2);
-        assertEquals(rrs.get().get(0), recordSet.get(0));
-        assertEquals(rrs.get().get(1), recordSet.get(2));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().ttl().get(), Integer.valueOf(10000));
+        assertEquals(rrs.get().rdata().size(), 2);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
+        assertEquals(rrs.get().rdata().get(1), recordSet.rdata().get(2));
     }
 
     @Test(dependsOnMethods = "replaceExistingRRSUpdatingTTL", dataProvider = "roundRobinRecords")
@@ -145,20 +145,20 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         Zone zone = skipIfNoMutableZone();
 
         rrsApi(zone).remove(ResourceRecordSet.<Map<String, Object>> builder()
-                                                 .name(recordSet.getName())
-                                                 .type(recordSet.getType())
-                                                 .add(recordSet.get(2)).build());
+                                                 .name(recordSet.name())
+                                                 .type(recordSet.type())
+                                                 .add(recordSet.rdata().get(2)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
         checkRRS(rrs.get());
-        assertEquals(rrs.get().getName(), recordSet.getName());
-        assertEquals(rrs.get().getType(), recordSet.getType());
-        assertEquals(rrs.get().size(), 1);
-        assertEquals(rrs.get().get(0), recordSet.get(0));
+        assertEquals(rrs.get().name(), recordSet.name());
+        assertEquals(rrs.get().type(), recordSet.type());
+        assertEquals(rrs.get().rdata().size(), 1);
+        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
     }
 
     @Test(dependsOnMethods = "removeRecordFromExistingRRS", dataProvider = "roundRobinRecords")
@@ -167,41 +167,41 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         Zone zone = skipIfNoMutableZone();
 
         rrsApi(zone).remove(ResourceRecordSet.<Map<String, Object>> builder()
-                                                 .name(recordSet.getName())
-                                                 .type(recordSet.getType())
-                                                 .add(recordSet.get(0)).build());
+                                                 .name(recordSet.name())
+                                                 .type(recordSet.type())
+                                                 .add(recordSet.rdata().get(0)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
-                .getByNameAndType(recordSet.getName(), recordSet.getType());
+                .getByNameAndType(recordSet.name(), recordSet.type());
 
         assertFalse(rrs.isPresent(),
-                format("recordset(%s, %s) still present in %s", recordSet.getName(), recordSet.getType(), zone));
+                format("recordset(%s, %s) still present in %s", recordSet.name(), recordSet.type(), zone));
     }
 
     @Test(dataProvider = "roundRobinRecords")
     private void deleteRRS(ResourceRecordSet<?> recordSet) {
         skipIfNoCredentials();
         Zone zone = skipIfNoMutableZone();
-        String recordName = recordSet.getName().replace("." + zone.name(), "-delete." + zone.name());
+        String recordName = recordSet.name().replace("." + zone.name(), "-delete." + zone.name());
 
-        skipIfRRSetExists(zone, recordName, recordSet.getType());
+        skipIfRRSetExists(zone, recordName, recordSet.type());
 
         rrsApi(zone).add(
-                ResourceRecordSet.<Map<String, Object>> builder().name(recordName).type(recordSet.getType())
+                ResourceRecordSet.<Map<String, Object>> builder().name(recordName).type(recordSet.type())
                         .addAll(recordSet).build());
 
-        Optional<ResourceRecordSet<?>> rrs = rrsApi(zone).getByNameAndType(recordName, recordSet.getType());
+        Optional<ResourceRecordSet<?>> rrs = rrsApi(zone).getByNameAndType(recordName, recordSet.type());
 
-        assertPresent(rrs, zone, recordSet.getName(), recordSet.getType());
+        assertPresent(rrs, zone, recordSet.name(), recordSet.type());
 
-        rrsApi(zone).deleteByNameAndType(recordName, recordSet.getType());
+        rrsApi(zone).deleteByNameAndType(recordName, recordSet.type());
 
-        String failureMessage = format("recordset(%s, %s) still exists in %s", recordName, recordSet.getType(), zone);
-        assertFalse(rrsApi(zone).getByNameAndType(recordName, recordSet.getType()).isPresent(), failureMessage);
-        assertFalse(any(rrsApi(zone).iterator(), and(nameEqualTo(recordName), typeEqualTo(recordSet.getType()))),
+        String failureMessage = format("recordset(%s, %s) still exists in %s", recordName, recordSet.type(), zone);
+        assertFalse(rrsApi(zone).getByNameAndType(recordName, recordSet.type()).isPresent(), failureMessage);
+        assertFalse(any(rrsApi(zone).iterator(), and(nameEqualTo(recordName), typeEqualTo(recordSet.type()))),
                 failureMessage);
 
         // test no exception if re-applied
-        rrsApi(zone).deleteByNameAndType(recordName, recordSet.getType());
+        rrsApi(zone).deleteByNameAndType(recordName, recordSet.type());
     }
 }

--- a/denominator-core/src/test/java/denominator/mock/MockProviderTest.java
+++ b/denominator-core/src/test/java/denominator/mock/MockProviderTest.java
@@ -1,7 +1,7 @@
 package denominator.mock;
 
 import static denominator.Denominator.create;
-import static denominator.Denominator.listProviders;
+import static denominator.Denominator.providers;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -26,7 +26,7 @@ public class MockProviderTest {
 
     @Test
     public void testMockRegistered() {
-        Set<Provider> allProviders = ImmutableSet.copyOf(listProviders());
+        Set<Provider> allProviders = ImmutableSet.copyOf(providers());
         assertTrue(allProviders.contains(PROVIDER));
     }
 

--- a/denominator-core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
@@ -51,15 +51,15 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
                 ResourceRecordSet<?> geoRRS = geoRRSIterator.next();
                 checkGeoRRS(geoRRS);
                 getAnonymousLogger().info(format("%s ::: geoRRS: %s", manager, geoRRS));
-                recordTypeCounts.getUnchecked(geoRRS.getType()).addAndGet(geoRRS.size());
-                geoRecordCounts.getUnchecked(toProfile(Geo.class).apply(geoRRS)).addAndGet(geoRRS.size());
+                recordTypeCounts.getUnchecked(geoRRS.type()).addAndGet(geoRRS.rdata().size());
+                geoRecordCounts.getUnchecked(toProfile(Geo.class).apply(geoRRS)).addAndGet(geoRRS.rdata().size());
                 
-                Iterator<ResourceRecordSet<?>> byNameAndType = geoApi(zone).listByNameAndType(geoRRS.getName(), geoRRS.getType());
+                Iterator<ResourceRecordSet<?>> byNameAndType = geoApi(zone).iterateByNameAndType(geoRRS.name(), geoRRS.type());
                 assertTrue(byNameAndType.hasNext(), "could not list by name and type: " + geoRRS);
-                assertTrue(Iterators.elementsEqual(geoApi(zone).listByNameAndType(geoRRS.getName(), geoRRS.getType()), byNameAndType));
+                assertTrue(Iterators.elementsEqual(geoApi(zone).iterateByNameAndType(geoRRS.name(), geoRRS.type()), byNameAndType));
                 
                 Optional<ResourceRecordSet<?>> byNameTypeAndGroup = geoApi(zone)
-                        .getByNameTypeAndGroup(geoRRS.getName(), geoRRS.getType(), toProfile(Geo.class).apply(geoRRS).getGroup());
+                        .getByNameTypeAndGroup(geoRRS.name(), geoRRS.type(), toProfile(Geo.class).apply(geoRRS).group());
                 assertTrue(byNameTypeAndGroup.isPresent(), "could not lookup by name, type, and group: " + geoRRS);
                 assertEquals(byNameTypeAndGroup.get(), geoRRS);
             }
@@ -68,15 +68,15 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
     }
 
     protected void checkGeoRRS(ResourceRecordSet<?> geoRRS) {
-        assertFalse(geoRRS.getProfiles().isEmpty(), "Profile absent: " + geoRRS);
+        assertFalse(geoRRS.profiles().isEmpty(), "Profile absent: " + geoRRS);
         Geo geo = toProfile(Geo.class).apply(geoRRS);
-        checkNotNull(geo.getGroup(), "Group: Geo %s", geoRRS);
-        assertTrue(!geo.getRegions().isEmpty(), "Regions empty on Geo: " + geoRRS);
+        checkNotNull(geo.group(), "Group: Geo %s", geoRRS);
+        assertTrue(!geo.regions().isEmpty(), "Regions empty on Geo: " + geoRRS);
         
-        checkNotNull(geoRRS.getName(), "Name: ResourceRecordSet %s", geoRRS);
-        checkNotNull(geoRRS.getType(), "Type: ResourceRecordSet %s", geoRRS);
-        checkNotNull(geoRRS.getTTL(), "TTL: ResourceRecordSet %s", geoRRS);
-        assertFalse(geoRRS.isEmpty(), "Values absent on ResourceRecordSet: " + geoRRS);
+        checkNotNull(geoRRS.name(), "Name: ResourceRecordSet %s", geoRRS);
+        checkNotNull(geoRRS.type(), "Type: ResourceRecordSet %s", geoRRS);
+        checkNotNull(geoRRS.ttl(), "TTL: ResourceRecordSet %s", geoRRS);
+        assertFalse(geoRRS.rdata().isEmpty(), "Values absent on ResourceRecordSet: " + geoRRS);
     }
 
     @Test
@@ -87,16 +87,16 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
             if (!geoRRSIterator.hasNext())
                 continue;
             ResourceRecordSet<?> geoRRSet = geoRRSIterator.next();
-            String name = geoRRSet.getName();
+            String name = geoRRSet.name();
             List<ResourceRecordSet<?>> withName = Lists.newArrayList();
             withName.add(geoRRSet);
             while (geoRRSIterator.hasNext()) {
                 geoRRSet = geoRRSIterator.next();
-                if (!name.equalsIgnoreCase(geoRRSet.getName()))
+                if (!name.equalsIgnoreCase(geoRRSet.name()))
                         break;
                 withName.add(geoRRSet);
             }
-            List<ResourceRecordSet<?>> fromApi = Lists.newArrayList(geoApi(zone).listByName(name));
+            List<ResourceRecordSet<?>> fromApi = Lists.newArrayList(geoApi(zone).iterateByName(name));
             assertEquals(usingToString().immutableSortedCopy(fromApi), usingToString().immutableSortedCopy(withName));
             break;
         }
@@ -106,7 +106,7 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
     private void testListByNameWhenNotFound() {
         skipIfNoCredentials();
         for (Zone zone : zones()) {
-            assertFalse(geoApi(zone).listByName("ARGHH." + zone.name()).hasNext());
+            assertFalse(geoApi(zone).iterateByName("ARGHH." + zone.name()).hasNext());
             break;
         }
     }
@@ -115,7 +115,7 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
     private void testListByNameAndTypeWhenNone() {
         skipIfNoCredentials();
         for (Zone zone : zones()) {
-            assertFalse(geoApi(zone).listByNameAndType("ARGHH." + zone.name(), "TXT").hasNext());
+            assertFalse(geoApi(zone).iterateByNameAndType("ARGHH." + zone.name(), "TXT").hasNext());
             break;
         }
     }

--- a/denominator-core/src/test/java/denominator/profile/BaseGeoWriteCommandsLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseGeoWriteCommandsLiveTest.java
@@ -33,48 +33,48 @@ public abstract class BaseGeoWriteCommandsLiveTest extends BaseProviderLiveTest 
         
         Geo existingGeo = toProfile(Geo.class).apply(existing);
         
-        String last = getLast(existingGeo.getRegions().values());
+        String last = getLast(existingGeo.regions().values());
         
-        Multimap<String, String> regions = filterValues(existingGeo.getRegions(), not(equalTo(last)));
+        Multimap<String, String> regions = filterValues(existingGeo.regions(), not(equalTo(last)));
 
-        geoApi().applyRegionsToNameTypeAndGroup(regions, existing.getName(), existing.getType(), mutableGeoRRSet.group);
+        geoApi().applyRegionsToNameTypeAndGroup(regions, existing.name(), existing.type(), mutableGeoRRSet.group);
 
         ResourceRecordSet<?> rrs = 
-                geoApi().getByNameTypeAndGroup(existing.getName(), existing.getType(), mutableGeoRRSet.group).get();
+                geoApi().getByNameTypeAndGroup(existing.name(), existing.type(), mutableGeoRRSet.group).get();
 
         checkRRS(rrs);
-        assertEquals(rrs.getName(), existing.getName());
-        assertEquals(rrs.getType(), existing.getType());
-        assertEquals(rrs.getTTL(), existing.getTTL());
+        assertEquals(rrs.name(), existing.name());
+        assertEquals(rrs.type(), existing.type());
+        assertEquals(rrs.ttl(), existing.ttl());
         assertEquals(ImmutableList.copyOf(rrs), ImmutableList.copyOf(existing));
-        assertEquals(toProfile(Geo.class).apply(rrs).getRegions(), ImmutableMultimap.copyOf(regions));
+        assertEquals(toProfile(Geo.class).apply(rrs).regions(), ImmutableMultimap.copyOf(regions));
 
         // reset back
         geoApi().applyRegionsToNameTypeAndGroup(
-                existingGeo.getRegions(), existing.getName(), existing.getType(), mutableGeoRRSet.group);
+                existingGeo.regions(), existing.name(), existing.type(), mutableGeoRRSet.group);
     }
 
     @Test
     private void applyTTLToNameTypeAndGroup() {
         skipIfNoCredentials();
         ResourceRecordSet<?> existing = skipIfNoMutableRRSet();
-        int ttl = existing.getTTL().or(300) + 300;
+        int ttl = existing.ttl().or(300) + 300;
 
-        geoApi().applyTTLToNameTypeAndGroup(ttl, existing.getName(), existing.getType(), mutableGeoRRSet.group);
+        geoApi().applyTTLToNameTypeAndGroup(ttl, existing.name(), existing.type(), mutableGeoRRSet.group);
 
         ResourceRecordSet<?> rrs = 
-                geoApi().getByNameTypeAndGroup(existing.getName(), existing.getType(), mutableGeoRRSet.group).get();
+                geoApi().getByNameTypeAndGroup(existing.name(), existing.type(), mutableGeoRRSet.group).get();
 
         checkRRS(rrs);
-        assertEquals(rrs.getName(), existing.getName());
-        assertEquals(rrs.getType(), existing.getType());
-        assertEquals(rrs.getTTL().get(), Integer.valueOf(ttl));
+        assertEquals(rrs.name(), existing.name());
+        assertEquals(rrs.type(), existing.type());
+        assertEquals(rrs.ttl().get(), Integer.valueOf(ttl));
         assertEquals(ImmutableList.copyOf(rrs), ImmutableList.copyOf(existing));
-        assertEquals(rrs.getProfiles(), existing.getProfiles());
+        assertEquals(rrs.profiles(), existing.profiles());
         
         // reset back
         geoApi().applyTTLToNameTypeAndGroup(
-                existing.getTTL().or(300), existing.getName(), existing.getType(), mutableGeoRRSet.group);
+                existing.ttl().or(300), existing.name(), existing.type(), mutableGeoRRSet.group);
     }
 
     protected ResourceRecordSet<?> skipIfNoMutableRRSet() {

--- a/denominator-model/src/main/java/denominator/model/AbstractRecordSetBuilder.java
+++ b/denominator-model/src/main/java/denominator/model/AbstractRecordSetBuilder.java
@@ -23,7 +23,7 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
     private ImmutableList.Builder<Map<String, Object>> profile = ImmutableList.builder();
 
     /**
-     * @see ResourceRecordSet#getName()
+     * @see ResourceRecordSet#name()
      */
     @SuppressWarnings("unchecked")
     public B name(String name) {
@@ -32,7 +32,7 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
     }
 
     /**
-     * @see ResourceRecordSet#getType()
+     * @see ResourceRecordSet#type()
      */
     @SuppressWarnings("unchecked")
     public B type(String type) {
@@ -41,7 +41,7 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
     }
 
     /**
-     * @see ResourceRecordSet#getTTL()
+     * @see ResourceRecordSet#ttl()
      */
     @SuppressWarnings("unchecked")
     public B ttl(Integer ttl) {
@@ -81,7 +81,7 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
     }
 
     /**
-     * @see ResourceRecordSet#getProfiles()
+     * @see ResourceRecordSet#profiles()
      */
     @SuppressWarnings("unchecked")
     public B profile(Iterable<Map<String, Object>> profile) {

--- a/denominator-model/src/main/java/denominator/model/ResourceRecordSet.java
+++ b/denominator-model/src/main/java/denominator/model/ResourceRecordSet.java
@@ -6,18 +6,21 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.beans.ConstructorProperties;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
-import com.google.common.collect.ForwardingList;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.UnsignedInteger;
 
 /**
  * A grouping of resource records by name and type. In implementation, this is
  * an immutable list of rdata values corresponding to records sharing the same
- * {@link #getName() name} and {@link #getType}.
+ * {@link #name() name} and {@link #type}.
  * 
  * @param <D>
  *            RData type shared across elements. This may be empty in the case
@@ -25,7 +28,7 @@ import com.google.common.primitives.UnsignedInteger;
  * 
  * @see <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class ResourceRecordSet<D extends Map<String, Object>> extends ForwardingList<D> {
+public class ResourceRecordSet<D extends Map<String, Object>> implements List<D> {
 
     private final String name;
     private final String type;
@@ -47,26 +50,68 @@ public class ResourceRecordSet<D extends Map<String, Object>> extends Forwarding
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #name()}
+     */
+    @Deprecated
+    public String getName() {
+        return name();
+    }
+
+    /**
      * an owner name, i.e., the name of the node to which this resource record
      * pertains.
+     * 
+     * @since 1.3
      */
-    public String getName() {
+    public String name() {
         return name;
     }
 
     /**
-     * The mnemonic type of the record. ex {@code CNAME}
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #type()}
      */
+    @Deprecated
     public String getType() {
+        return type();
+    }
+
+    /**
+     * The mnemonic type of the record. ex {@code CNAME}
+     * 
+     * @since 1.3
+     */
+    public String type() {
         return type;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #ttl()}
+     */
+    @Deprecated
+    public Optional<Integer> getTTL() {
+        return ttl();
     }
 
     /**
      * the time interval that the resource record may be cached. Zero implies it
      * is not cached. Absent means default for the zone.
+     * 
+     * @since 1.3
      */
-    public Optional<Integer> getTTL() {
+    public Optional<Integer> ttl() {
         return ttl;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #profiles()}
+     */
+    @Deprecated
+    public ImmutableList<Map<String, Object>> getProfiles() {
+        return profiles();
     }
 
     /**
@@ -77,15 +122,22 @@ public class ResourceRecordSet<D extends Map<String, Object>> extends Forwarding
      * For example, if this record set is intended for resolvers in Utah,
      * profiles will include a Map whose entries include {@code type -> "geo"},
      * and is an instance of {@link denominator.model.profile.Geo}, where
-     * {@link denominator.model.profile.Geo#getRegions()} contains something
+     * {@link denominator.model.profile.Geo#regions()} contains something
      * like `Utah` or `US-UT`.
+     * 
+     * @since 1.3
      */
-    public ImmutableList<Map<String, Object>> getProfiles() {
+    public ImmutableList<Map<String, Object>> profiles() {
         return profiles;
     }
 
-    @Override
-    protected ImmutableList<D> delegate() {
+    /**
+     * RData type shared across elements. This may be empty in the case of
+     * special profile such as `alias`.
+     * 
+     * @since 1.3
+     */
+    public List<D> rdata() {
         return rdata;
     }
 
@@ -179,5 +231,235 @@ public class ResourceRecordSet<D extends Map<String, Object>> extends Forwarding
         protected ImmutableList<D> rdataValues() {
             return rdata.build();
         }
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean add(D e) {
+        return rdata.add(e);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public void add(int index, D element) {
+        rdata.add(index, element);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean addAll(Collection<? extends D> c) {
+        return rdata.addAll(c);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean addAll(int index, Collection<? extends D> c) {
+        return rdata.addAll(index, c);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public void clear() {
+        rdata.clear();
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean contains(Object o) {
+        return rdata.contains(o);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return rdata.containsAll(c);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public D get(int index) {
+        return rdata.get(index);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public int indexOf(Object o) {
+        return rdata.indexOf(o);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean isEmpty() {
+        return rdata.isEmpty();
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public Iterator<D> iterator() {
+        return rdata.iterator();
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public int lastIndexOf(Object o) {
+        return rdata.lastIndexOf(o);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public ListIterator<D> listIterator() {
+        return rdata.listIterator();
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public ListIterator<D> listIterator(int index) {
+        return rdata.listIterator(index);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean remove(Object o) {
+        return rdata.remove(o);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public D remove(int index) {
+        return rdata.remove(index);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return rdata.removeAll(c);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return rdata.retainAll(c);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public D set(int index, D element) {
+        return rdata.set(index, element);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public int size() {
+        return rdata.size();
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public List<D> subList(int fromIndex, int toIndex) {
+        return rdata.subList(fromIndex, toIndex);
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public Object[] toArray() {
+        return rdata.toArray();
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rdata()}
+     */
+    @Deprecated
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return rdata.toArray(a);
     }
 }

--- a/denominator-model/src/main/java/denominator/model/ResourceRecordSets.java
+++ b/denominator-model/src/main/java/denominator/model/ResourceRecordSets.java
@@ -26,11 +26,11 @@ public class ResourceRecordSets {
 
     /**
      * evaluates to true if the input {@link ResourceRecordSet} exists with
-     * {@link ResourceRecordSet#getType() type} corresponding to the
+     * {@link ResourceRecordSet#type() type} corresponding to the
      * {@code type} parameter.
      * 
      * @param type
-     *            the {@link ResourceRecordSet#getType() type} of the desired
+     *            the {@link ResourceRecordSet#type() type} of the desired
      *            record set
      */
     public static Predicate<ResourceRecordSet<?>> typeEqualTo(String type) {
@@ -48,7 +48,7 @@ public class ResourceRecordSets {
         public boolean apply(ResourceRecordSet<?> input) {
             if (input == null)
                 return false;
-            return type.equals(input.getType());
+            return type.equals(input.type());
         }
 
         @Override
@@ -59,11 +59,11 @@ public class ResourceRecordSets {
 
     /**
      * evaluates to true if the input {@link ResourceRecordSet} exists with
-     * {@link ResourceRecordSet#getName() name} corresponding to the
+     * {@link ResourceRecordSet#name() name} corresponding to the
      * {@code name} parameter.
      * 
      * @param name
-     *            the {@link ResourceRecordSet#getName() name} of the desired
+     *            the {@link ResourceRecordSet#name() name} of the desired
      *            record set
      */
     public static Predicate<ResourceRecordSet<?>> nameEqualTo(String name) {
@@ -81,7 +81,7 @@ public class ResourceRecordSets {
         public boolean apply(ResourceRecordSet<?> input) {
             if (input == null)
                 return false;
-            return name.equals(input.getName());
+            return name.equals(input.name());
         }
 
         @Override
@@ -112,7 +112,7 @@ public class ResourceRecordSets {
         public boolean apply(ResourceRecordSet<?> input) {
             if (input == null)
                 return false;
-            return input.contains(rdata);
+            return input.rdata().contains(rdata);
         }
 
         @Override
@@ -123,7 +123,7 @@ public class ResourceRecordSets {
 
     /**
      * returns true if the input is not null and
-     * {@link ResourceRecordSet#getProfiles() profile} is empty.
+     * {@link ResourceRecordSet#profiles() profile} is empty.
      */
     public static Predicate<ResourceRecordSet<?>> withoutProfile() {
         return WithoutProfile.INSTANCE;
@@ -135,7 +135,7 @@ public class ResourceRecordSets {
 
         @Override
         public boolean apply(ResourceRecordSet<?> input) {
-            return input != null && input.getProfiles().isEmpty();
+            return input != null && input.profiles().isEmpty();
         }
 
         @Override
@@ -145,7 +145,7 @@ public class ResourceRecordSets {
     }
 
     /**
-     * returns true if {@link ResourceRecordSet#getProfiles() profile} contains a
+     * returns true if {@link ResourceRecordSet#profiles() profile} contains a
      * value is assignable from {@code type}.
      * 
      * @param type
@@ -166,9 +166,9 @@ public class ResourceRecordSets {
         public boolean apply(ResourceRecordSet<?> input) {
             if (input == null)
                 return false;
-            if (input.getProfiles().isEmpty())
+            if (input.profiles().isEmpty())
                 return false;
-            for (Map<String, Object> profile : input.getProfiles()) {
+            for (Map<String, Object> profile : input.profiles()) {
                 if (type.isAssignableFrom(profile.getClass()))
                     return true;
             }
@@ -182,7 +182,7 @@ public class ResourceRecordSets {
     }
 
     /**
-     * returns value of {@link ResourceRecordSet#getProfiles() profile},
+     * returns value of {@link ResourceRecordSet#profiles() profile},
      * if matches the input {@code type} and is not null;
      * 
      * @param type
@@ -204,9 +204,9 @@ public class ResourceRecordSets {
         public C apply(ResourceRecordSet<?> input) {
             if (input == null)
                 return null;
-            if (input.getProfiles().isEmpty())
+            if (input.profiles().isEmpty())
                 return null;
-            for (Map<String, Object> profile : input.getProfiles()) {
+            for (Map<String, Object> profile : input.profiles()) {
                 if (type.isAssignableFrom(profile.getClass()))
                     return type.cast(profile);
             }
@@ -239,7 +239,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param address
      *            ex. {@code 192.0.2.1}
      */
@@ -267,7 +267,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param addresses
      *            address values ex. {@code [192.0.2.1, 192.0.2.2]}
      */
@@ -305,7 +305,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param address
      *            ex. {@code 1234:ab00:ff00::6b14:abcd}
      */
@@ -334,7 +334,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param addresses
      *            address values ex.
      *            {@code [1234:ab00:ff00::6b14:abcd, 5678:ab00:ff00::6b14:abcd]}
@@ -375,7 +375,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param cname
      *            ex. {@code www1.denominator.io.}
      */
@@ -404,7 +404,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code www.denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param cnames
      *            cname values ex.
      *            {@code [www1.denominator.io., www2.denominator.io.]}
@@ -443,7 +443,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param nsdname
      *            ex. {@code ns1.denominator.io.}
      */
@@ -472,7 +472,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param nsdnames
      *            nsdname values ex.
      *            {@code [ns1.denominator.io., ns2.denominator.io.]}
@@ -511,7 +511,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param ptrdname
      *            ex. {@code ptr1.denominator.io.}
      */
@@ -540,7 +540,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param ptrdnames
      *            ptrdname values ex.
      *            {@code [ptr1.denominator.io., ptr2.denominator.io.]}
@@ -579,7 +579,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param spfdata
      *            ex. {@code v=spf1 a mx -all}
      */
@@ -608,7 +608,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param spfdata
      *            spfdata values ex.
      *            {@code [v=spf1 a mx -all, v=spf1 ipv6 -all]}
@@ -647,7 +647,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param txtdata
      *            ex. {@code "made in sweden"}
      */
@@ -676,7 +676,7 @@ public class ResourceRecordSets {
      * @param name
      *            ex. {@code denominator.io.}
      * @param ttl
-     *            see {@link ResourceRecordSet#getTTL()}
+     *            see {@link ResourceRecordSet#ttl()}
      * @param txtdata
      *            txtdata values ex.
      *            {@code ["made in sweden", "made in norway"]}

--- a/denominator-model/src/main/java/denominator/model/profile/Geo.java
+++ b/denominator-model/src/main/java/denominator/model/profile/Geo.java
@@ -22,8 +22,8 @@ import com.google.common.collect.Multimap;
 public class Geo extends ForwardingMap<String, Object> {
 
     /**
-     * @param group corresponds to {@link #getGroup()}
-     * @param regions corresponds to {@link #getRegions()}
+     * @param group corresponds to {@link #group()}
+     * @param regions corresponds to {@link #regions()}
      */
     public static Geo create(String group, Multimap<String, String> regions) {
         return new Geo(group, regions);
@@ -45,19 +45,41 @@ public class Geo extends ForwardingMap<String, Object> {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #group()}
+     */
+    @Deprecated
+    public String getGroup() {
+        return group();
+    }
+
+    /**
      * user-defined name for the group of regions that represent the traffic
      * desired. For example, {@code "US-West"} or {@code "Non-EU"}.
+     * 
+     * @since 1.3
      */
-    public String getGroup() {
+    public String group() {
         return group;
     }
 
     /**
-     * a filtered view of
-     * {@code denominator.profile.GeoResourceRecordSetApi.getSupportedRegions()}, which
-     * describes the traffic desired for this profile.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #regions()}
      */
+    @Deprecated
     public Multimap<String, String> getRegions() {
+        return regions();
+    }
+
+    /**
+     * a filtered view of
+     * {@code denominator.profile.GeoResourceRecordSetApi.supportedRegions()}
+     * , which describes the traffic desired for this profile.
+     * 
+     * @since 1.3
+     */
+    public Multimap<String, String> regions() {
         return regions;
     }
 

--- a/denominator-model/src/main/java/denominator/model/profile/Geos.java
+++ b/denominator-model/src/main/java/denominator/model/profile/Geos.java
@@ -14,7 +14,7 @@ public class Geos {
     }
 
     /**
-     * returns true if {@link Geo#getGroup() group}, if equals the
+     * returns true if {@link Geo#group() group}, if equals the
      * input {@code group};
      * 
      * @param group
@@ -35,7 +35,7 @@ public class Geos {
         public boolean apply(Geo input) {
             if (input == null)
                 return false;
-            return group.equals(input.getGroup());
+            return group.equals(input.group());
         }
 
         @Override

--- a/denominator-model/src/main/java/denominator/model/rdata/AAAAData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/AAAAData.java
@@ -47,9 +47,20 @@ public class AAAAData extends ForwardingMap<String, Object> {
     }
 
     /**
-     * a 128 bit IPv6 address
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #address()}
      */
+    @Deprecated
     public String getAddress() {
+        return address();
+    }
+
+    /**
+     * a 128 bit IPv6 address
+     * 
+     * @since 1.3
+     */
+    public String address() {
         return address;
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/AData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/AData.java
@@ -47,9 +47,20 @@ public class AData extends ForwardingMap<String, Object> {
     }
 
     /**
-     * a 32-bit internet address
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #address()}
      */
+    @Deprecated
     public String getAddress() {
+        return address();
+    }
+
+    /**
+     * a 32-bit internet address
+     * 
+     * @since 1.3
+     */
+    public String address() {
         return address;
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/CNAMEData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/CNAMEData.java
@@ -35,10 +35,21 @@ public class CNAMEData extends ForwardingMap<String, Object> {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #cname()}
+     */
+    @Deprecated
+    public String getCname() {
+        return cname();
+    }
+
+    /**
      * domain-name which specifies the canonical or primary name for the owner.
      * The owner name is an alias.
+     * 
+     * @since 1.3
      */
-    public String getCname() {
+    public String cname() {
         return cname;
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/MXData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/MXData.java
@@ -41,18 +41,40 @@ public class MXData extends ForwardingMap<String, Object> {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #preference()}
+     */
+    @Deprecated
+    public int getPreference() {
+        return preference();
+    }
+
+    /**
      * specifies the preference given to this RR among others at the same owner.
      * Lower values are preferred.
+     * 
+     * @since 1.3
      */
-    public int getPreference() {
+    public int preference() {
         return preference;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #exchange()}
+     */
+    @Deprecated
+    public String getExchange() {
+        return exchange();
     }
 
     /**
      * domain-name which specifies a host willing to act as a mail exchange for
      * the owner name.
+     * 
+     * @since 1.3
      */
-    public String getExchange() {
+    public String exchange() {
         return exchange;
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/NSData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/NSData.java
@@ -35,10 +35,21 @@ public class NSData extends ForwardingMap<String, Object> {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #nsdname()}
+     */
+    @Deprecated
+    public String getNsdname() {
+        return nsdname();
+    }
+
+    /**
      * domain-name which specifies a host which should be authoritative for the
      * specified class and domain.
+     * 
+     * @since 1.3
      */
-    public String getNsdname() {
+    public String nsdname() {
         return nsdname;
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/PTRData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/PTRData.java
@@ -34,9 +34,20 @@ public class PTRData extends ForwardingMap<String, Object> {
     }
 
     /**
-     * domain-name which points to some location in the domain name space.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #ptrdname()}
      */
+    @Deprecated
     public String getPtrdname() {
+        return ptrdname();
+    }
+
+    /**
+     * domain-name which points to some location in the domain name space.
+     * 
+     * @since 1.3
+     */
+    public String ptrdname() {
         return ptrdname;
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/SOAData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SOAData.java
@@ -64,55 +64,132 @@ public class SOAData extends ForwardingMap<String, Object> {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #mname()}
+     */
+    @Deprecated
+    public String getMname() {
+        return mname();
+    }
+
+    /**
      * domain-name of the name server that was the original or primary source of
      * data for this zone
+     * 
+     * @since 1.3
      */
-    public String getMname() {
+    public String mname() {
         return mname;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #rname()}
+     */
+    @Deprecated
+    public String getRname() {
+        return rname();
     }
 
     /**
      * domain-name which specifies the mailbox of the person responsible for
      * this zone.
+     * 
+     * @since 1.3
      */
-    public String getRname() {
+    public String rname() {
         return rname;
     }
 
     /**
-     * version number of the original copy of the zone.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #serial()}
      */
+    @Deprecated
     public int getSerial() {
+        return serial();
+    }
+
+    /**
+     * version number of the original copy of the zone.
+     * 
+     * @since 1.3
+     */
+    public int serial() {
         return serial;
     }
 
     /**
-     * time interval before the zone should be refreshed
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #refresh()}
      */
+    @Deprecated
     public int getRefresh() {
+        return refresh();
+    }
+
+    /**
+     * time interval before the zone should be refreshed
+     * 
+     * @since 1.3
+     */
+    public int refresh() {
         return refresh;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #retry()}
+     */
+    @Deprecated
+    public int getRetry() {
+        return retry();
     }
 
     /**
      * time interval that should elapse before a failed refresh should be
      * retried
+     * 
+     * @since 1.3
      */
-    public int getRetry() {
+    public int retry() {
         return retry;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #expire()}
+     */
+    @Deprecated
+    public int getExpire() {
+        return expire();
     }
 
     /**
      * time value that specifies the upper limit on the time interval that can
      * elapse before the zone is no longer authoritative.
+     * 
+     * @since 1.3
      */
-    public int getExpire() {
+    public int expire() {
         return expire;
     }
 
     /**
-     * minimum TTL field that should be exported with any RR from this zone.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #minimum()}
      */
+    @Deprecated
     public int getMinimum() {
+        return minimum();
+    }
+
+    /**
+     * minimum TTL field that should be exported with any RR from this zone.
+     * 
+     * @since 1.3
+     */
+    public int minimum() {
         return minimum;
     }
 
@@ -130,7 +207,7 @@ public class SOAData extends ForwardingMap<String, Object> {
         private int minimum = -1;
 
         /**
-         * @see SOAData#getMname()
+         * @see SOAData#mname()
          */
         public SOAData.Builder mname(String mname) {
             this.mname = mname;
@@ -138,7 +215,7 @@ public class SOAData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SOAData#getRname()
+         * @see SOAData#rname()
          */
         public SOAData.Builder rname(String rname) {
             this.rname = rname;
@@ -146,7 +223,7 @@ public class SOAData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SOAData#getSerial()
+         * @see SOAData#serial()
          */
         public SOAData.Builder serial(int serial) {
             this.serial = serial;
@@ -154,7 +231,7 @@ public class SOAData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SOAData#getRefresh()
+         * @see SOAData#refresh()
          */
         public SOAData.Builder refresh(int refresh) {
             this.refresh = refresh;
@@ -162,7 +239,7 @@ public class SOAData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SOAData#getRetry()
+         * @see SOAData#retry()
          */
         public SOAData.Builder retry(int retry) {
             this.retry = retry;
@@ -170,7 +247,7 @@ public class SOAData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SOAData#getExpire()
+         * @see SOAData#expire()
          */
         public SOAData.Builder expire(int expire) {
             this.expire = expire;
@@ -178,7 +255,7 @@ public class SOAData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SOAData#getMinimum()
+         * @see SOAData#minimum()
          */
         public SOAData.Builder minimum(int minimum) {
             this.minimum = minimum;
@@ -190,8 +267,8 @@ public class SOAData extends ForwardingMap<String, Object> {
         }
 
         public SOAData.Builder from(SOAData in) {
-            return this.mname(in.getMname()).rname(in.getRname()).serial(in.getSerial()).refresh(in.getRefresh())
-                    .expire(in.getExpire()).minimum(in.getMinimum());
+            return this.mname(in.mname()).rname(in.rname()).serial(in.serial()).refresh(in.refresh())
+                    .expire(in.expire()).minimum(in.minimum());
         }
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/SPFData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SPFData.java
@@ -36,9 +36,20 @@ public class SPFData extends ForwardingMap<String, Object> {
     }
 
     /**
-     * One or more character-strings.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #txtdata()}
      */
+    @Deprecated
     public String getTxtdata() {
+        return txtdata();
+    }
+
+    /**
+     * One or more character-strings.
+     * 
+     * @since 1.3
+     */
+    public String txtdata() {
         return txtdata;
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/SRVData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SRVData.java
@@ -48,36 +48,80 @@ public class SRVData extends ForwardingMap<String, Object> {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #priority()}
+     */
+    @Deprecated
+    public int getPriority() {
+        return priority();
+    }
+
+    /**
      * The priority of this target host. A client MUST attempt to contact the
      * target host with the lowest-numbered priority it can reach; target hosts
      * with the same priority SHOULD be tried in an order defined by the weight
      * field.
+     * 
+     * @since 1.3
      */
-    public int getPriority() {
+    public int priority() {
         return priority;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #weight()}
+     */
+    @Deprecated
+    public int getWeight() {
+        return weight();
     }
 
     /**
      * The weight field specifies a relative weight for entries with the same
      * priority. Larger weights SHOULD be given a proportionately higher
      * probability of being selected.
+     * 
+     * @since 1.3
      */
-    public int getWeight() {
+    public int weight() {
         return weight;
     }
 
     /**
-     * The port on this target host of this service.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #port()}
      */
+    @Deprecated
     public int getPort() {
+        return port();
+    }
+
+    /**
+     * The port on this target host of this service.
+     * 
+     * @since 1.3
+     */
+    public int port() {
         return port;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #target()}
+     */
+    @Deprecated
+    public String getTarget() {
+        return target();
     }
 
     /**
      * The domain name of the target host. There MUST be one or more address
      * records for this name, the name MUST NOT be an alias.
+     * 
+     * @since 1.3
      */
-    public String getTarget() {
+    public String target() {
         return target;
     }
 
@@ -92,7 +136,7 @@ public class SRVData extends ForwardingMap<String, Object> {
         private String target;
 
         /**
-         * @see SRVData#getPriority()
+         * @see SRVData#priority()
          */
         public SRVData.Builder priority(int priority) {
             this.priority = priority;
@@ -100,7 +144,7 @@ public class SRVData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SRVData#getWeight()
+         * @see SRVData#weight()
          */
         public SRVData.Builder weight(int weight) {
             this.weight = weight;
@@ -108,7 +152,7 @@ public class SRVData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SRVData#getPort()
+         * @see SRVData#port()
          */
         public SRVData.Builder port(int port) {
             this.port = port;
@@ -116,7 +160,7 @@ public class SRVData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SRVData#getTarget()
+         * @see SRVData#target()
          */
         public SRVData.Builder target(String target) {
             this.target = target;
@@ -128,7 +172,7 @@ public class SRVData extends ForwardingMap<String, Object> {
         }
 
         public SRVData.Builder from(SRVData in) {
-            return this.priority(in.getPriority()).weight(in.getWeight()).port(in.getPort()).target(in.getTarget());
+            return this.priority(in.priority()).weight(in.weight()).port(in.port()).target(in.target());
         }
     }
 

--- a/denominator-model/src/main/java/denominator/model/rdata/SSHFPData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/SSHFPData.java
@@ -59,11 +59,31 @@ public class SSHFPData extends ForwardingMap<String, Object> {
     }
 
     /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #algorithm()}
+     */
+    @Deprecated
+    public int getAlgorithm() {
+        return algorithm();
+    }
+
+    /**
      * This algorithm number octet describes the algorithm of the public key.
      * @return most often {@code 1} for {@code RSA} or {@code 2} for {@code DSA}. 
+     * 
+     * @since 1.3
      */
-    public int getAlgorithm() {
+    public int algorithm() {
         return algorithm;
+    }
+
+    /**
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #fptype()}
+     */
+    @Deprecated
+    public int getType() {
+        return fptype();
     }
 
     /**
@@ -71,15 +91,28 @@ public class SSHFPData extends ForwardingMap<String, Object> {
      * calculate the fingerprint of the public key.
      * 
      * @return most often {@code 1} for {@code SHA-1}
+     * 
+     * @since 1.3
      */
-    public int getType() {
+    public int fptype() {
         return fptype;
     }
 
     /**
-     * The fingerprint calculated over the public key blob.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #fingerprint()}
      */
+    @Deprecated
     public String getFingerprint() {
+        return fingerprint();
+    }
+
+    /**
+     * The fingerprint calculated over the public key blob.
+     * 
+     * @since 1.3
+     */
+    public String fingerprint() {
         return fingerprint;
     }
 
@@ -89,7 +122,7 @@ public class SSHFPData extends ForwardingMap<String, Object> {
         private String fingerprint;
 
         /**
-         * @see SSHFPData#getAlgorithm()
+         * @see SSHFPData#algorithm()
          */
         public SSHFPData.Builder algorithm(int algorithm) {
             this.algorithm = algorithm;
@@ -97,7 +130,7 @@ public class SSHFPData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SSHFPData#getType()
+         * @see SSHFPData#fptype()
          */
         public SSHFPData.Builder fptype(int fptype) {
             this.fptype = fptype;
@@ -105,7 +138,7 @@ public class SSHFPData extends ForwardingMap<String, Object> {
         }
 
         /**
-         * @see SSHFPData#getFingerprint()
+         * @see SSHFPData#fingerprint()
          */
         public SSHFPData.Builder fingerprint(String fingerprint) {
             this.fingerprint = fingerprint;

--- a/denominator-model/src/main/java/denominator/model/rdata/TXTData.java
+++ b/denominator-model/src/main/java/denominator/model/rdata/TXTData.java
@@ -36,15 +36,26 @@ public class TXTData extends ForwardingMap<String, Object> {
     }
 
     /**
-     * One or more character-strings.
+     * @deprecated Will be removed in denominator 2.0. Please use
+     *             {@link #txtdata()}
      */
+    @Deprecated
     public String getTxtdata() {
+        return txtdata();
+    }
+
+    /**
+     * One or more character-strings.
+     * 
+     * @since 1.3
+     */
+    public String txtdata() {
         return txtdata;
     }
 
     // transient to avoid serializing by default, for example in json
     private final transient ImmutableMap<String, Object> delegate;
-    
+
     @Override
     protected Map<String, Object> delegate() {
         return delegate;

--- a/denominator-model/src/test/java/denominator/model/ResourceRecordSetTest.java
+++ b/denominator-model/src/test/java/denominator/model/ResourceRecordSetTest.java
@@ -17,10 +17,10 @@ public class ResourceRecordSetTest {
                                                            .ttl(3600)
                                                            .add(AData.create("192.0.2.1")).build();
 
-        assertEquals(record.getName(), "www.denominator.io.");
-        assertEquals(record.getType(), "A");
-        assertEquals(record.getTTL().get(), Integer.valueOf(3600));
-        assertEquals(record.get(0), AData.create("192.0.2.1"));
+        assertEquals(record.name(), "www.denominator.io.");
+        assertEquals(record.type(), "A");
+        assertEquals(record.ttl().get(), Integer.valueOf(3600));
+        assertEquals(record.rdata().get(0), AData.create("192.0.2.1"));
     }
 
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "rdata")

--- a/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -42,7 +42,7 @@ public class ResourceRecordSetsTest {
                                                      .add(AData.create("192.0.2.1")).build();
 
     public void nameEqualToReturnsFalseOnNull() {
-        assertFalse(ResourceRecordSets.nameEqualTo(aRRS.getName()).apply(null));
+        assertFalse(ResourceRecordSets.nameEqualTo(aRRS.name()).apply(null));
     }
 
     public void nameEqualToReturnsFalseOnDifferentName() {
@@ -50,11 +50,11 @@ public class ResourceRecordSetsTest {
     }
 
     public void nameEqualToReturnsTrueOnSameName() {
-        assertTrue(ResourceRecordSets.nameEqualTo(aRRS.getName()).apply(aRRS));
+        assertTrue(ResourceRecordSets.nameEqualTo(aRRS.name()).apply(aRRS));
     }
 
     public void typeEqualToReturnsFalseOnNull() {
-        assertFalse(ResourceRecordSets.typeEqualTo(aRRS.getType()).apply(null));
+        assertFalse(ResourceRecordSets.typeEqualTo(aRRS.type()).apply(null));
     }
 
     public void typeEqualToReturnsFalseOnDifferentType() {
@@ -62,11 +62,11 @@ public class ResourceRecordSetsTest {
     }
 
     public void typeEqualToReturnsTrueOnSameType() {
-        assertTrue(ResourceRecordSets.typeEqualTo(aRRS.getType()).apply(aRRS));
+        assertTrue(ResourceRecordSets.typeEqualTo(aRRS.type()).apply(aRRS));
     }
 
     public void containsRDataReturnsFalseOnNull() {
-        assertFalse(ResourceRecordSets.containsRData(aRRS.get(0)).apply(null));
+        assertFalse(ResourceRecordSets.containsRData(aRRS.rdata().get(0)).apply(null));
     }
 
     public void containsRDataReturnsFalseWhenRDataDifferent() {
@@ -257,9 +257,9 @@ public class ResourceRecordSetsTest {
     @Test(dataProvider = "a")
     public void shortFormEqualsLongForm(ResourceRecordSet<?> shortForm, ResourceRecordSet<?> longForm) {
         assertEquals(shortForm, longForm);
-        assertEquals(shortForm.getName(), longForm.getName());
-        assertEquals(shortForm.getType(), longForm.getType());
-        assertEquals(shortForm.getTTL(), longForm.getTTL());
+        assertEquals(shortForm.name(), longForm.name());
+        assertEquals(shortForm.type(), longForm.type());
+        assertEquals(shortForm.ttl(), longForm.ttl());
         assertEquals(ImmutableList.copyOf(shortForm), ImmutableList.copyOf(longForm));
     }
 }

--- a/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSResourceRecordSetApi.java
+++ b/providers/denominator-clouddns/src/main/java/denominator/clouddns/CloudDNSResourceRecordSetApi.java
@@ -37,7 +37,13 @@ public final class CloudDNSResourceRecordSetApi implements denominator.ResourceR
     }
 
     @Override
+    @Deprecated
     public Iterator<ResourceRecordSet<?>> listByName(String name) {
+        return iterateByName(name);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
         checkNotNull(name, "name was null");
         return Iterators.filter(iterator(), nameEqualTo(name));
     }

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
@@ -2,7 +2,7 @@ package denominator.clouddns;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
-import static denominator.Denominator.listProviders;
+import static denominator.Denominator.providers;
 import static denominator.Denominator.provider;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -33,7 +33,7 @@ public class CloudDNSProviderTest {
 
     @Test
     public void testCloudDNSRegistered() {
-        Set<Provider> allProviders = ImmutableSet.copyOf(listProviders());
+        Set<Provider> allProviders = ImmutableSet.copyOf(providers());
         assertTrue(allProviders.contains(PROVIDER));
     }
 

--- a/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
+++ b/providers/denominator-clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
@@ -50,8 +50,8 @@ public class CloudDNSResourceRecordSetApiMockTest {
             while (records.hasNext()) {
                 ResourceRecordSet<?> record = records.next();
                 
-                assertEquals(record.getName(), "www.denominator.io");
-                assertEquals(record.getTTL().get().intValue(), 600000);
+                assertEquals(record.name(), "www.denominator.io");
+                assertEquals(record.ttl().get().intValue(), 600000);
             }
 
             assertEquals(server.getRequestCount(), 2);
@@ -107,8 +107,8 @@ public class CloudDNSResourceRecordSetApiMockTest {
             while (records.hasNext()) {
                 ResourceRecordSet<?> record = records.next();
                 
-                assertEquals(record.getName(), "www.denominator.io");
-                assertEquals(record.getTTL().get().intValue(), 600000);
+                assertEquals(record.name(), "www.denominator.io");
+                assertEquals(record.ttl().get().intValue(), 600000);
             }
 
             assertEquals(server.getRequestCount(), 3);
@@ -123,7 +123,7 @@ public class CloudDNSResourceRecordSetApiMockTest {
     String recordsByName = "{\"records\":[{\"name\":\"www.denominator.io\",\"id\":\"A-9872761\",\"type\":\"A\",\"data\":\"1.2.3.4\",\"ttl\":600000,\"updated\":\"2013-04-13T14:42:00.000+0000\",\"created\":\"2013-04-13T14:42:00.000+0000\"},{\"name\":\"www.denominator.io\",\"id\":\"NS-8703385\",\"type\":\"NS\",\"data\":\"dns1.stabletransit.com\",\"ttl\":600000,\"updated\":\"2013-04-13T14:42:00.000+0000\",\"created\":\"2013-04-13T14:42:00.000+0000\"},{\"name\":\"www.denominator.io\",\"id\":\"NS-8703386\",\"type\":\"NS\",\"data\":\"dns2.stabletransit.com\",\"ttl\":600000,\"updated\":\"2013-04-13T14:42:00.000+0000\",\"created\":\"2013-04-13T14:42:00.000+0000\"}],\"totalEntries\":3}";
 
     @Test
-    public void listByNameWhenPresent() throws IOException, InterruptedException {
+    public void iterateByNameWhenPresent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.play();
 
@@ -135,13 +135,13 @@ public class CloudDNSResourceRecordSetApiMockTest {
 
         try {
             ResourceRecordSetApi api = mockApi(url);
-            Iterator<ResourceRecordSet<?>> records = api.listByName("www.denominator.io");
+            Iterator<ResourceRecordSet<?>> records = api.iterateByName("www.denominator.io");
             
             while (records.hasNext()) {
             	ResourceRecordSet<?> record = records.next();
             	
-            	assertEquals(record.getName(), "www.denominator.io");
-            	assertEquals(record.getTTL().get().intValue(), 600000);
+            	assertEquals(record.name(), "www.denominator.io");
+            	assertEquals(record.ttl().get().intValue(), 600000);
             }
 
             assertEquals(server.getRequestCount(), 2);
@@ -153,7 +153,7 @@ public class CloudDNSResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenAbsent() throws IOException, InterruptedException {
+    public void iterateByNameWhenAbsent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.play();
 
@@ -165,7 +165,7 @@ public class CloudDNSResourceRecordSetApiMockTest {
 
         try {
             ResourceRecordSetApi api = mockApi(url);
-            assertFalse(api.listByName("www.denominator.io").hasNext());
+            assertFalse(api.iterateByName("www.denominator.io").hasNext());
 
             assertEquals(server.getRequestCount(), 2);
             assertEquals(server.takeRequest().getRequestLine(), "POST /tokens HTTP/1.1");

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTGeoResourceRecordSetApi.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTGeoResourceRecordSetApi.java
@@ -41,12 +41,24 @@ public final class DynECTGeoResourceRecordSetApi implements GeoResourceRecordSet
     }
 
     @Override
+    @Deprecated
     public Set<String> getSupportedTypes() {
+        return supportedTypes();
+    }
+
+    @Override
+    public Set<String> supportedTypes() {
         return types;
     }
 
     @Override
+    @Deprecated
     public Multimap<String, String> getSupportedRegions() {
+        return supportedRegions();
+    }
+
+    @Override
+    public Multimap<String, String> supportedRegions() {
         return regions;
     }
 
@@ -62,13 +74,25 @@ public final class DynECTGeoResourceRecordSetApi implements GeoResourceRecordSet
     }
 
     @Override
-    public Iterator<ResourceRecordSet<?>> listByName(String fqdn) {
+    @Deprecated
+    public Iterator<ResourceRecordSet<?>> listByName(String name) {
+        return iterateByName(name);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByName(String fqdn) {
         checkNotNull(fqdn, "fqdn was null");
         return geoServices(withNode(fqdn)).transformAndConcat(geoToRRSets).iterator();
     }
 
     @Override
-    public Iterator<ResourceRecordSet<?>> listByNameAndType(String fqdn, String type) {
+    @Deprecated
+    public Iterator<ResourceRecordSet<?>> listByNameAndType(String name, String type) {
+        return iterateByNameAndType(name, type);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String fqdn, String type) {
         checkNotNull(fqdn, "fqdn was null");
         checkNotNull(type, "type was null");
         return geoServices(withNode(fqdn)).transformAndConcat(geoToRRSets.type(type)).iterator();

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/GeoServiceToResourceRecordSets.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/GeoServiceToResourceRecordSets.java
@@ -32,7 +32,7 @@ final class GeoServiceToResourceRecordSets implements Function<GeoService, Itera
 
     /**
      * @param countryIndexer
-     *            {@link Geo#getRegions()} is indexed, but
+     *            {@link Geo#regions()} is indexed, but
      *            {@link GeoRegionGroup#getCountries()} is not. This function
      *            will index the countries so that they match the denominator
      *            model.
@@ -106,7 +106,7 @@ final class GeoServiceToResourceRecordSets implements Function<GeoService, Itera
 
     /**
      * the dynect {@code RecordSet} doesn't include
-     * {@link ResourceRecordSet#getName()}. This collects all details except the
+     * {@link ResourceRecordSet#name()}. This collects all details except the
      * name. The result of this function would be applied to all relevant
      * {@link GeoService#getNodes() nodes}.
      * 

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTGeoResourceRecordSetApiMockTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTGeoResourceRecordSetApiMockTest.java
@@ -92,7 +92,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenPresent() throws IOException, InterruptedException {
+    public void iterateByNameWhenPresent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
         server.enqueue(new MockResponse().setResponseCode(200).setBody(geoService));
@@ -100,7 +100,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
 
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            Iterator<ResourceRecordSet<?>> iterator = api.listByName("srv.denominator.io");
+            Iterator<ResourceRecordSet<?>> iterator = api.iterateByName("srv.denominator.io");
             assertEquals(iterator.next(), everywhereElse);
             assertEquals(iterator.next(), europe);
             assertEquals(iterator.next(), fallback);
@@ -115,7 +115,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenAbsent() throws IOException, InterruptedException {
+    public void iterateByNameWhenAbsent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
         server.enqueue(new MockResponse().setResponseCode(200).setBody(noGeoServices));
@@ -123,7 +123,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
 
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertFalse(api.listByName("www.denominator.io").hasNext());
+            assertFalse(api.iterateByName("www.denominator.io").hasNext());
 
             assertEquals(server.getRequestCount(), 2);
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");
@@ -134,7 +134,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameAndTypeWhenPresent() throws IOException, InterruptedException {
+    public void iterateByNameAndTypeWhenPresent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
         server.enqueue(new MockResponse().setResponseCode(200).setBody(geoService));
@@ -142,7 +142,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
 
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            Iterator<ResourceRecordSet<?>> iterator = api.listByNameAndType("srv.denominator.io", "CNAME");
+            Iterator<ResourceRecordSet<?>> iterator = api.iterateByNameAndType("srv.denominator.io", "CNAME");
             assertEquals(iterator.next(), everywhereElse);
             assertEquals(iterator.next(), europe);
             assertEquals(iterator.next(), fallback);
@@ -157,7 +157,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameAndTypeWhenAbsent() throws IOException, InterruptedException {
+    public void iterateByNameAndTypeWhenAbsent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
         server.enqueue(new MockResponse().setResponseCode(200).setBody(noGeoServices));
@@ -165,7 +165,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
 
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertFalse(api.listByNameAndType("www.denominator.io", "A").hasNext());
+            assertFalse(api.iterateByNameAndType("www.denominator.io", "A").hasNext());
 
             assertEquals(server.getRequestCount(), 2);
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTProviderTest.java
@@ -2,7 +2,7 @@ package denominator.dynect;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
-import static denominator.Denominator.listProviders;
+import static denominator.Denominator.providers;
 import static denominator.Denominator.provider;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -33,7 +33,7 @@ public class DynECTProviderTest {
 
     @Test
     public void testDynECTRegistered() {
-        Set<Provider> allProviders = ImmutableSet.copyOf(listProviders());
+        Set<Provider> allProviders = ImmutableSet.copyOf(providers());
         assertTrue(allProviders.contains(PROVIDER));
     }
 

--- a/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTResourceRecordSetApiMockTest.java
+++ b/providers/denominator-dynect/src/test/java/denominator/dynect/DynECTResourceRecordSetApiMockTest.java
@@ -333,7 +333,7 @@ public class DynECTResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenPresent() throws IOException, InterruptedException {
+    public void iterateByNameWhenPresent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
         server.enqueue(new MockResponse().setResponseCode(200).setBody(recordsByName));
@@ -341,7 +341,7 @@ public class DynECTResourceRecordSetApiMockTest {
 
         try {
             ResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertEquals(api.listByName("www.denominator.io").next(),
+            assertEquals(api.iterateByName("www.denominator.io").next(),
                     a("www.denominator.io", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
 
             assertEquals(server.getRequestCount(), 2);
@@ -353,7 +353,7 @@ public class DynECTResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenAbsent() throws IOException, InterruptedException {
+    public void iterateByNameWhenAbsent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(session));
         server.enqueue(new MockResponse().setResponseCode(404)); // no existing records
@@ -361,7 +361,7 @@ public class DynECTResourceRecordSetApiMockTest {
 
         try {
             ResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertFalse(api.listByName("www.denominator.io").hasNext());
+            assertFalse(api.iterateByName("www.denominator.io").hasNext());
 
             assertEquals(server.getRequestCount(), 2);
             assertEquals(server.takeRequest().getRequestLine(), "POST /Session HTTP/1.1");

--- a/providers/denominator-route53/src/main/java/denominator/route53/GroupByRecordNameAndTypeIterator.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/GroupByRecordNameAndTypeIterator.java
@@ -30,12 +30,12 @@ class GroupByRecordNameAndTypeIterator implements Iterator<ResourceRecordSet<?>>
     @Override
     public ResourceRecordSet<?> next() {
         ResourceRecordSet<?> rrset = peekingIterator.next();
-        while (hasNext() && and(nameEqualTo(rrset.getName()), typeEqualTo(rrset.getType())).apply(peekingIterator.peek())) {
+        while (hasNext() && and(nameEqualTo(rrset.name()), typeEqualTo(rrset.type())).apply(peekingIterator.peek())) {
             ResourceRecordSet<?> next = peekingIterator.next();
             rrset = ResourceRecordSet.builder()
-                                     .name(rrset.getName())
-                                     .type(rrset.getType())
-                                     .ttl(rrset.getTTL().or(next.getTTL()).orNull())
+                                     .name(rrset.name())
+                                     .type(rrset.type())
+                                     .ttl(rrset.ttl().or(next.ttl()).orNull())
                                      .addAll(rrset)
                                      .addAll(next)
                                      .build();

--- a/providers/denominator-route53/src/main/java/denominator/route53/ToRoute53ResourceRecordSet.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/ToRoute53ResourceRecordSet.java
@@ -18,9 +18,9 @@ enum ToRoute53ResourceRecordSet implements Function<ResourceRecordSet<?>, org.jc
     @Override
     public org.jclouds.route53.domain.ResourceRecordSet apply(ResourceRecordSet<?> rrset) {
         return org.jclouds.route53.domain.ResourceRecordSet.builder()
-                .name(rrset.getName())
-                .type(rrset.getType())
-                .ttl(rrset.getTTL().or(300))
+                .name(rrset.name())
+                .type(rrset.type())
+                .ttl(rrset.ttl().or(300))
                 .addAll(toTextFormat(rrset)).build();
     }
 
@@ -28,7 +28,7 @@ enum ToRoute53ResourceRecordSet implements Function<ResourceRecordSet<?>, org.jc
         Builder<String> values = ImmutableList.builder();
         for (Map<String, Object> rdata : rrset) {
             String textFormat = Joiner.on(' ').join(rdata.values());
-            if (ImmutableSet.of("SPF", "TXT").contains(rrset.getType())) {
+            if (ImmutableSet.of("SPF", "TXT").contains(rrset.type())) {
                 textFormat = format("\"%s\"", textFormat);
             }
             values.add(textFormat);

--- a/providers/denominator-route53/src/test/java/denominator/route53/Route53ProviderTest.java
+++ b/providers/denominator-route53/src/test/java/denominator/route53/Route53ProviderTest.java
@@ -2,7 +2,7 @@ package denominator.route53;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
-import static denominator.Denominator.listProviders;
+import static denominator.Denominator.providers;
 import static denominator.Denominator.provider;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -34,7 +34,7 @@ public class Route53ProviderTest {
 
     @Test
     public void testRoute53Registered() {
-        Set<Provider> allProviders = ImmutableSet.copyOf(listProviders());
+        Set<Provider> allProviders = ImmutableSet.copyOf(providers());
         assertTrue(allProviders.contains(PROVIDER));
     }
 

--- a/providers/denominator-route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
+++ b/providers/denominator-route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
@@ -47,14 +47,14 @@ public class Route53ResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWeightedRecordSubsetsAggregateOnNameAndType() throws IOException, InterruptedException {
+    public void iterateByNameWeightedRecordSubsetsAggregateOnNameAndType() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(weightedRecords));
         server.play();
 
         try {
             ResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertEquals(api.listByName("www.denominator.io.").next(),
+            assertEquals(api.iterateByName("www.denominator.io.").next(),
                     cname("www.denominator.io.", 0, ImmutableList.of("www1.denominator.io.", "www2.denominator.io.")));
 
             assertEquals(server.getRequestCount(), 1);
@@ -285,14 +285,14 @@ public class Route53ResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenPresent() throws IOException, InterruptedException {
+    public void iterateByNameWhenPresent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(twoRecords));
         server.play();
 
         try {
             ResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertEquals(api.listByName("www.denominator.io.").next(),
+            assertEquals(api.iterateByName("www.denominator.io.").next(),
                     a("www.denominator.io.", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
 
             assertEquals(server.getRequestCount(), 1);
@@ -305,14 +305,14 @@ public class Route53ResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenAbsent() throws IOException, InterruptedException {
+    public void iterateByNameWhenAbsent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(noRecords));
         server.play();
 
         try {
             ResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertFalse(api.listByName("www.denominator.io.").hasNext());
+            assertFalse(api.iterateByName("www.denominator.io.").hasNext());
 
             assertEquals(server.getRequestCount(), 1);
 

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/GroupGeoRecordByNameTypeIterator.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/GroupGeoRecordByNameTypeIterator.java
@@ -48,10 +48,10 @@ class GroupGeoRecordByNameTypeIterator implements Iterator<ResourceRecordSet<?>>
         /**
          * @param sortedIterator
          *            only contains records with the same
-         *            {@link DirectionalPoolRecordDetail#getName()}, sorted by
-         *            {@link DirectionalRecord#getType()},
+         *            {@link DirectionalPoolRecordDetail#name()}, sorted by
+         *            {@link DirectionalRecord#type()},
          *            {@link DirectionalPoolRecordDetail#getGeolocationGroup()}
-         *            or {@link DirectionalPoolRecordDetail#getGroup()}
+         *            or {@link DirectionalPoolRecordDetail#group()}
          */
         Iterator<ResourceRecordSet<?>> create(Iterator<DirectionalPoolRecordDetail> sortedIterator) {
             LoadingCache<String, Multimap<String, String>> requestScopedGeoCache = 

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
@@ -62,12 +62,24 @@ public final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordS
     }
 
     @Override
+    @Deprecated
     public Set<String> getSupportedTypes() {
+        return supportedTypes();
+    }
+
+    @Override
+    public Set<String> supportedTypes() {
         return types;
     }
 
     @Override
+    @Deprecated
     public Multimap<String, String> getSupportedRegions() {
+        return supportedRegions();
+    }
+
+    @Override
+    public Multimap<String, String> supportedRegions() {
         return regions;
     }
 
@@ -89,12 +101,24 @@ public final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordS
     }
 
     @Override
+    @Deprecated
     public Iterator<ResourceRecordSet<?>> listByName(String name) {
+        return iterateByName(name);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
         return iteratorForDNameAndDirectionalType(checkNotNull(name, "name"), 0);
     }
 
     @Override
+    @Deprecated
     public Iterator<ResourceRecordSet<?>> listByNameAndType(String name, String type) {
+        return iterateByNameAndType(name, type);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type) {
         checkNotNull(name, "name");
         checkNotNull(type, "type");
         if ("CNAME".equals(type)) {

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoSupport.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoSupport.java
@@ -57,7 +57,7 @@ public class UltraDNSGeoSupport {
     @Provides
     @Singleton
     @denominator.config.profile.Geo
-    Multimap<String, String> getRegions(UltraDNSWSApi api) {
+    Multimap<String, String> regions(UltraDNSWSApi api) {
         Builder<String, String> regions = ImmutableMultimap.<String, String> builder();
         for (Entry<IdAndName, Collection<String>> region : api.getRegionsByIdAndName().asMap().entrySet()) {
             regions.putAll(region.getKey().getName(), region.getValue());

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
@@ -226,7 +226,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameWhenPresent() throws IOException, InterruptedException {
+    public void iterateByNameWhenPresent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(getAvailableRegionsResponse));
         server.enqueue(new MockResponse().setResponseCode(200).setBody(getAccountsListOfUserResponse));
@@ -239,7 +239,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
                          
-            Iterator<ResourceRecordSet<?>> iterator = api.listByName("srv.denominator.io.");
+            Iterator<ResourceRecordSet<?>> iterator = api.iterateByName("srv.denominator.io.");
             assertEquals(iterator.next().toString(), europe.toString());
             assertEquals(iterator.next().toString(), everywhereElse.toString());
             assertEquals(iterator.next().toString(), us.toString());
@@ -272,7 +272,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
     }
 
     @Test
-    public void listByNameAndTypeWhenPresent() throws IOException, InterruptedException {
+    public void iterateByNameAndTypeWhenPresent() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(getAvailableRegionsResponse));
         server.enqueue(new MockResponse().setResponseCode(200).setBody(getAccountsListOfUserResponse));
@@ -286,7 +286,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
                          
-            Iterator<ResourceRecordSet<?>> iterator = api.listByNameAndType("srv.denominator.io.", "CNAME");
+            Iterator<ResourceRecordSet<?>> iterator = api.iterateByNameAndType("srv.denominator.io.", "CNAME");
             assertEquals(iterator.next().toString(), europe.toString());
             assertEquals(iterator.next().toString(), everywhereElse.toString());
             assertEquals(iterator.next().toString(), us.toString());
@@ -346,7 +346,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
 
-            Multimap<String, String> regions = toProfile(Geo.class).apply(europe).getRegions();
+            Multimap<String, String> regions = toProfile(Geo.class).apply(europe).regions();
             api.applyRegionsToNameTypeAndGroup(regions, "srv.denominator.io.", "CNAME", "Europe");
 
             assertEquals(server.getRequestCount(), 5);

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSProviderTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSProviderTest.java
@@ -2,7 +2,7 @@ package denominator.ultradns;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
-import static denominator.Denominator.listProviders;
+import static denominator.Denominator.providers;
 import static denominator.Denominator.provider;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -33,7 +33,7 @@ public class UltraDNSProviderTest {
 
     @Test
     public void testUltraDNSRegistered() {
-        Set<Provider> allProviders = ImmutableSet.copyOf(listProviders());
+        Set<Provider> allProviders = ImmutableSet.copyOf(providers());
         assertTrue(allProviders.contains(PROVIDER));
     }
 

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSResourceRecordSetApiMockTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSResourceRecordSetApiMockTest.java
@@ -58,14 +58,14 @@ public class UltraDNSResourceRecordSetApiMockTest {
             "www.denominator.io.", 0);
 
     @Test
-    public void listByNameWhenNoneMatch() throws IOException, InterruptedException {
+    public void iterateByNameWhenNoneMatch() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(noRecords));
         server.play();
 
         try {
             ResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertFalse(api.listByName("www.denominator.io.").hasNext());
+            assertFalse(api.iterateByName("www.denominator.io.").hasNext());
 
             assertEquals(server.getRequestCount(), 1);
 
@@ -85,14 +85,14 @@ public class UltraDNSResourceRecordSetApiMockTest {
             .append(getResourceRecordsOfZoneResponseFooter).toString();
 
     @Test
-    public void listByNameWhenMatch() throws IOException, InterruptedException {
+    public void iterateByNameWhenMatch() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(records1And2));
         server.play();
 
         try {
             ResourceRecordSetApi api = mockApi(server.getUrl("/"));
-            assertEquals(api.listByName("www.denominator.io.").next(),
+            assertEquals(api.iterateByName("www.denominator.io.").next(),
                     a("www.denominator.io.", 3600, ImmutableList.of("192.0.2.1", "198.51.100.1")));
 
             assertEquals(server.getRequestCount(), 1);


### PR DESCRIPTION
This change deprecates remaining naming conventions that use syntax like `getUrl()` or `listByName()` to `url()` or `iterateByName0` to support migration to denominator 2.0.

This also deprecates the list form of ResourceRecordSet, as it gets in the way of extensibility. Previously, RRSet acted as a list of rdata.  Now, users are required to access the rdata as `rrset.rdata()`.  Removing List contract allows ResourceRecordSet to implement a map as necessary (for example, to decorate in new attributes like qualifier).
