### PR TITLE
added url key to yaml commandline config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### Version 2.2
+* adds url key to commandline config
+
 ### Version 2.1.1
 * backfills dynect session invalidation logic from issue #106
 

--- a/denominator-cli/README.md
+++ b/denominator-cli/README.md
@@ -27,6 +27,7 @@ credentials:
 ---
 name: ultradns-prod
 provider: ultradns
+url: https://alternative/rest/endpoint
 credentials:
   username: your_username
   password: your_password

--- a/denominator-cli/src/main/java/denominator/cli/Denominator.java
+++ b/denominator-cli/src/main/java/denominator/cli/Denominator.java
@@ -165,6 +165,8 @@ public class Denominator {
                 if (configFromFile != null) {
                     credentials = MapCredentials.from(Map.class.cast(configFromFile.get("credentials")));
                     providerName = configFromFile.get("provider").toString();
+                    if (configFromFile.containsKey("url"))
+                        url = configFromFile.get("url").toString();
                 }
             }
             Builder<Object> modulesForGraph = ImmutableList.builder().add(provider(newProvider())).add(newModule());

--- a/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -89,6 +89,7 @@ public class DenominatorTest {
             "---\n" +
             "name: blah2\n" +
             "provider: mock\n" +
+            "url: mem:mock2\n" +
             "credentials:\n" +
             "  accessKey: foo3\n" +
             "  secretKey: foo4\n" +
@@ -116,6 +117,7 @@ public class DenominatorTest {
                 assertEquals(configPath, getTestConfigPath());
                 Map<?, ?> configFromFile = getConfigFromFile();
                 assertEquals(configFromFile.get("provider"), "mock");
+                assertEquals(configFromFile.get("url"), "mem:mock2");
                 Map<?, ?> credentials = Map.class.cast(configFromFile.get("credentials"));
                 assertEquals(credentials.get("accessKey"), "foo3");
                 assertEquals(credentials.get("secretKey"), "foo4");

--- a/denominator-cli/src/test/resources/test-config.yml
+++ b/denominator-cli/src/test/resources/test-config.yml
@@ -6,6 +6,7 @@ credentials:
 ---
 name: blah2
 provider: mock
+url: mem:mock2
 credentials:
   accessKey: foo3
   secretKey: foo4


### PR DESCRIPTION
ex. you can now add the following to your config

```
 name: ultradns-prod
 provider: ultradns
 url: https://alternative/rest/endpoint
 credentials:
   username: your_username
   password: your_password
```
