### PR TITLE
Profiles like Geo can be specified as maps and serialize naturally as json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### Version 1.4.0
+* Profiles like Geo can be specified as maps and serialize naturally as json.
+
 ### Version 1.3.0
 * Added full write support to `AllProfileResourceRecordSetApi`.
 * Added `Provider.basicRecordTypes()` and `Provider.profileToRecordTypes()` advertizing what record types are supported.

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ subprojects {
         compile     'org.slf4j:slf4j-api:1.7.5'
         testCompile 'org.testng:testng:6.8.1'
         testCompile 'ch.qos.logback:logback-classic:1.0.12'
-        testCompile     'com.google.mockwebserver:mockwebserver:20130505'
+        testCompile 'com.fasterxml.jackson.core:jackson-databind:2.2.0'
+        testCompile 'com.google.mockwebserver:mockwebserver:20130505'
     }
 }

--- a/denominator-cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
+++ b/denominator-cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
@@ -4,7 +4,7 @@ import static com.google.common.collect.Iterators.concat;
 import static com.google.common.collect.Iterators.forArray;
 import static com.google.common.collect.Iterators.transform;
 import static denominator.cli.Denominator.idOrName;
-import static denominator.model.ResourceRecordSets.toProfile;
+import static denominator.model.profile.Geo.asGeo;
 import static java.lang.String.format;
 import io.airlift.command.Arguments;
 import io.airlift.command.Command;
@@ -27,7 +27,6 @@ import denominator.DNSApiManager;
 import denominator.cli.Denominator.DenominatorCommand;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetToString;
 import denominator.model.ResourceRecordSet;
-import denominator.model.profile.Geo;
 import denominator.profile.GeoResourceRecordSetApi;
 
 class GeoResourceRecordSetCommands {
@@ -152,10 +151,9 @@ class GeoResourceRecordSetCommands {
 
         @Override
         public String apply(ResourceRecordSet<?> geoRRS) {
-            Geo geo = toProfile(Geo.class).apply(geoRRS);
             ImmutableList.Builder<String> lines = ImmutableList.<String> builder();
             for (String line : Splitter.on('\n').split(ResourceRecordSetToString.INSTANCE.apply(geoRRS))) {
-                lines.add(new StringBuilder().append(line).append(' ').append(geo.regions()).toString());
+                lines.add(new StringBuilder().append(line).append(' ').append(asGeo(geoRRS).regions()).toString());
             }
             return Joiner.on('\n').join(lines.build());
         }

--- a/denominator-core/src/main/java/denominator/mock/MockWeightedResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/mock/MockWeightedResourceRecordSetApi.java
@@ -17,12 +17,11 @@ import com.google.common.collect.Multimap;
 import denominator.Provider;
 import denominator.model.ResourceRecordSet;
 import denominator.model.Zone;
-import denominator.model.profile.Weighted;
 import denominator.profile.WeightedResourceRecordSetApi;
 
 public final class MockWeightedResourceRecordSetApi extends MockAllProfileResourceRecordSetApi implements
         WeightedResourceRecordSetApi {
-    private static final Predicate<ResourceRecordSet<?>> IS_WEIGHTED = profileContainsType(Weighted.class);
+    private static final Predicate<ResourceRecordSet<?>> IS_WEIGHTED = profileContainsType("weighted");
 
     private final Set<String> supportedTypes;
     private final SortedSet<Integer> supportedWeights;

--- a/denominator-core/src/main/java/denominator/profile/GeoResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/profile/GeoResourceRecordSetApi.java
@@ -106,7 +106,7 @@ public interface GeoResourceRecordSetApi extends QualifiedResourceRecordSetApi {
      *            {@link ResourceRecordSet#name() name} of the rrset
      * @param type
      *            {@link ResourceRecordSet#type() type} of the rrset
-     * @param qualifier
+     * @param group
      *            {@link ResourceRecordSet#qualifier() qualifier} of the rrset
      * 
      * @deprecated Will be removed in denominator 2.0. Please use

--- a/denominator-core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
@@ -3,7 +3,7 @@ package denominator.profile;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterators.size;
 import static com.google.common.collect.Ordering.usingToString;
-import static denominator.model.ResourceRecordSets.toProfile;
+import static denominator.model.profile.Geo.asGeo;
 import static java.lang.String.format;
 import static java.util.logging.Logger.getAnonymousLogger;
 import static org.testng.Assert.assertEquals;
@@ -53,7 +53,7 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
 
                 getAnonymousLogger().info(format("%s ::: geoRRS: %s", manager, geoRRS));
                 recordTypeCounts.getUnchecked(geoRRS.type()).addAndGet(geoRRS.rdata().size());
-                geoRecordCounts.getUnchecked(toProfile(Geo.class).apply(geoRRS)).addAndGet(geoRRS.rdata().size());
+                geoRecordCounts.getUnchecked(asGeo(geoRRS)).addAndGet(geoRRS.rdata().size());
                 
                 Iterator<ResourceRecordSet<?>> byNameAndType = geoApi(zone).iterateByNameAndType(geoRRS.name(), geoRRS.type());
                 assertTrue(byNameAndType.hasNext(), "could not list by name and type: " + geoRRS);
@@ -72,7 +72,7 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
         assertFalse(geoRRS.profiles().isEmpty(), "Profile absent: " + geoRRS);
         checkNotNull(geoRRS.qualifier().orNull(), "Qualifier: ResourceRecordSet %s", geoRRS);
 
-        Geo geo = toProfile(Geo.class).apply(geoRRS);
+        Geo geo = asGeo(geoRRS);
         assertTrue(!geo.regions().isEmpty(), "Regions empty on Geo: " + geoRRS);
         
         // TODO: remove in 2.0

--- a/denominator-core/src/test/java/denominator/profile/BaseWeightedReadOnlyLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseWeightedReadOnlyLiveTest.java
@@ -2,7 +2,7 @@ package denominator.profile;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Ordering.usingToString;
-import static denominator.model.ResourceRecordSets.toProfile;
+import static denominator.model.profile.Weighted.asWeighted;
 import static java.lang.String.format;
 import static java.util.logging.Logger.getAnonymousLogger;
 import static org.testng.Assert.assertEquals;
@@ -42,13 +42,13 @@ public abstract class BaseWeightedReadOnlyLiveTest extends BaseProviderLiveTest 
                 assertTrue(weightedRRS.qualifier().isPresent(), "Weighted record sets should include a qualifier: " + weightedRRS);
                 checkWeightedRRS(weightedRRS);
 
-                Weighted weighted = toProfile(Weighted.class).apply(weightedRRS);
+                Weighted weighted = asWeighted(weightedRRS);
                 assertTrue(weightedApi(zone).supportedWeights().contains(weighted.weight()));
                 assertTrue(manager.provider().profileToRecordTypes().get("weighted").contains(weightedRRS.type()));
 
                 getAnonymousLogger().info(format("%s ::: weightedRRS: %s", manager, weightedRRS));
                 recordTypeCounts.getUnchecked(weightedRRS.type()).addAndGet(weightedRRS.rdata().size());
-                weightedRecordCounts.getUnchecked(toProfile(Weighted.class).apply(weightedRRS)).addAndGet(weightedRRS.rdata().size());
+                weightedRecordCounts.getUnchecked(asWeighted(weightedRRS)).addAndGet(weightedRRS.rdata().size());
                 
                 Iterator<ResourceRecordSet<?>> byNameAndType = weightedApi(zone).iterateByNameAndType(weightedRRS.name(), weightedRRS.type());
                 assertTrue(byNameAndType.hasNext(), "could not list by name and type: " + weightedRRS);
@@ -67,7 +67,7 @@ public abstract class BaseWeightedReadOnlyLiveTest extends BaseProviderLiveTest 
         assertFalse(weightedRRS.profiles().isEmpty(), "Profile absent: " + weightedRRS);
         checkNotNull(weightedRRS.qualifier().orNull(), "Qualifier: ResourceRecordSet %s", weightedRRS);
 
-        Weighted weighted = toProfile(Weighted.class).apply(weightedRRS);
+        Weighted weighted = asWeighted(weightedRRS);
         assertTrue(weighted.weight() >= 0, "Weight negative on ResourceRecordSet: " + weightedRRS);
         
         checkNotNull(weightedRRS.name(), "Name: ResourceRecordSet %s", weightedRRS);

--- a/denominator-model/src/main/java/denominator/model/profile/Weighted.java
+++ b/denominator-model/src/main/java/denominator/model/profile/Weighted.java
@@ -1,12 +1,15 @@
 package denominator.model.profile;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static denominator.model.ResourceRecordSets.tryFindProfile;
 
 import java.beans.ConstructorProperties;
 import java.util.Map;
 
 import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.ImmutableMap;
+
+import denominator.model.ResourceRecordSet;
 
 /**
  * Record sets with this profile are load balanced, differentiated by an integer
@@ -21,6 +24,30 @@ import com.google.common.collect.ImmutableMap;
  * @since 1.3
  */
 public class Weighted extends ForwardingMap<String, Object> {
+
+    /**
+     * returns a Weighted view of the {@code profile} or null if no weighted
+     * profile found.
+     * 
+     * @since 1.4.0
+     */
+    public static Weighted asWeighted(Map<String, Object> profile) {
+        if (profile == null)
+            return null;
+        if (profile instanceof Weighted)
+            return Weighted.class.cast(profile);
+        return new Weighted(Integer.class.cast(profile.get("weight")));
+    }
+
+    /**
+     * returns a Weighted view of the {@code rrset} or null if no weighted
+     * profile found.
+     * 
+     * @since 1.4.0
+     */
+    public static Weighted asWeighted(ResourceRecordSet<?> rrset) {
+        return asWeighted(tryFindProfile(rrset, "weighted").orNull());
+    }
 
     /**
      * @param weight

--- a/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -2,11 +2,12 @@ package denominator.model;
 
 import static denominator.model.ResourceRecordSets.a;
 import static denominator.model.ResourceRecordSets.cname;
-import static denominator.model.ResourceRecordSets.profileContainsType;
 import static denominator.model.ResourceRecordSets.ns;
+import static denominator.model.ResourceRecordSets.profileContainsType;
 import static denominator.model.ResourceRecordSets.ptr;
 import static denominator.model.ResourceRecordSets.spf;
 import static denominator.model.ResourceRecordSets.toProfile;
+import static denominator.model.ResourceRecordSets.tryFindProfile;
 import static denominator.model.ResourceRecordSets.txt;
 import static denominator.model.ResourceRecordSets.withoutProfile;
 import static org.testng.Assert.assertEquals;
@@ -18,6 +19,7 @@ import java.util.Map;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -120,22 +122,43 @@ public class ResourceRecordSetsTest {
         assertTrue(withoutProfile().apply(aRRS));
     }
 
-    public void profileContainsTypeReturnsFalseOnNull() {
+    @Deprecated
+    public void deprecatedProfileContainsTypeReturnsFalseOnNull() {
         assertFalse(profileContainsType(Geo.class).apply(null));
     }
 
-    public void profileContainsTypeReturnsFalseOnDifferentType() {
+    @Deprecated
+    public void deprecatedProfileContainsTypeReturnsFalseOnDifferentType() {
         assertFalse(profileContainsType(String.class).apply(geoRRS));
     }
 
-    public void profileContainsTypeReturnsFalseOnAbsent() {
+    @Deprecated
+    public void deprecatedProfileContainsTypeReturnsFalseOnAbsent() {
         assertFalse(profileContainsType(Geo.class).apply(aRRS));
     }
 
-    public void profileContainsTypeReturnsTrueOnSameType() {
+    @Deprecated
+    public void deprecatedProfileContainsTypeReturnsTrueOnSameType() {
         assertTrue(profileContainsType(Geo.class).apply(geoRRS));
     }
 
+    public void profileContainsTypeReturnsFalseOnNull() {
+        assertFalse(profileContainsType("geo").apply(null));
+    }
+
+    public void profileContainsTypeReturnsFalseOnDifferentType() {
+        assertFalse(profileContainsType("weighted").apply(geoRRS));
+    }
+
+    public void profileContainsTypeReturnsFalseOnAbsent() {
+        assertFalse(profileContainsType("geo").apply(aRRS));
+    }
+
+    public void profileContainsTypeReturnsTrueOnSameType() {
+        assertTrue(profileContainsType("geo").apply(geoRRS));
+    }
+
+    @Deprecated
     public void toProfileReturnsNullOnNull() {
         assertEquals(toProfile(Geo.class).apply(null), null);
     }
@@ -149,16 +172,27 @@ public class ResourceRecordSetsTest {
 
     }
 
+    @Deprecated
     public void toProfileReturnsNullOnDifferentType() {
         assertEquals(toProfile(Foo.class).apply(geoRRS), null);
     }
 
+    @Deprecated
     public void toProfileReturnsNullOnAbsent() {
         assertEquals(toProfile(Geo.class).apply(aRRS), null);
     }
 
+    @Deprecated
     public void toProfileReturnsProfileOnSameType() {
         assertEquals(toProfile(Geo.class).apply(geoRRS), geo);
+    }
+
+    public void tryFindProfileReturnsAbsentOnDifferentType() {
+        assertEquals(tryFindProfile(aRRS, "geo"), Optional.absent());
+    }
+
+    public void tryFindProfileReturnsProfileOnSameType() {
+        assertEquals(tryFindProfile(geoRRS, "geo").get(), geo);
     }
 
     public void toProfileTypesEmptyOnBasicRRSet() {

--- a/denominator-model/src/test/java/denominator/model/profile/GeoTest.java
+++ b/denominator-model/src/test/java/denominator/model/profile/GeoTest.java
@@ -1,0 +1,83 @@
+package denominator.model.profile;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+
+import denominator.model.ResourceRecordSet;
+import denominator.model.rdata.AData;
+
+@Test
+public class GeoTest {
+
+    Geo geo = Geo.create(ImmutableMultimap.<String, String> builder()//
+            .put("US", "US-VA")//
+            .put("US", "US-CA")//
+            .put("IM", "IM").build());
+
+    String asJson = "{\"type\":\"geo\",\"regions\":{\"US\":[\"US-VA\",\"US-CA\"],\"IM\":[\"IM\"]}}";
+
+    public void serializeNaturallyAsJson() throws JsonProcessingException {
+        assertEquals(new ObjectMapper().writeValueAsString(geo), asJson);
+    }
+
+    public void equalToDeserializedMap() throws IOException {
+        assertEquals(new ObjectMapper().readValue(asJson, new TypeReference<Map<String, Object>>() {
+        }), geo);
+    }
+
+    Map<String, Object> geoWhereRegionsAreMapStringCollectionString = ImmutableMap.<String, Object> builder()//
+            .put("type", "geo")//
+            .put("regions", ImmutableMultimap.<String, String> builder()//
+                    .put("US", "US-VA")//
+                    .put("US", "US-CA")//
+                    .put("IM", "IM").build().asMap()).build();
+
+    public void asGeo() {
+        assertEquals(Geo.asGeo(geoWhereRegionsAreMapStringCollectionString), geo);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "expected profile to have a Map<String, Collection<String>> regions field, not class com.google.common.collect.ImmutableListMultimap")
+    public void asGeoNoGuavaAllowed() {
+        Map<String, Object> geoWhereRegionsAreMultimapStringString = ImmutableMap.<String, Object> builder()//
+                .put("type", "geo")//
+                .put("regions", ImmutableMultimap.<String, String> builder()//
+                        .put("US", "US-VA")//
+                        .put("US", "US-CA")//
+                        .put("IM", "IM").build()).build();
+
+        Geo.asGeo(geoWhereRegionsAreMultimapStringString);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "expected regions values to be a subtype of Iterable<String>, not String")
+    public void asGeoMultivalueTerritories() {
+        Map<String, Object> geoWhereRegionsAreMultimapStringString = ImmutableMap.<String, Object> builder()//
+                .put("type", "geo")//
+                .put("regions", ImmutableMap.<String, String> builder()//
+                        .put("US", "US-VA")//
+                        .put("IM", "IM").build()).build();
+
+        Geo.asGeo(geoWhereRegionsAreMultimapStringString);
+    }
+
+    ResourceRecordSet<AData> geoRRS = ResourceRecordSet.<AData> builder()//
+            .name("www.denominator.io.")//
+            .type("A")//
+            .qualifier("US-East")//
+            .ttl(3600)//
+            .add(AData.create("1.1.1.1"))//
+            .addProfile(geoWhereRegionsAreMapStringCollectionString).build();
+
+    public void asGeoRRSet() {
+        assertEquals(Geo.asGeo(geoRRS), geo);
+    }
+}

--- a/denominator-model/src/test/java/denominator/model/profile/WeightedTest.java
+++ b/denominator-model/src/test/java/denominator/model/profile/WeightedTest.java
@@ -1,11 +1,57 @@
 package denominator.model.profile;
 
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Map;
+
 import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import denominator.model.ResourceRecordSet;
+import denominator.model.rdata.AData;
 
 @Test
 public class WeightedTest {
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "weight must be positive")
     public void testInvalidWeight() {
         Weighted.create(-1);
+    }
+
+    Weighted weighted = Weighted.create(2);
+
+    String asJson = "{\"type\":\"weighted\",\"weight\":2}";
+
+    public void serializeNaturallyAsJson() throws JsonProcessingException {
+        assertEquals(new ObjectMapper().writeValueAsString(weighted), asJson);
+    }
+
+    public void equalToDeserializedMap() throws IOException {
+        assertEquals(new ObjectMapper().readValue(asJson, new TypeReference<Map<String, Object>>() {
+        }), weighted);
+    }
+
+    Map<String, Object> weightedMap = ImmutableMap.<String, Object> builder()//
+            .put("type", "weighted")//
+            .put("weight", 2).build();
+
+    public void asWeighted() {
+        assertEquals(Weighted.asWeighted(weightedMap), weighted);
+    }
+
+    ResourceRecordSet<AData> weightedRRS = ResourceRecordSet.<AData> builder()//
+            .name("www.denominator.io.")//
+            .type("A")//
+            .qualifier("US-East")//
+            .ttl(3600)//
+            .add(AData.create("1.1.1.1"))//
+            .addProfile(weightedMap).build();
+
+    public void asWeightedRRSet() {
+        assertEquals(Weighted.asWeighted(weightedRRS), weighted);
     }
 }

--- a/providers/denominator-route53/src/main/java/denominator/route53/Route53WeightedResourceRecordSetApi.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/Route53WeightedResourceRecordSetApi.java
@@ -33,8 +33,7 @@ import denominator.model.ResourceRecordSet;
 import denominator.profile.WeightedResourceRecordSetApi;
 
 final class Route53WeightedResourceRecordSetApi implements WeightedResourceRecordSetApi {
-    private static final Predicate<ResourceRecordSet<?>> IS_WEIGHTED =
-            profileContainsType(denominator.model.profile.Weighted.class);
+    private static final Predicate<ResourceRecordSet<?>> IS_WEIGHTED = profileContainsType("weighted");
 
     private final ResourceRecordSetApi route53RRsetApi;
     private final Set<String> supportedTypes;

--- a/providers/denominator-route53/src/main/java/denominator/route53/ToRoute53ResourceRecordSet.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/ToRoute53ResourceRecordSet.java
@@ -1,5 +1,5 @@
 package denominator.route53;
-import static denominator.model.ResourceRecordSets.toProfile;
+import static denominator.model.profile.Weighted.asWeighted;
 import static java.lang.String.format;
 
 import java.util.List;
@@ -26,7 +26,7 @@ enum ToRoute53ResourceRecordSet implements Function<ResourceRecordSet<?>, org.jc
                                                             .id(rrset.qualifier().orNull())
                                                             .ttl(rrset.ttl().or(300))
                                                             .addAll(toTextFormat(rrset));
-        Weighted weighted = toProfile(Weighted.class).apply(rrset);
+        Weighted weighted = asWeighted(rrset);
         if (weighted != null) {
             builder.weight(weighted.weight());
         }

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
@@ -8,8 +8,8 @@ import static com.google.common.collect.Iterators.emptyIterator;
 import static com.google.common.collect.Iterators.filter;
 import static com.google.common.collect.Lists.newArrayList;
 import static denominator.model.ResourceRecordSets.profileContainsType;
-import static denominator.model.ResourceRecordSets.toProfile;
 import static denominator.model.ResourceRecordSets.typeEqualTo;
+import static denominator.model.profile.Geo.asGeo;
 import static denominator.ultradns.UltraDNSFunctions.forTypeAndRData;
 import static denominator.ultradns.UltraDNSPredicates.isGeolocationPool;
 import static org.jclouds.ultradns.ws.domain.DirectionalPool.RecordType.IPV4;
@@ -50,11 +50,10 @@ import dagger.Lazy;
 import denominator.Provider;
 import denominator.ResourceTypeToValue;
 import denominator.model.ResourceRecordSet;
-import denominator.model.profile.Geo;
 import denominator.profile.GeoResourceRecordSetApi;
 
 public final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordSetApi {
-    private static final Predicate<ResourceRecordSet<?>> IS_GEO = profileContainsType(Geo.class);
+    private static final Predicate<ResourceRecordSet<?>> IS_GEO = profileContainsType("geo");
     private static final int DEFAULT_TTL = 300;
 
     private final Set<String> supportedTypes;
@@ -162,7 +161,7 @@ public final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordS
         int ttlToApply = rrset.ttl().or(DEFAULT_TTL);
         String group = rrset.qualifier().get();
 
-        Multimap<String, String> regions = toProfile(Geo.class).apply(rrset).regions();
+        Multimap<String, String> regions = asGeo(rrset).regions();
 
         List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset);
         for (Iterator<DirectionalPoolRecordDetail> references = recordsByNameTypeAndQualifier(rrset.name(),

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
@@ -2,7 +2,7 @@ package denominator.ultradns;
 
 import static com.google.common.io.Resources.getResource;
 import static denominator.CredentialsConfiguration.credentials;
-import static denominator.model.ResourceRecordSets.toProfile;
+import static denominator.model.profile.Geo.asGeo;
 import static java.lang.String.format;
 import static org.jclouds.util.Strings2.toStringAndClose;
 import static org.testng.Assert.assertEquals;
@@ -353,7 +353,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
         try {
             GeoResourceRecordSetApi api = mockApi(server.getUrl("/"));
 
-            Multimap<String, String> regions = toProfile(Geo.class).apply(europe).regions();
+            Multimap<String, String> regions = asGeo(europe).regions();
             api.applyRegionsToNameTypeAndGroup(regions, "srv.denominator.io.", "CNAME", "Europe");
 
             assertEquals(server.getRequestCount(), 5);


### PR DESCRIPTION
Part of issue #181.

This allows you to write Geo and Weighted profiles using jackson ObjectMapper with no configuration.  It also proves that a profile read into `Map<String, Object>` using ObjectMapper is equal to an equivalent Geo or Weighted instance.
