### PR TITLE
Add OpenStack Designate provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Version 2.2
 * adds url key to commandline config
+* adds support for OpenStack Designate
 
 ### Version 2.1.1
 * backfills dynect session invalidation logic from issue #106

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Portable control of DNS clouds
 
-Denominator is a portable Java library for manipulating DNS clouds.  Denominator has pluggable back-ends, initially including AWS Route53, Neustar Ultra, DynECT, Rackspace Cloud DNS, and a mock for testing.  We also ship a command line version so it's easy for anyone to try it out.  Denominator currently supports basic zone and record features, as well GEO (aka Directional) profiles.  See [Netflix Tech Blog](http://techblog.netflix.com/2013/03/denominator-multi-vendor-interface-for.html) for an introduction.
+Denominator is a portable Java library for manipulating DNS clouds.  Denominator has pluggable back-ends, initially including AWS Route53, Neustar Ultra, DynECT, Rackspace Cloud DNS, OpenStack Designate, and a mock for testing.  We also ship a command line version so it's easy for anyone to try it out.  Denominator currently supports basic zone and record features, as well GEO (aka Directional) profiles.  See [Netflix Tech Blog](http://techblog.netflix.com/2013/03/denominator-multi-vendor-interface-for.html) for an introduction.
 
 [![Build Status](https://netflixoss.ci.cloudbees.com/job/denominator-master/badge/icon)](https://netflixoss.ci.cloudbees.com/job/denominator-master/)
 
@@ -41,6 +41,7 @@ $ denominator providers
 provider   url                                                 duplicateZones credentialType credentialArgs
 mock       mem:mock                                            false
 clouddns   https://identity.api.rackspacecloud.com/v2.0/       true           apiKey         username apiKey
+designate  http://localhost:5000/v2.0                          true           password       tenantId username password
 dynect     https://api2.dynect.net/REST                        false          password       customer username password
 route53    https://route53.amazonaws.com                       true           accessKey      accessKey secretKey
 route53    https://route53.amazonaws.com                       true           session        accessKey secretKey sessionToken

--- a/denominator-cli/README.md
+++ b/denominator-cli/README.md
@@ -57,6 +57,7 @@ $ denominator providers
 provider   url                                                 duplicateZones credentialType credentialArgs
 mock       mem:mock                                            false
 clouddns   https://identity.api.rackspacecloud.com/v2.0/       true           apiKey         username apiKey
+designate  http://localhost:5000/v2.0                          true           password       tenantId username password
 dynect     https://api2.dynect.net/REST                        false          password       customer username password
 route53    https://route53.amazonaws.com                       true           accessKey      accessKey secretKey
 route53    https://route53.amazonaws.com                       true           session        accessKey secretKey sessionToken

--- a/denominator-cli/build.gradle
+++ b/denominator-cli/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   compile      project(':providers:denominator-ultradns')
   compile      project(':providers:denominator-route53')
   compile      project(':providers:denominator-clouddns')
+  compile      project(':providers:denominator-designate')
   compile     'io.airlift:airline:0.5'
   compile     'org.yaml:snakeyaml:1.12'
   testCompile 'org.testng:testng:6.8.1'

--- a/denominator-cli/src/main/java/denominator/cli/Denominator.java
+++ b/denominator-cli/src/main/java/denominator/cli/Denominator.java
@@ -52,6 +52,7 @@ import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetList;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetRemove;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetReplace;
 import denominator.clouddns.CloudDNSProvider;
+import denominator.designate.DesignateProvider;
 import denominator.dynect.DynECTProvider;
 import denominator.mock.MockProvider;
 import denominator.model.Zone;
@@ -241,6 +242,8 @@ public class Denominator {
                 return new MockProvider(url);
             } else if ("clouddns".equals(providerName)) {
                 return new CloudDNSProvider(url);
+            } else if ("designate".equals(providerName)) {
+                return new DesignateProvider(url);
             } else if ("dynect".equals(providerName)) {
                 return new DynECTProvider(url);
             } else if ("route53".equals(providerName)) {
@@ -257,6 +260,8 @@ public class Denominator {
                 return new MockProvider.Module();
             } else if ("clouddns".equals(providerName)) {
                 return new CloudDNSProvider.Module();
+            } else if ("designate".equals(providerName)) {
+                return new DesignateProvider.Module();
             } else if ("dynect".equals(providerName)) {
                 return new DynECTProvider.Module();
             } else if ("route53".equals(providerName)) {
@@ -281,6 +286,7 @@ public class Denominator {
         return ImmutableList.<Provider> builder()
                             .add(new MockProvider())
                             .add(new CloudDNSProvider())
+                            .add(new DesignateProvider())
                             .add(new DynECTProvider())
                             .add(new Route53Provider())
                             .add(new UltraDNSProvider()).build();

--- a/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/denominator-cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -43,6 +43,7 @@ public class DenominatorTest {
                 "mock       mem:mock                                            false          ",
                 "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           password       username password",
                 "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           apiKey         username apiKey",
+                "designate  http://localhost:5000/v2.0                          true           password       tenantId username password",
                 "dynect     https://api2.dynect.net/REST                        false          password       customer username password",
                 "route53    https://route53.amazonaws.com                       true           accessKey      accessKey secretKey",
                 "route53    https://route53.amazonaws.com                       true           session        accessKey secretKey sessionToken",

--- a/providers/denominator-clouddns/src/main/java/denominator/clouddns/RackspaceApis.java
+++ b/providers/denominator-clouddns/src/main/java/denominator/clouddns/RackspaceApis.java
@@ -55,6 +55,8 @@ class RackspaceApis {
     }
 
     static class Record {
+        // transient to avoid serializing as json
+        transient String id;
         String name;
         String type;
         Integer ttl;

--- a/providers/denominator-designate/build.gradle
+++ b/providers/denominator-designate/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
+
+eclipse {
+  classpath {
+    downloadSources = true
+    downloadJavadoc = true
+  }
+}
+
+test {
+  useTestNG()
+  systemProperty 'designate.url', System.getProperty('designate.url', '')
+  systemProperty 'designate.tenantId', System.getProperty('designate.tenantId', '')
+  systemProperty 'designate.username', System.getProperty('designate.username', '')
+  systemProperty 'designate.password', System.getProperty('designate.password', '')
+  systemProperty 'designate.zone', System.getProperty('designate.zone', '')
+}
+
+dependencies {
+  compile      project(':denominator-core')
+  compile     'com.netflix.feign:feign-core:2.0.0'
+  compile     'com.google.code.gson:gson:2.2.4'
+  provided    'com.squareup.dagger:dagger-compiler:1.0.1'
+  testCompile  project(':denominator-core').sourceSets.test.output
+  testCompile 'org.testng:testng:6.8.1'
+  testCompile 'com.google.mockwebserver:mockwebserver:20130505'
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/DesignateProvider.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/DesignateProvider.java
@@ -1,0 +1,161 @@
+package denominator.designate;
+
+import static com.google.common.base.Strings.emptyToNull;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
+
+import dagger.Provides;
+import denominator.BasicProvider;
+import denominator.DNSApiManager;
+import denominator.ResourceRecordSetApi;
+import denominator.ZoneApi;
+import denominator.config.GeoUnsupported;
+import denominator.config.NothingToClose;
+import denominator.config.OnlyBasicResourceRecordSets;
+import denominator.config.WeightedUnsupported;
+import denominator.designate.OpenStackApis.Designate;
+import denominator.designate.OpenStackApis.KeystoneV2;
+import denominator.designate.OpenStackApis.TokenIdAndPublicURL;
+import denominator.designate.OpenStackDecoders.DomainListDecoder;
+import denominator.designate.OpenStackDecoders.RecordDecoder;
+import denominator.designate.OpenStackDecoders.RecordListDecoder;
+import denominator.designate.OpenStackEncoders.RecordEncoder;
+import feign.Feign;
+import feign.Feign.Defaults;
+import feign.ReflectiveFeign;
+import feign.Target.HardCodedTarget;
+import feign.codec.BodyEncoder;
+import feign.codec.Decoder;
+
+public class DesignateProvider extends BasicProvider {
+    private final String url;
+
+    public DesignateProvider() {
+        this(null);
+    }
+
+    /**
+     * @param url
+     *            if empty or null use default
+     */
+    public DesignateProvider(String url) {
+        url = emptyToNull(url);
+        this.url = url != null ? url : "http://localhost:5000/v2.0";
+    }
+
+    @Override
+    public String url() {
+        return url;
+    }
+
+    // http://docs.hpcloud.com/api/dns/#create_record-jumplink-span
+    @Override
+    public Set<String> basicRecordTypes() {
+        return ImmutableSet.of("A", "AAAA", "CNAME", "MX", "NS", "SRV", "TXT");
+    }
+
+    @Override
+    public SetMultimap<String, String> profileToRecordTypes() {
+        return ImmutableSetMultimap.<String, String> builder()
+                .putAll("roundRobin", ImmutableSet.of("A", "AAAA", "MX", "NS", "SRV", "TXT")).build();
+    }
+
+    @Override
+    public boolean supportsDuplicateZoneNames() {
+        return true;
+    }
+
+    @Override
+    public Multimap<String, String> credentialTypeToParameterNames() {
+        return ImmutableMultimap.<String, String> builder()//
+//                .putAll("password", "username", "password")
+                .putAll("password", "tenantId", "username", "password")
+                .build();
+    }
+
+    @dagger.Module(injects = DNSApiManager.class, complete = false, overrides = true, //
+    includes = { NothingToClose.class,//
+            GeoUnsupported.class,//
+            WeightedUnsupported.class, //
+            OnlyBasicResourceRecordSets.class,//
+            FeignModule.class })
+    public static final class Module {
+
+        @Provides
+        @Singleton
+        ZoneApi provideZoneApi(DesignateZoneApi in) {
+            return in;
+        }
+
+        @Provides
+        @Singleton
+        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(DesignateResourceRecordSetApi.Factory in) {
+            return in;
+        }
+    }
+
+    @dagger.Module(injects = DesignateResourceRecordSetApi.Factory.class, complete = false, overrides = true, includes = {
+            Defaults.class, ReflectiveFeign.Module.class })
+    public static final class FeignModule {
+
+        @Provides
+        @Singleton
+        Designate cloudDNS(Feign feign, DesignateTarget target) {
+            return feign.newInstance(target);
+        }
+
+        // override binding to use whatever your service type is
+        @Provides
+        @Named("serviceTypeSuffix")
+        String serviceTypeSuffix() {
+            return ":dns";
+        }
+
+        @Provides
+        @Singleton
+        KeystoneV2 cloudIdentity(Feign feign) {
+            return feign.newInstance(new HardCodedTarget<KeystoneV2>(KeystoneV2.class, "keystone", "http://invalid"));
+        }
+
+        @Provides
+        @Singleton
+        Map<String, Decoder> decoders(KeystoneV2AccessDecoder keyStone) {
+            ImmutableMap.Builder<String, Decoder> decoders = ImmutableMap.<String, Decoder> builder();
+            decoders.put("KeystoneV2", keyStone);
+            Decoder domainListDecoder = new DomainListDecoder();
+            decoders.put("Designate#domains()", domainListDecoder);
+            Decoder recordListDecoder = new RecordListDecoder();
+            decoders.put("Designate#records(String)", recordListDecoder);
+            Decoder recordDecoder = new RecordDecoder();
+            decoders.put("Designate#createRecord(String,Record)", recordDecoder);
+            decoders.put("Designate#updateRecord(String,Record)", recordDecoder);
+            return decoders.build();
+        }
+
+        @Provides
+        @Singleton
+        Map<String, BodyEncoder> bodyEncoders() {
+            ImmutableMap.Builder<String, BodyEncoder> bodyEncoders = ImmutableMap.<String, BodyEncoder> builder();
+            BodyEncoder recordEncoder = new RecordEncoder();
+            bodyEncoders.put("Designate#createRecord(String,Record)", recordEncoder);
+            bodyEncoders.put("Designate#updateRecord(String,Record)", recordEncoder);
+            return bodyEncoders.build();
+        }
+
+        @Provides
+        public TokenIdAndPublicURL urlAndToken(InvalidatableAuthSupplier supplier) {
+            return supplier.get();
+        }
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
@@ -1,0 +1,126 @@
+package denominator.designate;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Iterators.filter;
+import static com.google.common.collect.Iterators.tryFind;
+import static com.google.common.collect.Lists.newArrayList;
+import static denominator.designate.DesignateFunctions.toRDataMap;
+import static denominator.model.ResourceRecordSets.nameEqualTo;
+import static denominator.model.ResourceRecordSets.typeEqualTo;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+
+import denominator.ResourceRecordSetApi;
+import denominator.designate.OpenStackApis.Designate;
+import denominator.designate.OpenStackApis.Record;
+import denominator.model.ResourceRecordSet;
+
+class DesignateResourceRecordSetApi implements denominator.ResourceRecordSetApi {
+
+    private final Designate api;
+    private final String domainId;
+
+    DesignateResourceRecordSetApi(Designate api, String domainId) {
+        this.api = api;
+        this.domainId = domainId;
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterator() {
+        return new GroupByRecordNameAndTypeIterator(api.records(domainId).iterator());
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
+        // TODO: investigate query by name call in designate
+        return filter(iterator(), nameEqualTo(name));
+    }
+
+    @Override
+    public Optional<ResourceRecordSet<?>> getByNameAndType(String name, String type) {
+        // TODO: investigate query by name and type call in designate
+        return tryFind(iterator(), and(nameEqualTo(name), typeEqualTo(type)));
+    }
+
+    @Override
+    public void put(ResourceRecordSet<?> rrset) {
+        checkNotNull(rrset, "rrset was null");
+        checkArgument(!rrset.rdata().isEmpty(), "rrset was empty %s", rrset);
+
+        List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset.rdata());
+
+        for (Record record : api.records(domainId)) {
+            // TODO: name and type filter
+            if (rrset.name().equals(record.name) && rrset.type().equals(record.type)) {
+                Map<String, Object> rdata = toRDataMap(record);
+                if (recordsLeftToCreate.contains(rdata)) {
+                    recordsLeftToCreate.remove(rdata);
+                    if (rrset.ttl().isPresent()) {
+                        if (rrset.ttl().get().equals(record.ttl)) {
+                            continue;
+                        }
+                        record.ttl = rrset.ttl().get();
+                        api.updateRecord(domainId, record);
+                    }
+                } else {
+                    api.deleteRecord(domainId, record.id);
+                }
+            }
+        }
+
+        Record record = new Record();
+        record.name = rrset.name();
+        record.type = rrset.type();
+        record.ttl = rrset.ttl().orNull();
+
+        for (Map<String, Object> rdata : recordsLeftToCreate) {
+            LinkedHashMap<String, Object> mutable = new LinkedHashMap<String, Object>(rdata);
+            if (mutable.containsKey("priority")) { // SRVData
+                record.priority = Integer.class.cast(mutable.remove("priority"));
+            } else if (mutable.containsKey("preference")) { // MXData
+                record.priority = Integer.class.cast(mutable.remove("preference"));
+            } else {
+                record.priority = null;
+            }
+            record.data = Joiner.on(' ').join(mutable.values());
+            api.createRecord(domainId, record);
+        }
+    }
+
+    @Override
+    public void deleteByNameAndType(String name, String type) {
+        checkNotNull(name, "name");
+        checkNotNull(type, "type");
+        for (Record record : api.records(domainId)) {
+            // TODO: name and type filter
+            if (name.equals(record.name) && type.equals(record.type)) {
+                api.deleteRecord(domainId, record.id);
+            }
+        }
+    }
+
+    static final class Factory implements denominator.ResourceRecordSetApi.Factory {
+
+        private final Designate api;
+
+        @Inject
+        Factory(Designate api) {
+            this.api = checkNotNull(api, "api");
+        }
+
+        @Override
+        public ResourceRecordSetApi create(String id) {
+            return new DesignateResourceRecordSetApi(api, checkNotNull(id, "id"));
+        }
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/DesignateTarget.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/DesignateTarget.java
@@ -1,0 +1,46 @@
+package denominator.designate;
+
+import javax.inject.Inject;
+
+import denominator.Provider;
+import denominator.designate.OpenStackApis.Designate;
+import denominator.designate.OpenStackApis.TokenIdAndPublicURL;
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Target;
+
+class DesignateTarget implements Target<Designate> {
+
+    private final Provider provider;
+    private final javax.inject.Provider<TokenIdAndPublicURL> lazyUrlAndToken;
+
+    @Inject
+    DesignateTarget(Provider provider, javax.inject.Provider<TokenIdAndPublicURL> lazyUrlAndToken) {
+        this.provider = provider;
+        this.lazyUrlAndToken = lazyUrlAndToken;
+    }
+
+    @Override
+    public Class<Designate> type() {
+        return Designate.class;
+    }
+
+    @Override
+    public String name() {
+        return provider.name();
+    }
+
+    @Override
+    public String url() {
+        return lazyUrlAndToken.get().publicURL;
+    }
+
+    @Override
+    public Request apply(RequestTemplate input) {
+        TokenIdAndPublicURL urlAndToken = lazyUrlAndToken.get();
+        if (input.url().indexOf("http") != 0)
+            input.insert(0, urlAndToken.publicURL);
+        input.header("X-Auth-Token", urlAndToken.tokenId);
+        return input.request();
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/DesignateZoneApi.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/DesignateZoneApi.java
@@ -1,0 +1,22 @@
+package denominator.designate;
+
+import java.util.Iterator;
+
+import javax.inject.Inject;
+
+import denominator.designate.OpenStackApis.Designate;
+import denominator.model.Zone;
+
+class DesignateZoneApi implements denominator.ZoneApi {
+    private final Designate api;
+
+    @Inject
+    DesignateZoneApi(Designate api) {
+        this.api = api;
+    }
+
+    @Override
+    public Iterator<Zone> iterator() {
+        return api.domains().iterator();
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/GroupByRecordNameAndTypeIterator.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/GroupByRecordNameAndTypeIterator.java
@@ -1,0 +1,99 @@
+package denominator.designate;
+
+import static com.google.common.collect.Iterators.peekingIterator;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.PeekingIterator;
+
+import denominator.designate.OpenStackApis.Record;
+import denominator.model.ResourceRecordSet;
+import denominator.model.ResourceRecordSet.Builder;
+import denominator.model.rdata.AAAAData;
+import denominator.model.rdata.AData;
+import denominator.model.rdata.CNAMEData;
+import denominator.model.rdata.MXData;
+import denominator.model.rdata.NSData;
+import denominator.model.rdata.PTRData;
+import denominator.model.rdata.SRVData;
+import denominator.model.rdata.TXTData;
+
+class GroupByRecordNameAndTypeIterator implements Iterator<ResourceRecordSet<?>> {
+
+    private final PeekingIterator<Record> peekingIterator;
+
+    public GroupByRecordNameAndTypeIterator(Iterator<Record> sortedIterator) {
+        this.peekingIterator = peekingIterator(sortedIterator);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return peekingIterator.hasNext();
+    }
+
+    @Override
+    public ResourceRecordSet<?> next() {
+        Record recordDetail = peekingIterator.next();
+        Builder<Map<String, Object>> builder = ResourceRecordSet.builder()
+                                                                .name(recordDetail.name)
+                                                                .type(recordDetail.type)
+                                                                .ttl(recordDetail.ttl)
+                                                                .add(toRData(recordDetail));
+        while (hasNext()) {
+            Record next = peekingIterator.peek();
+            if (next == null)
+                continue;
+            if (nameAndTypeEquals(next, recordDetail)) {
+                builder.add(toRData(peekingIterator.next()));
+            } else {
+                break;
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static boolean nameAndTypeEquals(Record actual, Record expected) {
+        return actual.name.equals(expected.name) && actual.type.equals(expected.type);
+    }
+
+    static Map<String, Object> toRData(Record record) {
+        if ("A".equals(record.type)) {
+            return AData.create(record.data);
+        } else if ("AAAA".equals(record.type)) {
+            return AAAAData.create(record.data);
+        } else if ("CNAME".equals(record.type)) {
+            return CNAMEData.create(record.data);
+        } else if ("MX".equals(record.type)) {
+            return MXData.create(record.priority, record.data);
+        } else if ("NS".equals(record.type)) {
+            return NSData.create(record.data);
+        } else if ("PTR".equals(record.type)) {
+            return PTRData.create(record.data);
+        } else if ("SRV".equals(record.type)) {
+            ImmutableList<String> parts = split(record.data);
+            
+            return SRVData.builder()
+                          .priority(record.priority)
+                          .weight(Integer.valueOf(parts.get(0)))
+                          .port(Integer.valueOf(parts.get(1)))
+                          .target(parts.get(2)).build();
+        } else if ("TXT".equals(record.type)) {
+            return TXTData.create(record.data);
+        } else {
+            return ImmutableMap.<String, Object> of("rdata", record.data);
+        }
+    }
+
+    private static ImmutableList<String> split(String rdata) {
+        return ImmutableList.copyOf(Splitter.on(' ').split(rdata));
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/InvalidatableAuthSupplier.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/InvalidatableAuthSupplier.java
@@ -1,0 +1,84 @@
+package denominator.designate;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.google.common.base.Supplier;
+
+import denominator.Credentials;
+import denominator.Credentials.ListCredentials;
+import denominator.designate.OpenStackApis.KeystoneV2;
+import denominator.designate.OpenStackApis.TokenIdAndPublicURL;
+
+/**
+ * gets the current endpoint and authorization token from the identity service
+ * using password or api key auth.
+ */
+// similar to guava MemoizingSupplier
+@Singleton
+class InvalidatableAuthSupplier implements Supplier<TokenIdAndPublicURL> {
+    private final denominator.Provider provider;
+    private final KeystoneV2 identityService;
+    private final Provider<Credentials> credentials;
+    transient volatile String lastKeystoneUrl;
+    transient volatile int lastCredentialsHashCode;
+    transient volatile boolean initialized;
+    // "value" does not need to be volatile; visibility piggy-backs
+    // on above
+    transient TokenIdAndPublicURL value;
+
+    @Inject
+    InvalidatableAuthSupplier(denominator.Provider provider, KeystoneV2 identityService,
+            javax.inject.Provider<Credentials> credentials) {
+        this.provider = provider;
+        this.identityService = identityService;
+        this.credentials = credentials;
+        // for toString
+        this.lastKeystoneUrl = provider.url();
+    }
+
+    public void invalidate() {
+        initialized = false;
+    }
+
+    @Override
+    public TokenIdAndPublicURL get() {
+        String currentUrl = provider.url();
+        Credentials currentCreds = credentials.get();
+
+        if (needsRefresh(currentUrl, currentCreds)) {
+            synchronized (this) {
+                if (needsRefresh(currentUrl, currentCreds)) {
+                    lastCredentialsHashCode = currentCreds.hashCode();
+                    lastKeystoneUrl = currentUrl;
+                    TokenIdAndPublicURL t = auth(currentCreds);
+                    value = t;
+                    initialized = true;
+                    return t;
+                }
+            }
+        }
+        return value;
+    }
+
+    private boolean needsRefresh(String currentUrl, Credentials currentCreds) {
+        return !initialized || currentCreds.hashCode() != lastCredentialsHashCode
+                || !currentUrl.equals(lastKeystoneUrl);
+    }
+
+    private TokenIdAndPublicURL auth(Credentials currentCreds) {
+        URI url = URI.create(lastKeystoneUrl);
+        List<Object> listCreds = ListCredentials.asList(currentCreds);
+        return identityService.passwordAuth(url, listCreds.get(0).toString(), listCreds.get(1).toString(), listCreds
+                .get(2).toString());
+    }
+
+    @Override
+    public String toString() {
+        return "InvalidatableAuthSupplier(" + lastKeystoneUrl + ")";
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/KeystoneV2AccessDecoder.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/KeystoneV2AccessDecoder.java
@@ -1,0 +1,65 @@
+package denominator.designate;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.Reader;
+import java.lang.reflect.Type;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import denominator.designate.OpenStackApis.TokenIdAndPublicURL;
+import feign.codec.Decoder;
+
+class KeystoneV2AccessDecoder extends Decoder {
+    private final String serviceTypeSuffix;
+
+    @Inject
+    KeystoneV2AccessDecoder(@Named("serviceTypeSuffix") String serviceTypeSuffix) {
+        this.serviceTypeSuffix = checkNotNull(serviceTypeSuffix, "serviceTypeSuffix was null");
+    }
+
+    @Override
+    public TokenIdAndPublicURL decode(String methodKey, Reader reader, Type ignored) throws Throwable {
+        JsonObject access = new JsonParser().parse(reader).getAsJsonObject().get("access").getAsJsonObject();
+        JsonElement tokenField = access.get("token");
+        if (isNull(tokenField)) {
+            return null;
+        }
+        JsonElement idField = tokenField.getAsJsonObject().get("id");
+        if (isNull(idField)) {
+            return null;
+        }
+
+        TokenIdAndPublicURL tokenUrl = new TokenIdAndPublicURL();
+        tokenUrl.tokenId = idField.getAsString();
+
+        for (JsonElement s : access.get("serviceCatalog").getAsJsonArray()) {
+            JsonObject service = s.getAsJsonObject();
+            JsonElement typeField = service.get("type");
+            JsonElement endpointsField = service.get("endpoints");
+            if (!isNull(typeField) && !isNull(endpointsField) && typeField.getAsString().endsWith(serviceTypeSuffix)) {
+                for (JsonElement e : endpointsField.getAsJsonArray()) {
+                    JsonObject endpoint = e.getAsJsonObject();
+                    tokenUrl.publicURL = endpoint.get("publicURL").getAsString();
+                    if (tokenUrl.publicURL.endsWith("/"))
+                        tokenUrl.publicURL = tokenUrl.publicURL.substring(0, tokenUrl.publicURL.length() - 1);
+                }
+            }
+        }
+        return tokenUrl;
+    }
+
+    @Override
+    public String toString() {
+        return "KeystoneV2AccessDecoder(" + serviceTypeSuffix + ")";
+    }
+
+    static boolean isNull(JsonElement element) {
+        return element == null || element.isJsonNull();
+    }
+};

--- a/providers/denominator-designate/src/main/java/denominator/designate/OpenStackApis.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/OpenStackApis.java
@@ -1,0 +1,64 @@
+package denominator.designate;
+
+import static com.google.common.base.Objects.toStringHelper;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.inject.Named;
+
+import denominator.model.Zone;
+import feign.Body;
+import feign.Headers;
+import feign.RequestLine;
+
+class OpenStackApis {
+    static interface KeystoneV2 {
+        @RequestLine("POST /tokens")
+        @Body("%7B\"auth\":%7B\"passwordCredentials\":%7B\"username\":\"{username}\",\"password\":\"{password}\"%7D,\"tenantId\":\"{tenantId}\"%7D%7D")
+        @Headers("Content-Type: application/json")
+        TokenIdAndPublicURL passwordAuth(URI endpoint, @Named("tenantId") String tenantId,
+                @Named("username") String username, @Named("password") String password);
+    }
+
+    static class TokenIdAndPublicURL {
+        String tokenId;
+        String publicURL;
+    }
+
+    // http://docs.hpcloud.com/api/dns/#4.RESTAPISpecifications
+    static interface Designate {
+        @RequestLine("GET /domains")
+        List<Zone> domains();
+
+        @RequestLine("GET /domains/{domainId}/records")
+        List<Record> records(@Named("domainId") String domainId);
+
+        @RequestLine("POST /domains/{domainId}/records")
+        @Headers("Content-Type: application/json")
+        Record createRecord(@Named("domainId") String domainId, Record record);
+
+        @RequestLine("PUT /domains/{domainId}/records")
+        @Headers("Content-Type: application/json")
+        Record updateRecord(@Named("domainId") String domainId, Record record);
+
+        @RequestLine("DELETE /domains/{domainId}/records/{recordId}")
+        void deleteRecord(@Named("domainId") String domainId, @Named("recordId") String recordId);
+    }
+
+    static class Record {
+        String id;
+        String name;
+        String type;
+        Integer ttl;
+        String data;
+        Integer priority;
+
+        // toString ordering
+        @Override
+        public String toString() {
+            return toStringHelper("").omitNullValues().add("name", name).add("type", type).add("ttl", ttl)
+                    .add("data", data).add("priority", priority).toString();
+        }
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/OpenStackDecoders.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/OpenStackDecoders.java
@@ -1,0 +1,118 @@
+package denominator.designate;
+
+import static com.google.common.collect.Ordering.usingToString;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+
+import denominator.designate.OpenStackApis.Record;
+import denominator.model.Zone;
+import feign.codec.Decoder;
+
+class OpenStackDecoders {
+    static class DomainListDecoder extends ListDecoder<Zone> {
+        @Override
+        protected String jsonKey() {
+            return "domains";
+        }
+
+        protected Zone build(JsonReader reader) throws IOException {
+            String name = null;
+            String id = null;
+            while (reader.hasNext()) {
+                String key = reader.nextName();
+                if (key.equals("name")) {
+                    name = reader.nextString();
+                } else if (key.equals("id")) {
+                    id = reader.nextString();
+                } else {
+                    reader.skipValue();
+                }
+            }
+            return Zone.create(name, id);
+        }
+    }
+
+    static class RecordDecoder extends Decoder {
+        @Override
+        public Record decode(String methodKey, Reader ireader, Type type) throws Throwable {
+            JsonReader reader = new JsonReader(ireader);
+            reader.beginObject();
+            Record record = buildRecord(reader);
+            reader.endObject();
+            reader.close();
+            return record;
+        }
+    }
+
+    static class RecordListDecoder extends ListDecoder<Record> {
+        @Override
+        protected String jsonKey() {
+            return "records";
+        }
+
+        protected Record build(JsonReader reader) throws IOException {
+            return buildRecord(reader);
+        }
+    }
+
+    static Record buildRecord(JsonReader reader) throws IOException {
+        Record record = new Record();
+        while (reader.hasNext()) {
+            String key = reader.nextName();
+            if (key.equals("id")) {
+                record.id = reader.nextString();
+            } else if (key.equals("name")) {
+                record.name = reader.nextString();
+            } else if (key.equals("type")) {
+                record.type = reader.nextString();
+            } else if (key.equals("ttl") && reader.peek() != JsonToken.NULL) {
+                record.ttl = reader.nextInt();
+            } else if (key.equals("data")) {
+                record.data = reader.nextString();
+            } else if (key.equals("priority") && reader.peek() != JsonToken.NULL) {
+                record.priority = reader.nextInt();
+            } else {
+                reader.skipValue();
+            }
+        }
+        return record;
+    }
+
+    private static abstract class ListDecoder<X> extends Decoder {
+        protected abstract String jsonKey();
+
+        protected abstract X build(JsonReader reader) throws IOException;
+
+        @Override
+        public List<X> decode(String methodKey, Reader ireader, Type type) throws Throwable {
+            Builder<X> builder = ImmutableList.<X> builder();
+            JsonReader reader = new JsonReader(ireader);
+            reader.beginObject();
+            while (reader.hasNext()) {
+                String nextName = reader.nextName();
+                if (jsonKey().equals(nextName)) {
+                    reader.beginArray();
+                    while (reader.hasNext()) {
+                        reader.beginObject();
+                        builder.add(build(reader));
+                        reader.endObject();
+                    }
+                    reader.endArray();
+                } else {
+                    reader.skipValue();
+                }
+            }
+            reader.endObject();
+            reader.close();
+            return usingToString().sortedCopy(builder.build());
+        }
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/OpenStackEncoders.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/OpenStackEncoders.java
@@ -1,0 +1,32 @@
+package denominator.designate;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import denominator.designate.OpenStackApis.Record;
+import feign.RequestTemplate;
+import feign.codec.BodyEncoder;
+
+class OpenStackEncoders {
+    static class RecordEncoder implements BodyEncoder {
+        /**
+         * As formats are stable, using normal json to create the string as
+         * opposed to reflection.
+         */
+        @Override
+        public void encodeBody(Object bodyParam, RequestTemplate base) {
+            Record record = Record.class.cast(bodyParam);
+            if (record.id != null)
+                base.append("/").append(record.id);
+            JsonObject asJson = new JsonObject();
+            asJson.add("name", new JsonPrimitive(record.name));
+            asJson.add("type", new JsonPrimitive(record.type));
+            if (record.ttl != null)
+                asJson.add("ttl", new JsonPrimitive(record.ttl));
+            asJson.add("data", new JsonPrimitive(record.data));
+            if (record.priority != null)
+                asJson.add("priority", new JsonPrimitive(record.priority));
+            base.body(asJson.toString());
+        }
+    }
+}

--- a/providers/denominator-designate/src/main/java/denominator/designate/UltraDNSFunctions.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/UltraDNSFunctions.java
@@ -1,0 +1,43 @@
+package denominator.designate;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+import denominator.designate.OpenStackApis.Record;
+import denominator.model.rdata.AAAAData;
+import denominator.model.rdata.AData;
+import denominator.model.rdata.CNAMEData;
+import denominator.model.rdata.MXData;
+import denominator.model.rdata.NSData;
+import denominator.model.rdata.SRVData;
+import denominator.model.rdata.TXTData;
+
+final class DesignateFunctions {
+    private DesignateFunctions() { /* */
+    }
+
+    static Map<String, Object> toRDataMap(Record record) {
+        if ("A".equals(record.type)) {
+            return AData.create(record.data);
+        } else if ("AAAA".equals(record.type)) {
+            return AAAAData.create(record.data);
+        } else if ("CNAME".equals(record.type)) {
+            return CNAMEData.create(record.data);
+        } else if ("MX".equals(record.type)) {
+            return MXData.create(record.priority, record.data);
+        } else if ("NS".equals(record.type)) {
+            return NSData.create(record.data);
+        } else if ("SRV".equals(record.type)) {
+            List<String> rdata = ImmutableList.copyOf(Splitter.on(' ').split(record.data));
+            return SRVData.builder().priority(record.priority).weight(Integer.valueOf(rdata.get(0)))
+                    .port(Integer.valueOf(rdata.get(1))).target(rdata.get(2)).build();
+        } else if ("TXT".equals(record.type)) {
+            return TXTData.create(record.data);
+        } else {
+            throw new UnsupportedOperationException("record type not yet supported" + record);
+        }
+    }
+}

--- a/providers/denominator-designate/src/main/resources/META-INF/services/denominator.Provider
+++ b/providers/denominator-designate/src/main/resources/META-INF/services/denominator.Provider
@@ -1,0 +1,1 @@
+denominator.designate.DesignateProvider

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateConnection.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateConnection.java
@@ -1,0 +1,45 @@
+package denominator.designate;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static denominator.CredentialsConfiguration.credentials;
+import static java.lang.System.getProperty;
+
+import java.io.File;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+import denominator.DNSApiManager;
+import denominator.Denominator;
+import denominator.designate.DesignateProvider;
+import feign.Wire;
+
+public class DesignateConnection {
+
+    final DNSApiManager manager;
+    final String mutableZone;
+
+    DesignateConnection() {
+        String tenantId = emptyToNull(getProperty("designate.tenantId"));
+        String username = emptyToNull(getProperty("designate.username"));
+        String password = emptyToNull(getProperty("designate.password"));
+        if (username != null && password != null) {
+            DesignateProvider provider = new DesignateProvider(emptyToNull(getProperty("designate.url")));
+            @Module(overrides = true)
+            class Overrides {
+                @Provides
+                @Singleton
+                Wire provideWire() {
+                    new File("target/test-data").mkdirs();
+                    return new Wire.LoggingWire().appendToFile("target/test-data/http-wire.log");
+                }
+            }
+            manager = Denominator.create(provider, credentials(tenantId, username, password), new Overrides());
+        } else {
+            manager = null;
+        }
+        mutableZone = emptyToNull(getProperty("designate.zone"));
+    }
+
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateProviderDynamicUpdateMockTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateProviderDynamicUpdateMockTest.java
@@ -1,0 +1,113 @@
+package denominator.designate;
+
+import static denominator.CredentialsConfiguration.credentials;
+import static denominator.designate.DesignateTest.accessResponse;
+import static denominator.designate.DesignateTest.auth;
+import static denominator.designate.DesignateTest.getURLReplacingQueueDispatcher;
+import static denominator.designate.DesignateTest.password;
+import static denominator.designate.DesignateTest.tenantId;
+import static denominator.designate.DesignateTest.username;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.annotations.Test;
+
+import com.google.common.base.Supplier;
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+
+import denominator.Credentials;
+import denominator.Credentials.ListCredentials;
+import denominator.DNSApi;
+import denominator.Denominator;
+
+@Test(singleThreaded = true)
+public class DesignateProviderDynamicUpdateMockTest {
+
+    @Test
+    public void dynamicEndpointUpdates() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        String initialPath = "";
+        String updatedPath = "alt";
+        URL mockUrl = server.getUrl(initialPath);
+        final AtomicReference<URL> dynamicUrl = new AtomicReference<URL>(mockUrl);
+        server.setDispatcher(getURLReplacingQueueDispatcher(dynamicUrl));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"domains\": [] }"));
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"domains\": [] }"));
+
+        try {
+            DNSApi api = Denominator.create(new DesignateProvider() {
+                @Override
+                public String url() {
+                    return dynamicUrl.get().toString();
+                }
+            }, credentials(tenantId, username, password)).api();
+
+            assertFalse(api.zones().iterator().hasNext());
+            dynamicUrl.set(new URL(mockUrl, updatedPath));
+            assertFalse(api.zones().iterator().hasNext());
+
+            assertEquals(server.getRequestCount(), 4);
+            assertEquals(server.takeRequest().getRequestLine(), "POST /tokens HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(), "GET /v1/domains HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(), "POST /alt/tokens HTTP/1.1");
+            assertEquals(server.takeRequest().getRequestLine(), "GET /alt/v1/domains HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void dynamicCredentialUpdates() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        final URL mockUrl = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(new AtomicReference<URL>(mockUrl)));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"domains\": [] }"));
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"domains\": [] }"));
+
+        try {
+
+            final AtomicReference<Credentials> dynamicCredentials = new AtomicReference<Credentials>(
+                    ListCredentials.from(tenantId, username, password));
+
+            DNSApi api = Denominator.create(new DesignateProvider() {
+                @Override
+                public String url() {
+                    return mockUrl.toString();
+                }
+            }, credentials(new Supplier<Credentials>() {
+                @Override
+                public Credentials get() {
+                    return dynamicCredentials.get();
+                }
+            })).api();
+
+            assertFalse(api.zones().iterator().hasNext());
+            dynamicCredentials.set(ListCredentials.from(tenantId, "jclouds-bob", "comeon"));
+            assertFalse(api.zones().iterator().hasNext());
+
+            assertEquals(server.getRequestCount(), 4);
+            assertEquals(new String(server.takeRequest().getBody()), auth);
+            assertEquals(server.takeRequest().getRequestLine(), "GET /v1/domains HTTP/1.1");
+            assertEquals(new String(server.takeRequest().getBody()),
+                    auth.replace(username, "jclouds-bob").replace(password, "comeon"));
+            assertEquals(server.takeRequest().getRequestLine(), "GET /v1/domains HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateProviderTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateProviderTest.java
@@ -1,0 +1,67 @@
+package denominator.designate;
+
+import static denominator.CredentialsConfiguration.credentials;
+import static denominator.Denominator.create;
+import static denominator.Denominator.providers;
+import static denominator.Denominator.provider;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+import dagger.ObjectGraph;
+import denominator.DNSApiManager;
+import denominator.Provider;
+import denominator.Credentials.MapCredentials;
+import denominator.designate.DesignateProvider;
+import denominator.designate.DesignateZoneApi;
+
+public class DesignateProviderTest {
+    private static final Provider PROVIDER = new DesignateProvider();
+
+    @Test
+    public void testMockMetadata() {
+        assertEquals(PROVIDER.name(), "designate");
+        assertEquals(PROVIDER.supportsDuplicateZoneNames(), true);
+        assertEquals(PROVIDER.credentialTypeToParameterNames(), ImmutableMultimap.<String, String> builder()
+                .putAll("password", "tenantId", "username", "password").build());
+    }
+
+    @Test
+    public void testDesignateRegistered() {
+        Set<Provider> allProviders = ImmutableSet.copyOf(providers());
+        assertTrue(allProviders.contains(PROVIDER));
+    }
+
+    @Test
+    public void testProviderWiresDesignateZoneApi() {
+        DNSApiManager manager = create(PROVIDER, credentials("tenantId", "username", "password"));
+        assertEquals(manager.api().zones().getClass(), DesignateZoneApi.class);
+        manager = create("designate", credentials("tenantId", "username", "password"));
+        assertEquals(manager.api().zones().getClass(), DesignateZoneApi.class);
+        manager = create("designate", credentials(MapCredentials.from(ImmutableMap.<String, String> builder()
+                                                                .put("tenantId", "T")
+                                                                .put("username", "U")
+                                                                .put("password", "P").build())));
+        assertEquals(manager.api().zones().getClass(), DesignateZoneApi.class);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "no credentials supplied. designate requires tenantId, username, password")
+    public void testCredentialsRequired() {
+        create(PROVIDER).api().zones().iterator();
+    }
+
+    @Test
+    public void testViaDagger() {
+        DNSApiManager manager = ObjectGraph
+                .create(provider(new DesignateProvider()), new DesignateProvider.Module(), credentials("tenantId", "username", "password"))
+                .get(DNSApiManager.class);
+        assertEquals(manager.api().zones().getClass(), DesignateZoneApi.class);
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateReadOnlyLiveTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateReadOnlyLiveTest.java
@@ -1,0 +1,14 @@
+package denominator.designate;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseReadOnlyLiveTest;
+
+@Test
+public class DesignateReadOnlyLiveTest extends BaseReadOnlyLiveTest {
+    @BeforeClass
+    private void setUp() {
+        manager = new DesignateConnection().manager;
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateRecordSetLiveTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateRecordSetLiveTest.java
@@ -1,0 +1,16 @@
+package denominator.designate;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseRecordSetLiveTest;
+
+@Test
+public class DesignateRecordSetLiveTest extends BaseRecordSetLiveTest {
+    @BeforeClass
+    private void setUp() {
+        DesignateConnection connection = new DesignateConnection();
+        manager = connection.manager;
+        setMutableZoneIfPresent(connection.mutableZone);
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateResourceRecordSetApiMockTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateResourceRecordSetApiMockTest.java
@@ -1,0 +1,365 @@
+package denominator.designate;
+
+import static denominator.CredentialsConfiguration.credentials;
+import static denominator.designate.DesignateTest.aRecordResponse;
+import static denominator.designate.DesignateTest.accessResponse;
+import static denominator.designate.DesignateTest.domainId;
+import static denominator.designate.DesignateTest.getURLReplacingQueueDispatcher;
+import static denominator.designate.DesignateTest.password;
+import static denominator.designate.DesignateTest.recordsResponse;
+import static denominator.designate.DesignateTest.takeAuthResponse;
+import static denominator.designate.DesignateTest.tenantId;
+import static denominator.designate.DesignateTest.username;
+import static denominator.model.ResourceRecordSets.a;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+import com.google.mockwebserver.RecordedRequest;
+
+import denominator.Denominator;
+import denominator.ResourceRecordSetApi;
+import denominator.model.ResourceRecordSet;
+import denominator.model.rdata.MXData;
+
+@Test(singleThreaded = true)
+public class DesignateResourceRecordSetApiMockTest {
+
+    @Test
+    public void listWhenPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+
+        try {
+            ResourceRecordSetApi api = mockApi(url);
+            Iterator<ResourceRecordSet<?>> records = api.iterator();
+            assertEquals(records.next(), ResourceRecordSet.<MXData> builder() //
+                    .name("denominator.io.") //
+                    .type("MX") //
+                    .ttl(3600) //
+                    .add(MXData.create(10, "www.denominator.io.")).build());
+            assertEquals(records.next(), a("www.denominator.io.", 300, Arrays.asList("192.0.2.1", "192.0.2.2")));
+            assertFalse(records.hasNext());
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void listWhenAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
+
+        try {
+            ResourceRecordSetApi api = mockApi(url);
+
+            assertFalse(api.iterator().hasNext());
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void putCreatesRecord() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
+        server.enqueue(new MockResponse().setBody(aRecordResponse));
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            api.put(a("www.denominator.io.", 3600, "192.0.2.1"));
+
+            assertEquals(server.getRequestCount(), 3);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+
+            RecordedRequest createRequest = server.takeRequest();
+            assertEquals(createRequest.getRequestLine(), format("POST /v1/domains/%s/records HTTP/1.1", domainId));
+            assertEquals(new String(createRequest.getBody()),
+                    "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"ttl\":3600,\"data\":\"192.0.2.1\"}");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void putSameRecordNoOp() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            api.put(a("www.denominator.io.", ImmutableSet.of("192.0.2.1", "192.0.2.2")));
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void putUpdatesWhenPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+        server.enqueue(new MockResponse().setBody(aRecordResponse));
+        server.enqueue(new MockResponse().setBody(aRecordResponse));
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            api.put(a("www.denominator.io.", 10000000, ImmutableSet.of("192.0.2.1", "192.0.2.2")));
+
+            assertEquals(server.getRequestCount(), 4);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+
+            RecordedRequest updateRequest = server.takeRequest();
+            assertEquals(updateRequest.getRequestLine(),
+                    format("PUT /v1/domains/%s/records/%s HTTP/1.1", domainId, "d7eb0fc4-e069-4c92-a272-c5c969b4f558"));
+            assertEquals(new String(updateRequest.getBody()),
+                    "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"ttl\":10000000,\"data\":\"192.0.2.1\"}");
+
+            updateRequest = server.takeRequest();
+            assertEquals(updateRequest.getRequestLine(),
+                    format("PUT /v1/domains/%s/records/%s HTTP/1.1", domainId, "c538d70e-d65f-4d5a-92a2-cd5d4d1d9da4"));
+            assertEquals(new String(updateRequest.getBody()),
+                    "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"ttl\":10000000,\"data\":\"192.0.2.2\"}");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void putOneLessDeletesExtra() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+        server.enqueue(new MockResponse());
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            api.put(a("www.denominator.io.", "192.0.2.2"));
+
+            assertEquals(server.getRequestCount(), 3);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+            assertEquals(
+                    server.takeRequest().getRequestLine(),
+                    format("DELETE /v1/domains/%s/records/%s HTTP/1.1", domainId,
+                            "d7eb0fc4-e069-4c92-a272-c5c969b4f558"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void iterateByNameWhenPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            assertEquals(api.iterateByName("www.denominator.io.").next(),
+                    a("www.denominator.io.", ImmutableList.of("192.0.2.1", "192.0.2.2")));
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void iterateByNameWhenAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            assertFalse(api.iterateByName("www.denominator.io.").hasNext());
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void getByNameAndTypeWhenPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            assertEquals(api.getByNameAndType("www.denominator.io.", "A").get(),
+                    a("www.denominator.io.", ImmutableList.of("192.0.2.1", "192.0.2.2")));
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void getByNameAndTypeWhenAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            assertEquals(api.getByNameAndType("www.denominator.io.", "A"), Optional.absent());
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void deleteOne() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+        server.enqueue(new MockResponse());
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            api.deleteByNameAndType("denominator.io.", "MX");
+
+            assertEquals(server.getRequestCount(), 3);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+            assertEquals(
+                    server.takeRequest().getRequestLine(),
+                    format("DELETE /v1/domains/%s/records/%s HTTP/1.1", domainId,
+                            "13d2516b-1f18-455b-aa05-1997b26192ad"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void deleteAbsentRRSDoesNothing() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(aRecordResponse));
+        server.enqueue(new MockResponse());
+
+        try {
+            ResourceRecordSetApi api = mockApi(server.getUrl(""));
+            api.deleteByNameAndType("www1.denominator.io.", "A");
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    private static ResourceRecordSetApi mockApi(final URL url) {
+        return Denominator.create(new DesignateProvider() {
+            @Override
+            public String url() {
+                return url.toString();
+            }
+        }, credentials(tenantId, username, password)).api().basicRecordSetsInZone(domainId);
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateRoundRobinLiveTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateRoundRobinLiveTest.java
@@ -1,0 +1,16 @@
+package denominator.designate;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import denominator.BaseRoundRobinLiveTest;
+
+@Test
+public class DesignateRoundRobinLiveTest extends BaseRoundRobinLiveTest {
+    @BeforeClass
+    private void setUp() {
+        DesignateConnection connection = new DesignateConnection();
+        manager = connection.manager;
+        setMutableZoneIfPresent(connection.mutableZone);
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateTest.java
@@ -1,0 +1,485 @@
+package denominator.designate;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+import com.google.mockwebserver.QueueDispatcher;
+import com.google.mockwebserver.RecordedRequest;
+
+import denominator.designate.OpenStackApis.Designate;
+import denominator.designate.OpenStackApis.KeystoneV2;
+import denominator.designate.OpenStackApis.Record;
+import denominator.designate.OpenStackApis.TokenIdAndPublicURL;
+import denominator.model.Zone;
+import feign.Feign;
+import feign.Target.HardCodedTarget;
+
+@Test(singleThreaded = true)
+public class DesignateTest {
+    static String tenantId = "123123";
+    static String username = "joe";
+    static String password = "letmein";
+
+    static String auth = format(
+            "{\"auth\":{\"passwordCredentials\":{\"username\":\"%s\",\"password\":\"%s\"},\"tenantId\":\"%s\"}}",
+            username, password, tenantId);
+
+    static String tokenId = "b84f4a37-5126-4603-9521-ccd0665fbde1";
+
+    static String accessResponse = "" //
+            + "{\"access\": {\n" //
+            + "  \"token\": {\n" //
+            + "    \"expires\": \"2013-07-08T05:55:31.809Z\",\n" //
+            + format("    \"id\": \"%s\",\n", tokenId) //
+            + "    \"tenant\": {\n" //
+            + format("      \"id\": \"%s\",\n", tenantId) //
+            + "      \"name\": \"denominator\"\n" //
+            + "    }\n" //
+            + "  },\n" //
+            + "  \"serviceCatalog\": [\n" //
+            + "    {\n" //
+            + "      \"name\": \"Identity\",\n" //
+            + "      \"type\": \"identity\",\n" //
+            + "      \"endpoints\": [\n" //
+            + "        {\n" //
+            + "          \"publicURL\": \"URL\\/v2.0\\/\",\n" //
+            + "          \"region\": \"region-a.geo-1\",\n" //
+            + "          \"versionId\": \"2.0\",\n" //
+            + "          \"versionInfo\": \"URL\\/v2.0\\/\",\n" //
+            + "          \"versionList\": \"URL\"\n" //
+            + "        },\n" //
+            + "        {\n" //
+            + "          \"publicURL\": \"URL\\/v3\\/\",\n" //
+            + "          \"region\": \"region-a.geo-1\",\n" //
+            + "          \"versionId\": \"3.0\",\n" //
+            + "          \"versionInfo\": \"URL\\/v3\\/\",\n" //
+            + "          \"versionList\": \"URL\"\n" //
+            + "        }\n" //
+            + "      ]\n" //
+            + "    },\n" //
+            + "    {\n" //
+            + "      \"name\": \"DNS\",\n" //
+            + "      \"type\": \"hpext:dns\",\n" //
+            + "      \"endpoints\": [{\n" //
+            + "        \"tenantId\": \"10448598368512\",\n" //
+            + "        \"publicURL\": \"URL\\/v1\\/\",\n" //
+            + "        \"publicURL2\": \"\",\n" //
+            + "        \"region\": \"region-a.geo-1\",\n" //
+            + "        \"versionId\": \"1\",\n" //
+            + "        \"versionInfo\": \"URL\\/v1\\/\",\n" //
+            + "        \"versionList\": \"URL\\/\"\n" //
+            + "      }]\n" //
+            + "    }\n" //
+            + "  ]\n" //
+            + "}}";
+
+    @Test
+    public void authSuccess() throws IOException, InterruptedException, URISyntaxException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.play();
+
+        try {
+            KeystoneV2 api = Feign.create(new HardCodedTarget<KeystoneV2>(KeystoneV2.class, "not used!!"),
+                    new DesignateProvider.FeignModule());
+            TokenIdAndPublicURL tokenIdAndPublicURL = api.passwordAuth(server.getUrl("").toURI(), tenantId, username,
+                    password);
+
+            assertEquals(tokenIdAndPublicURL.tokenId, tokenId);
+            assertEquals(tokenIdAndPublicURL.publicURL, "URL/v1");
+
+            takeAuthResponse(server);
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    static String domainId = "62ac4caf-6108-4b74-b6fe-460967db32a7";
+
+    static String domainsResponse = ""//
+            + "{\n" //
+            + "  \"domains\": [\n" //
+            + "    {\n" //
+            + "      \"name\": \"denominator.io.\",\n" //
+            + "      \"created_at\": \"2013-07-07T17:55:21.000000\",\n" //
+            + "      \"updated_at\": null,\n" //
+            + "      \"email\": \"admin@denominator.io\",\n" //
+            + "      \"ttl\": 3600,\n" //
+            + "      \"serial\": 1373219721,\n" //
+            + format("      \"id\": \"%s\"\n", domainId) //
+            + "    }\n" //
+            + "  ]\n" //
+            + "}";
+
+    @Test
+    public void domainsPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(domainsResponse));
+        server.play();
+
+        try {
+            assertEquals(mockApi(server.getUrl("")).domains(),
+                    ImmutableList.of(Zone.create("denominator.io.", domainId)));
+
+            assertEquals(server.takeRequest().getRequestLine(), "GET /v1/domains HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void domainsAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody("{ \"domains\": [] }"));
+        server.play();
+
+        try {
+            assertTrue(mockApi(server.getUrl("")).domains().isEmpty());
+
+            assertEquals(server.takeRequest().getRequestLine(), "GET /v1/domains HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    // NOTE records are allowed to be out of order by type
+    static String recordsResponse = ""//
+            + "{\n" //
+            + "  \"records\": [\n" //
+            + "    {\n" //
+            + "      \"name\": \"www.denominator.io.\",\n" //
+            + "      \"data\": \"192.0.2.2\",\n" //
+            + "      \"created_at\": \"2013-07-07T18:09:47.000000\",\n" //
+            + "      \"updated_at\": null,\n" //
+            + "      \"id\": \"c538d70e-d65f-4d5a-92a2-cd5d4d1d9da4\",\n" //
+            + "      \"priority\": null,\n" //
+            + "      \"ttl\": 300,\n" //
+            + "      \"type\": \"A\",\n" //
+            + format("      \"domain_id\": \"%s\"\n", domainId) //
+            + "    },\n" //
+            + "    {\n" //
+            + "      \"name\": \"denominator.io.\",\n" //
+            + "      \"data\": \"www.denominator.io.\",\n" //
+            + "      \"created_at\": \"2013-07-07T18:09:47.000000\",\n" //
+            + "      \"updated_at\": null,\n" //
+            + "      \"id\": \"13d2516b-1f18-455b-aa05-1997b26192ad\",\n" //
+            + "      \"priority\": 10,\n" //
+            + "      \"ttl\": 300,\n" //
+            + "      \"type\": \"MX\",\n" //
+            + format("      \"domain_id\": \"%s\"\n", domainId) //
+            + "    },\n" //
+            + "    {\n" //
+            + "      \"name\": \"www.denominator.io.\",\n" //
+            + "      \"data\": \"192.0.2.1\",\n" //
+            + "      \"created_at\": \"2013-07-07T18:09:31.000000\",\n" //
+            + "      \"updated_at\": null,\n" //
+            + "      \"id\": \"d7eb0fc4-e069-4c92-a272-c5c969b4f558\",\n" //
+            + "      \"priority\": null,\n" //
+            + "      \"ttl\": 300,\n" //
+            + "      \"type\": \"A\",\n" //
+            + format("      \"domain_id\": \"%s\"\n", domainId) //
+            + "    }\n" //
+            + "  ]\n" //
+            + "}";
+
+    @Test
+    public void recordsPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(recordsResponse));
+        server.play();
+
+        try {
+            List<Record> records = mockApi(server.getUrl("")).records(domainId);
+            assertEquals(records.size(), 3);
+
+            // note that the response parser orders these by name, type, data!
+
+            assertEquals(records.get(0).id, "13d2516b-1f18-455b-aa05-1997b26192ad");
+            assertEquals(records.get(0).name, "denominator.io.");
+            assertEquals(records.get(0).data, "www.denominator.io.");
+            assertEquals(records.get(0).priority.intValue(), 10);
+            assertEquals(records.get(0).ttl.intValue(), 300);
+            assertEquals(records.get(0).type, "MX");
+
+            assertEquals(records.get(1).id, "d7eb0fc4-e069-4c92-a272-c5c969b4f558");
+            assertEquals(records.get(1).name, "www.denominator.io.");
+            assertEquals(records.get(1).data, "192.0.2.1");
+            assertNull(records.get(1).priority);
+            assertEquals(records.get(1).ttl.intValue(), 300);
+            assertEquals(records.get(1).type, "A");
+
+            assertEquals(records.get(2).id, "c538d70e-d65f-4d5a-92a2-cd5d4d1d9da4");
+            assertEquals(records.get(2).name, "www.denominator.io.");
+            assertEquals(records.get(2).data, "192.0.2.2");
+            assertNull(records.get(2).priority);
+            assertEquals(records.get(2).ttl.intValue(), 300);
+            assertEquals(records.get(2).type, "A");
+
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void recordsAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
+        server.play();
+
+        try {
+            assertTrue(mockApi(server.getUrl("")).records(domainId).isEmpty());
+
+            assertEquals(server.takeRequest().getRequestLine(), format("GET /v1/domains/%s/records HTTP/1.1", domainId));
+
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    static String mxRecordResponse = ""//
+            + "{\n" //
+            + "  \"name\": \"denominator.io.\",\n" //
+            + "  \"data\": \"www.denominator.io.\",\n" //
+            + "  \"created_at\": \"2013-07-07T18:09:47.000000\",\n" //
+            + "  \"updated_at\": null,\n" //
+            + "  \"id\": \"13d2516b-1f18-455b-aa05-1997b26192ad\",\n" //
+            + "  \"priority\": 10,\n" //
+            + "  \"ttl\": 300,\n" //
+            + "  \"type\": \"MX\",\n" //
+            + format("  \"domain_id\": \"%s\"\n", domainId) //
+            + "}";
+
+    @Test
+    public void createMXRecord() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(mxRecordResponse));
+        server.play();
+
+        try {
+            Record record = new Record();
+            record.name = "denominator.io.";
+            record.data = "www.denominator.io.";
+            record.priority = 10;
+            record.ttl = 300;
+            record.type = "MX";
+
+            record = mockApi(server.getUrl("")).createRecord(domainId, record);
+
+            assertEquals(record.id, "13d2516b-1f18-455b-aa05-1997b26192ad");
+            assertEquals(record.name, "denominator.io.");
+            assertEquals(record.data, "www.denominator.io.");
+            assertEquals(record.priority.intValue(), 10);
+            assertEquals(record.ttl.intValue(), 300);
+            assertEquals(record.type, "MX");
+
+            RecordedRequest createRequest = server.takeRequest();
+            assertEquals(createRequest.getRequestLine(), format("POST /v1/domains/%s/records HTTP/1.1", domainId));
+            assertEquals(new String(createRequest.getBody()),
+                    "{\"name\":\"denominator.io.\",\"type\":\"MX\",\"ttl\":300,\"data\":\"www.denominator.io.\",\"priority\":10}");
+
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void updateMXRecord() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(mxRecordResponse));
+        server.play();
+
+        try {
+            Record record = new Record();
+            record.id = "13d2516b-1f18-455b-aa05-1997b26192ad";
+            record.name = "denominator.io.";
+            record.data = "www.denominator.io.";
+            record.priority = 10;
+            record.ttl = 300;
+            record.type = "MX";
+
+            record = mockApi(server.getUrl("")).updateRecord(domainId, record);
+
+            assertEquals(record.id, "13d2516b-1f18-455b-aa05-1997b26192ad");
+            assertEquals(record.name, "denominator.io.");
+            assertEquals(record.data, "www.denominator.io.");
+            assertEquals(record.priority.intValue(), 10);
+            assertEquals(record.ttl.intValue(), 300);
+            assertEquals(record.type, "MX");
+
+            RecordedRequest updateRequest = server.takeRequest();
+            assertEquals(updateRequest.getRequestLine(),
+                    format("PUT /v1/domains/%s/records/%s HTTP/1.1", domainId, record.id));
+            assertEquals(new String(updateRequest.getBody()),
+                    "{\"name\":\"denominator.io.\",\"type\":\"MX\",\"ttl\":300,\"data\":\"www.denominator.io.\",\"priority\":10}");
+
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    static String aRecordResponse = ""//
+            + "{\n" //
+            + "  \"name\": \"www.denominator.io.\",\n" //
+            + "  \"data\": \"192.0.2.1\",\n" //
+            + "  \"created_at\": \"2013-07-07T18:09:47.000000\",\n" //
+            + "  \"updated_at\": null,\n" //
+            + "  \"id\": \"13d2516b-1f18-455b-aa05-1997b26192ad\",\n" //
+            + "  \"ttl\": null,\n" //
+            + "  \"type\": \"A\",\n" //
+            + format("  \"domain_id\": \"%s\"\n", domainId) //
+            + "}";
+
+    @Test
+    public void createARecord() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(aRecordResponse));
+        server.play();
+
+        try {
+            Record record = new Record();
+            record.name = "www.denominator.io.";
+            record.data = "192.0.2.1";
+            record.type = "A";
+
+            record = mockApi(server.getUrl("")).createRecord(domainId, record);
+
+            assertEquals(record.id, "13d2516b-1f18-455b-aa05-1997b26192ad");
+            assertEquals(record.name, "www.denominator.io.");
+            assertEquals(record.data, "192.0.2.1");
+            assertNull(record.priority);
+            assertNull(record.ttl);
+            assertEquals(record.type, "A");
+
+            RecordedRequest createRequest = server.takeRequest();
+            assertEquals(createRequest.getRequestLine(), format("POST /v1/domains/%s/records HTTP/1.1", domainId));
+            assertEquals(new String(createRequest.getBody()),
+                    "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"data\":\"192.0.2.1\"}");
+
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void updateARecord() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(aRecordResponse));
+        server.play();
+
+        try {
+            Record record = new Record();
+            record.id = "13d2516b-1f18-455b-aa05-1997b26192ad";
+            record.name = "www.denominator.io.";
+            record.data = "192.0.2.1";
+            record.type = "A";
+
+            record = mockApi(server.getUrl("")).updateRecord(domainId, record);
+
+            assertEquals(record.id, "13d2516b-1f18-455b-aa05-1997b26192ad");
+            assertEquals(record.name, "www.denominator.io.");
+            assertEquals(record.data, "192.0.2.1");
+            assertNull(record.priority);
+            assertNull(record.ttl);
+            assertEquals(record.type, "A");
+
+            RecordedRequest updateRequest = server.takeRequest();
+            assertEquals(updateRequest.getRequestLine(),
+                    format("PUT /v1/domains/%s/records/%s HTTP/1.1", domainId, record.id));
+            assertEquals(new String(updateRequest.getBody()),
+                    "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"data\":\"192.0.2.1\"}");
+
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void deleteRecord() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse());
+        server.play();
+
+        try {
+            String recordId = "13d2516b-1f18-455b-aa05-1997b26192ad";
+
+            mockApi(server.getUrl("")).deleteRecord(domainId, recordId);
+
+            assertEquals(server.takeRequest().getRequestLine(),
+                    format("DELETE /v1/domains/%s/records/%s HTTP/1.1", domainId, recordId));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    static Designate mockApi(final URL url) {
+        final TokenIdAndPublicURL tokenIdAndPublicURL = new TokenIdAndPublicURL();
+        tokenIdAndPublicURL.tokenId = tokenId;
+        tokenIdAndPublicURL.publicURL = url.toString() + "/v1";
+        return Feign.create(new DesignateTarget(new DesignateProvider() {
+            @Override
+            public String url() {
+                return tokenIdAndPublicURL.publicURL;
+            }
+        }, new javax.inject.Provider<TokenIdAndPublicURL>() {
+
+            @Override
+            public TokenIdAndPublicURL get() {
+                return tokenIdAndPublicURL;
+            }
+
+        }), new DesignateProvider.FeignModule());
+    }
+
+    static void takeAuthResponse(MockWebServer server) throws InterruptedException {
+        RecordedRequest authRequest = server.takeRequest();
+        assertEquals(authRequest.getRequestLine(), "POST /tokens HTTP/1.1");
+        assertEquals(new String(authRequest.getBody()), auth);
+    }
+
+    /**
+     * there's no built-in way to defer evaluation of a response header, hence
+     * this method, which allows us to send back links to the mock server.
+     */
+    static QueueDispatcher getURLReplacingQueueDispatcher(final URL url) {
+        return getURLReplacingQueueDispatcher(new AtomicReference<URL>(url));
+    }
+
+    static QueueDispatcher getURLReplacingQueueDispatcher(final AtomicReference<URL> url) {
+        final QueueDispatcher dispatcher = new QueueDispatcher() {
+            protected final BlockingQueue<MockResponse> responseQueue = new LinkedBlockingQueue<MockResponse>();
+
+            @Override
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                MockResponse response = responseQueue.take();
+                if (response.getBody() != null) {
+                    String newBody = new String(response.getBody()).replace(": \"URL", ": \"" + url.toString());
+                    response = response.setBody(newBody);
+                }
+                return response;
+            }
+
+            @Override
+            public void enqueueResponse(MockResponse response) {
+                responseQueue.add(response);
+            }
+        };
+
+        return dispatcher;
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/DesignateZoneApiMockTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/DesignateZoneApiMockTest.java
@@ -1,0 +1,91 @@
+package denominator.designate;
+
+import static denominator.CredentialsConfiguration.credentials;
+import static denominator.designate.DesignateTest.accessResponse;
+import static denominator.designate.DesignateTest.domainId;
+import static denominator.designate.DesignateTest.domainsResponse;
+import static denominator.designate.DesignateTest.getURLReplacingQueueDispatcher;
+import static denominator.designate.DesignateTest.password;
+import static denominator.designate.DesignateTest.takeAuthResponse;
+import static denominator.designate.DesignateTest.tenantId;
+import static denominator.designate.DesignateTest.username;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Iterator;
+
+import org.testng.annotations.Test;
+
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+
+import denominator.Denominator;
+import denominator.ZoneApi;
+import denominator.model.Zone;
+
+@Test(singleThreaded = true)
+public class DesignateZoneApiMockTest {
+
+    @Test
+    public void iteratorWhenPresent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody(domainsResponse));
+
+        try {
+            ZoneApi api = mockApi(url);
+            Iterator<Zone> domains = api.iterator();
+
+            while (domains.hasNext()) {
+                Zone zone = domains.next();
+                assertEquals(zone.name(), "denominator.io.");
+                assertEquals(zone.id().get(), domainId);
+            }
+
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), "GET /v1/domains HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void iteratorWhenAbsent() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        server.play();
+
+        URL url = server.getUrl("");
+        server.setDispatcher(getURLReplacingQueueDispatcher(url));
+
+        server.enqueue(new MockResponse().setBody(accessResponse));
+        server.enqueue(new MockResponse().setBody("{ \"domains\": [] }"));
+
+        try {
+            ZoneApi api = mockApi(url);
+
+            assertFalse(api.iterator().hasNext());
+            assertEquals(server.getRequestCount(), 2);
+            takeAuthResponse(server);
+            assertEquals(server.takeRequest().getRequestLine(), "GET /v1/domains HTTP/1.1");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    private static ZoneApi mockApi(final URL url) {
+        return Denominator.create(new DesignateProvider() {
+            @Override
+            public String url() {
+                return url.toString();
+            }
+        }, credentials(tenantId, username, password)).api().zones();
+    }
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/KeystoneV2AccessDecoderTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/KeystoneV2AccessDecoderTest.java
@@ -1,0 +1,100 @@
+package denominator.designate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.io.StringReader;
+
+import org.testng.annotations.Test;
+
+import denominator.designate.OpenStackApis.TokenIdAndPublicURL;
+
+@Test
+public class KeystoneV2AccessDecoderTest {
+
+    @Test
+    public void publicURLFound() throws Throwable {
+        String nameThenType = ""//
+                + "            \"name\": \"DNS\",\n" //
+                + "            \"endpoints\": [{\n" //
+                + "                \"tenantId\": \"1234\",\n" //
+                + "                \"publicURL\": \"https:\\/\\/dns.api.rackspacecloud.com\\/v1.0\\/1234\"\n" //
+                + "            }],\n" //
+                + "            \"type\": \"hpext:dns\"\n";
+
+        TokenIdAndPublicURL tokenIdAndPublicUrl = new KeystoneV2AccessDecoder("hpext:dns").decode(null,
+                new StringReader(ACCESS_HEADER + nameThenType + SERVICE + ACCESS_FOOTER), null);
+
+        assertEquals(tokenIdAndPublicUrl.tokenId, "1bcd122d87494f5ab39a185b9ec5ff73");
+        assertEquals(tokenIdAndPublicUrl.publicURL, "https://dns.api.rackspacecloud.com/v1.0/1234");
+    }
+
+    @Test
+    public void noEndpoints() throws Throwable {
+        String noEndpoints = ""//
+                + "            \"name\": \"DNS\",\n" //
+                + "            \"type\": \"hpext:dns\"\n";
+
+        TokenIdAndPublicURL tokenIdAndPublicUrl = new KeystoneV2AccessDecoder("hpext:dns").decode(null,
+                new StringReader(ACCESS_HEADER + noEndpoints + SERVICE + ACCESS_FOOTER), null);
+
+        assertEquals(tokenIdAndPublicUrl.tokenId, "1bcd122d87494f5ab39a185b9ec5ff73");
+        assertNull(tokenIdAndPublicUrl.publicURL);
+    }
+
+    @Test
+    public void serviceNotFound() throws Throwable {
+        TokenIdAndPublicURL tokenIdAndPublicUrl = new KeystoneV2AccessDecoder("hpext:dns").decode(null,
+                new StringReader(ACCESS_HEADER + SERVICE + ACCESS_FOOTER), null);
+
+        assertEquals(tokenIdAndPublicUrl.tokenId, "1bcd122d87494f5ab39a185b9ec5ff73");
+        assertNull(tokenIdAndPublicUrl.publicURL);
+    }
+
+    @Test
+    public void noServices() throws Throwable {
+        TokenIdAndPublicURL tokenIdAndPublicUrl = new KeystoneV2AccessDecoder("hpext:dns").decode(null,
+                new StringReader(ACCESS_HEADER + ACCESS_FOOTER), null);
+
+        assertEquals(tokenIdAndPublicUrl.tokenId, "1bcd122d87494f5ab39a185b9ec5ff73");
+        assertNull(tokenIdAndPublicUrl.publicURL);
+    }
+
+    @Test
+    public void noToken() throws Throwable {
+        TokenIdAndPublicURL tokenIdAndPublicUrl = new KeystoneV2AccessDecoder("hpext:dns").decode(null,
+                new StringReader("{\n" //
+                        + "    \"access\": {\n" //
+                        + "        \"serviceCatalog\": [{\n"//
+                        + ACCESS_FOOTER), null);
+
+        assertNull(tokenIdAndPublicUrl);
+    }
+
+    static final String TOKEN = ""//
+            + "        \"token\": {\n" //
+            + "            \"id\": \"1bcd122d87494f5ab39a185b9ec5ff73\",\n" //
+            + "            \"expires\": \"2013-07-01T10:13:55.109-05:00\",\n" //
+            + "            \"tenant\": {\n" //
+            + "                \"id\": \"1234\",\n" //
+            + "                \"name\": \"1234\"\n" //
+            + "            }\n" //
+            + "        },\n";
+    static final String ACCESS_HEADER = "{\n" //
+            + "    \"access\": {\n" //
+            + TOKEN //
+            + "        \"serviceCatalog\": [{\n";
+    static final String SERVICE = ""//
+            + "        }, {\n" //
+            + "            \"name\": \"cloudMonitoring\",\n" //
+            + "            \"endpoints\": [{\n" //
+            + "                \"tenantId\": \"1234\",\n" //
+            + "                \"publicURL\": \"https:\\/\\/monitoring.api.rackspacecloud.com\\/v1.0\\/1234\"\n" //
+            + "            }],\n" //
+            + "            \"type\": \"rax:monitor\"\n";
+    static final String ACCESS_FOOTER = ""//
+            + "        }]\n"//
+            + "    }\n" //
+            + "}";
+
+}

--- a/providers/denominator-designate/src/test/java/denominator/designate/ToRDataTest.java
+++ b/providers/denominator-designate/src/test/java/denominator/designate/ToRDataTest.java
@@ -1,0 +1,36 @@
+package denominator.designate;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import denominator.designate.GroupByRecordNameAndTypeIterator;
+import denominator.designate.OpenStackApis.Record;
+
+@Test
+public class ToRDataTest {
+
+    public void transformsNSRecordSet() {
+        Record input = new Record();
+        input.name = "denominator.io";
+        input.type = "NS";
+        input.ttl = 3600;
+        input.data = "dns1.stabletransit.com";              
+
+        assertEquals(GroupByRecordNameAndTypeIterator.toRData(input), ImmutableMap.<String, String> of(
+        		"nsdname", "dns1.stabletransit.com"));
+    }
+
+    public void transformsTXTRecordSet() {
+        Record input = new Record();
+        input.name = "denominator.io";
+        input.type = "TXT";
+        input.ttl = 3600;
+        input.data = "Hello DNS";                
+
+        assertEquals(GroupByRecordNameAndTypeIterator.toRData(input), ImmutableMap.<String, String> of(
+        		"txtdata", "Hello DNS"));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,5 +5,6 @@ include 'denominator-model', \
 'providers:denominator-ultradns', \
 'providers:denominator-dynect', \
 'providers:denominator-clouddns', \
+'providers:denominator-designate', \
 'denominator-cli'
 if (System.getenv("ANDROID_HOME") || System.getProperty("android.home")) include 'examples:denominator-example-android'


### PR DESCRIPTION
This adds full support for [OpenStack Designate](https://wiki.openstack.org/wiki/Designate).

I tested this using HP Cloud DNS using the below configuration:

```
name: hpcloud
provider: designate
url: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0
credentials:
  tenantId: 12345678910
  username: my_username
  password: my_password
```

This almost works against Rackspace Cloud DNS, except its api is slightly different.  For example, it returns a 404 when there are no domains or records whereas designate returns a 200 with an empty array.
