### PR TITLE
deprecate rrset.rdata in favor of the more intuitive rrset.records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### Version 2.3
+* deprecate `ResourceRecordSet.rdata()` for `ResourceRecordSet.records()`
+
 ### Version 2.2
 * adds url key to commandline config
 * adds support for OpenStack Designate

--- a/denominator-core/src/main/java/denominator/mock/MockGeoResourceRecordSetApi.java
+++ b/denominator-core/src/main/java/denominator/mock/MockGeoResourceRecordSetApi.java
@@ -64,7 +64,7 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
                         .qualifier(toTest.qualifier().get())//
                         .ttl(toTest.ttl().orNull())//
                         .addProfile(Geo.create(without))//
-                        .addAll(toTest.rdata()).build());
+                        .addAll(toTest.records()).build());
             }
         }
     }

--- a/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseProviderLiveTest.java
@@ -108,7 +108,7 @@ public abstract class BaseProviderLiveTest {
         checkNotNull(rrs.name(), "Name: ResourceRecordSet %s", rrs);
         checkNotNull(rrs.type(), "Type: ResourceRecordSet %s", rrs);
         checkNotNull(rrs.ttl(), "TTL: ResourceRecordSet %s", rrs);
-        assertTrue(!rrs.rdata().isEmpty(), "Values absent on ResourceRecordSet: " + rrs);
+        assertTrue(!rrs.records().isEmpty(), "Values absent on ResourceRecordSet: " + rrs);
     }
 
     protected void skipIfRRSetExists(Zone zone, String name, String type) {

--- a/denominator-core/src/test/java/denominator/BaseReadOnlyLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseReadOnlyLiveTest.java
@@ -35,7 +35,7 @@ public abstract class BaseReadOnlyLiveTest extends BaseProviderLiveTest {
         skipIfNoCredentials();
         for (Zone zone : zones()) {
             for (ResourceRecordSet<?> rrs : allApi(zone)) {
-                recordTypeCounts.getUnchecked(rrs.type()).addAndGet(rrs.rdata().size());
+                recordTypeCounts.getUnchecked(rrs.type()).addAndGet(rrs.records().size());
                 checkRRS(rrs);
                 checkListByNameAndTypeConsistent(zone, rrs);
                 if (rrs.qualifier().isPresent()) {

--- a/denominator-core/src/test/java/denominator/BaseRecordSetLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseRecordSetLiveTest.java
@@ -114,7 +114,7 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
                                           .name(recordSet.name())
                                           .type(recordSet.type())
                                           .ttl(1800)
-                                          .add(recordSet.rdata().get(0)).build());
+                                          .add(recordSet.records().get(0)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
                 .getByNameAndType(recordSet.name(), recordSet.type());
@@ -125,8 +125,8 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
         assertEquals(rrs.get().name(), recordSet.name());
         assertEquals(rrs.get().ttl().get(), Integer.valueOf(1800));
         assertEquals(rrs.get().type(), recordSet.type());
-        assertEquals(rrs.get().rdata().size(), 1);
-        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
+        assertEquals(rrs.get().records().size(), 1);
+        assertEquals(rrs.get().records().get(0), recordSet.records().get(0));
     }
 
     @Test(dependsOnMethods = "putNewRRS", dataProvider = "simpleRecords")
@@ -138,7 +138,7 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
                     .name(recordSet.name())
                     .type(recordSet.type())
                     .ttl(200000)
-                    .add(recordSet.rdata().get(0)).build());;
+                    .add(recordSet.records().get(0)).build());;
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
                 .getByNameAndType(recordSet.name(), recordSet.type());
@@ -149,8 +149,8 @@ public abstract class BaseRecordSetLiveTest extends BaseProviderLiveTest {
         assertEquals(rrs.get().name(), recordSet.name());
         assertEquals(rrs.get().type(), recordSet.type());
         assertEquals(rrs.get().ttl().get(), Integer.valueOf(200000));
-        assertEquals(rrs.get().rdata().size(), 1);
-        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
+        assertEquals(rrs.get().records().size(), 1);
+        assertEquals(rrs.get().records().get(0), recordSet.records().get(0));
     }
 
     @Test(dependsOnMethods = "putChangingTTL", dataProvider = "simpleRecords")

--- a/denominator-core/src/test/java/denominator/BaseRoundRobinLiveTest.java
+++ b/denominator-core/src/test/java/denominator/BaseRoundRobinLiveTest.java
@@ -51,7 +51,7 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
                                           .name(recordSet.name())
                                           .type(recordSet.type())
                                           .ttl(1800)
-                                          .add(recordSet.rdata().get(0)).build());
+                                          .add(recordSet.records().get(0)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
                 .getByNameAndType(recordSet.name(), recordSet.type());
@@ -62,8 +62,8 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         assertEquals(rrs.get().name(), recordSet.name());
         assertEquals(rrs.get().ttl().get(), Integer.valueOf(1800));
         assertEquals(rrs.get().type(), recordSet.type());
-        assertEquals(rrs.get().rdata().size(), 1);
-        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
+        assertEquals(rrs.get().records().size(), 1);
+        assertEquals(rrs.get().records().get(0), recordSet.records().get(0));
     }
 
     @Test(dependsOnMethods = "putNewRRS", dataProvider = "roundRobinRecords")
@@ -75,8 +75,8 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
                     .name(recordSet.name())
                     .type(recordSet.type())
                     .ttl(1800)
-                    .add(recordSet.rdata().get(0))
-                    .add(recordSet.rdata().get(1)).build());
+                    .add(recordSet.records().get(0))
+                    .add(recordSet.records().get(1)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
                 .getByNameAndType(recordSet.name(), recordSet.type());
@@ -86,9 +86,9 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         checkRRS(rrs.get());
         assertEquals(rrs.get().name(), recordSet.name());
         assertEquals(rrs.get().type(), recordSet.type());
-        assertEquals(rrs.get().rdata().size(), 2);
-        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
-        assertEquals(rrs.get().rdata().get(1), recordSet.rdata().get(1));
+        assertEquals(rrs.get().records().size(), 2);
+        assertEquals(rrs.get().records().get(0), recordSet.records().get(0));
+        assertEquals(rrs.get().records().get(1), recordSet.records().get(1));
     }
 
     @Test(dependsOnMethods = "putAddingRData", dataProvider = "roundRobinRecords")
@@ -100,8 +100,8 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
                     .name(recordSet.name())
                     .type(recordSet.type())
                     .ttl(200000)
-                    .add(recordSet.rdata().get(0))
-                    .add(recordSet.rdata().get(1)).build());
+                    .add(recordSet.records().get(0))
+                    .add(recordSet.records().get(1)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
                 .getByNameAndType(recordSet.name(), recordSet.type());
@@ -112,9 +112,9 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         assertEquals(rrs.get().name(), recordSet.name());
         assertEquals(rrs.get().type(), recordSet.type());
         assertEquals(rrs.get().ttl().get(), Integer.valueOf(200000));
-        assertEquals(rrs.get().rdata().size(), 2);
-        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
-        assertEquals(rrs.get().rdata().get(1), recordSet.rdata().get(1));
+        assertEquals(rrs.get().records().size(), 2);
+        assertEquals(rrs.get().records().get(0), recordSet.records().get(0));
+        assertEquals(rrs.get().records().get(1), recordSet.records().get(1));
     }
 
     @Test(dependsOnMethods = "putChangingTTL", dataProvider = "roundRobinRecords")
@@ -126,7 +126,7 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
                     .name(recordSet.name())
                     .type(recordSet.type())
                     .ttl(200000)
-                    .add(recordSet.rdata().get(0)).build());
+                    .add(recordSet.records().get(0)).build());
 
         Optional<ResourceRecordSet<?>> rrs = rrsApi(zone)
                 .getByNameAndType(recordSet.name(), recordSet.type());
@@ -136,8 +136,8 @@ public abstract class BaseRoundRobinLiveTest extends BaseProviderLiveTest {
         checkRRS(rrs.get());
         assertEquals(rrs.get().name(), recordSet.name());
         assertEquals(rrs.get().type(), recordSet.type());
-        assertEquals(rrs.get().rdata().size(), 1);
-        assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(0));
+        assertEquals(rrs.get().records().size(), 1);
+        assertEquals(rrs.get().records().get(0), recordSet.records().get(0));
     }
 
     @Test(dependsOnMethods = "putRemovingRData", dataProvider = "roundRobinRecords")

--- a/denominator-core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
@@ -52,8 +52,8 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
                 assertTrue(manager.provider().profileToRecordTypes().get("geo").contains(geoRRS.type()));
 
                 getAnonymousLogger().info(format("%s ::: geoRRS: %s", manager, geoRRS));
-                recordTypeCounts.getUnchecked(geoRRS.type()).addAndGet(geoRRS.rdata().size());
-                geoRecordCounts.getUnchecked(asGeo(geoRRS)).addAndGet(geoRRS.rdata().size());
+                recordTypeCounts.getUnchecked(geoRRS.type()).addAndGet(geoRRS.records().size());
+                geoRecordCounts.getUnchecked(asGeo(geoRRS)).addAndGet(geoRRS.records().size());
                 
                 Iterator<ResourceRecordSet<?>> byNameAndType = geoApi(zone).iterateByNameAndType(geoRRS.name(), geoRRS.type());
                 assertTrue(byNameAndType.hasNext(), "could not list by name and type: " + geoRRS);
@@ -77,7 +77,7 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
         checkNotNull(geoRRS.name(), "Name: ResourceRecordSet %s", geoRRS);
         checkNotNull(geoRRS.type(), "Type: ResourceRecordSet %s", geoRRS);
         checkNotNull(geoRRS.ttl(), "TTL: ResourceRecordSet %s", geoRRS);
-        assertFalse(geoRRS.rdata().isEmpty(), "Values absent on ResourceRecordSet: " + geoRRS);
+        assertFalse(geoRRS.records().isEmpty(), "Values absent on ResourceRecordSet: " + geoRRS);
     }
 
     @Test

--- a/denominator-core/src/test/java/denominator/profile/BaseGeoWriteCommandsLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseGeoWriteCommandsLiveTest.java
@@ -79,7 +79,7 @@ public abstract class BaseGeoWriteCommandsLiveTest extends BaseProviderLiveTest 
                                               .ttl(1800)
                                               .qualifier(qualifier)
                                               .addProfile(territories)
-                                              .add(recordSet.rdata().get(i)).build());
+                                              .add(recordSet.records().get(i)).build());
     
             Optional<ResourceRecordSet<?>> rrs = geoApi(zone)
                     .getByNameTypeAndQualifier(recordSet.name(), recordSet.type(), qualifier);
@@ -92,8 +92,8 @@ public abstract class BaseGeoWriteCommandsLiveTest extends BaseProviderLiveTest 
             assertEquals(rrs.get().type(), recordSet.type());
             assertEquals(rrs.get().qualifier().get(), qualifier);
             assertEquals(asGeo(rrs.get()).regions(), asGeo(territories).regions());
-            assertEquals(rrs.get().rdata().size(), 1);
-            assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(i++));
+            assertEquals(rrs.get().records().size(), 1);
+            assertEquals(rrs.get().records().get(0), recordSet.records().get(i++));
         }
     }
 
@@ -121,7 +121,7 @@ public abstract class BaseGeoWriteCommandsLiveTest extends BaseProviderLiveTest 
                                           .qualifier(qualifier2)
                                           .ttl(rrs2.ttl().orNull())
                                           .addProfile(Geo.create(plus1))
-                                          .addAll(rrs2.rdata()).build());
+                                          .addAll(rrs2.records()).build());
 
         rrs1 = geoApi(zone).getByNameTypeAndQualifier(
                 recordSet.name(), recordSet.type(), qualifier1).get();
@@ -156,7 +156,7 @@ public abstract class BaseGeoWriteCommandsLiveTest extends BaseProviderLiveTest 
                                               .ttl(ttl)
                                               .qualifier(qualifier)
                                               .addProfile(oldGeo)
-                                              .add(recordSet.rdata().get(i)).build());
+                                              .add(recordSet.records().get(i)).build());
 
             rrs = geoApi(zone).getByNameTypeAndQualifier(recordSet.name(), recordSet.type(),
                     qualifier).get();
@@ -167,8 +167,8 @@ public abstract class BaseGeoWriteCommandsLiveTest extends BaseProviderLiveTest 
             assertEquals(rrs.type(), recordSet.type());
             assertEquals(rrs.qualifier().get(), qualifier);
             assertEquals(asGeo(rrs).regions(), oldGeo.regions());
-            assertEquals(rrs.rdata().size(), 1);
-            assertEquals(rrs.rdata().get(0), recordSet.rdata().get(i++));
+            assertEquals(rrs.records().size(), 1);
+            assertEquals(rrs.records().get(0), recordSet.records().get(i++));
         }
     }
 

--- a/denominator-core/src/test/java/denominator/profile/BaseWeightedReadOnlyLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseWeightedReadOnlyLiveTest.java
@@ -47,8 +47,8 @@ public abstract class BaseWeightedReadOnlyLiveTest extends BaseProviderLiveTest 
                 assertTrue(manager.provider().profileToRecordTypes().get("weighted").contains(weightedRRS.type()));
 
                 getAnonymousLogger().info(format("%s ::: weightedRRS: %s", manager, weightedRRS));
-                recordTypeCounts.getUnchecked(weightedRRS.type()).addAndGet(weightedRRS.rdata().size());
-                weightedRecordCounts.getUnchecked(asWeighted(weightedRRS)).addAndGet(weightedRRS.rdata().size());
+                recordTypeCounts.getUnchecked(weightedRRS.type()).addAndGet(weightedRRS.records().size());
+                weightedRecordCounts.getUnchecked(asWeighted(weightedRRS)).addAndGet(weightedRRS.records().size());
                 
                 Iterator<ResourceRecordSet<?>> byNameAndType = weightedApi(zone).iterateByNameAndType(weightedRRS.name(), weightedRRS.type());
                 assertTrue(byNameAndType.hasNext(), "could not list by name and type: " + weightedRRS);
@@ -73,7 +73,7 @@ public abstract class BaseWeightedReadOnlyLiveTest extends BaseProviderLiveTest 
         checkNotNull(weightedRRS.name(), "Name: ResourceRecordSet %s", weightedRRS);
         checkNotNull(weightedRRS.type(), "Type: ResourceRecordSet %s", weightedRRS);
         checkNotNull(weightedRRS.ttl(), "TTL: ResourceRecordSet %s", weightedRRS);
-        assertFalse(weightedRRS.rdata().isEmpty(), "Values absent on ResourceRecordSet: " + weightedRRS);
+        assertFalse(weightedRRS.records().isEmpty(), "Values absent on ResourceRecordSet: " + weightedRRS);
     }
 
     @Test

--- a/denominator-core/src/test/java/denominator/profile/BaseWeightedWriteCommandsLiveTest.java
+++ b/denominator-core/src/test/java/denominator/profile/BaseWeightedWriteCommandsLiveTest.java
@@ -65,7 +65,7 @@ public abstract class BaseWeightedWriteCommandsLiveTest extends BaseProviderLive
                                               .addProfile(ImmutableMap.<String, Object> builder()//
                                                       .put("type", "weighted")//
                                                       .put("weight", 0).build())
-                                              .add(recordSet.rdata().get(i)).build());
+                                              .add(recordSet.records().get(i)).build());
     
             Optional<ResourceRecordSet<?>> rrs = weightedApi(zone)
                     .getByNameTypeAndQualifier(recordSet.name(), recordSet.type(), qualifier);
@@ -78,8 +78,8 @@ public abstract class BaseWeightedWriteCommandsLiveTest extends BaseProviderLive
             assertEquals(rrs.get().type(), recordSet.type());
             assertEquals(rrs.get().qualifier().get(), qualifier);
             assertEquals(asWeighted(rrs.get()).weight(), 0);
-            assertEquals(rrs.get().rdata().size(), 1);
-            assertEquals(rrs.get().rdata().get(0), recordSet.rdata().get(i++));
+            assertEquals(rrs.get().records().size(), 1);
+            assertEquals(rrs.get().records().get(0), recordSet.records().get(i++));
         }
     }
 
@@ -96,7 +96,7 @@ public abstract class BaseWeightedWriteCommandsLiveTest extends BaseProviderLive
                                                .ttl(1800)
                                                .qualifier(qualifier1)
                                                .addProfile(Weighted.create(heaviest))
-                                               .add(recordSet.rdata().get(0)).build());
+                                               .add(recordSet.records().get(0)).build());
 
         ResourceRecordSet<?> rrs1 = weightedApi(zone).getByNameTypeAndQualifier(
                 recordSet.name(), recordSet.type(), qualifier1).get();

--- a/denominator-model/src/main/java/denominator/model/AbstractRecordSetBuilder.java
+++ b/denominator-model/src/main/java/denominator/model/AbstractRecordSetBuilder.java
@@ -100,11 +100,11 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
     }
 
     public ResourceRecordSet<D> build() {
-        return new ResourceRecordSet<D>(name, type, qualifier, ttl, rdataValues(), profile.build());
+        return new ResourceRecordSet<D>(name, type, qualifier, ttl, records(), profile.build());
     }
 
     /**
      * aggregate collected rdata values
      */
-    protected abstract ImmutableList<D> rdataValues();
+    protected abstract ImmutableList<D> records();
 }

--- a/denominator-model/src/main/java/denominator/model/ResourceRecordSet.java
+++ b/denominator-model/src/main/java/denominator/model/ResourceRecordSet.java
@@ -33,11 +33,11 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
     private final String type;
     private final Optional<String> qualifier;
     private final Optional<Integer> ttl;
-    private final ImmutableList<D> rdata;
+    private final ImmutableList<D> records;
     private final ImmutableList<Map<String, Object>> profiles;
 
-    @ConstructorProperties({ "name", "type", "qualifier", "ttl", "rdata", "profiles" })
-    ResourceRecordSet(String name, String type, Optional<String> qualifier, Optional<Integer> ttl, ImmutableList<D> rdata,
+    @ConstructorProperties({ "name", "type", "qualifier", "ttl", "records", "profiles" })
+    ResourceRecordSet(String name, String type, Optional<String> qualifier, Optional<Integer> ttl, ImmutableList<D> records,
             ImmutableList<Map<String, Object>> profiles) {
         this.name = checkNotNull(name, "name");
         checkArgument(name.length() <= 255, "Name must be limited to 255 characters"); 
@@ -46,7 +46,7 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
         this.ttl = checkNotNull(ttl, "ttl of %s %s", name, type);
         checkArgument(UnsignedInteger.fromIntBits(this.ttl.or(0)).longValue() <= 0x7FFFFFFFL, // Per RFC 2181 
                 "Invalid ttl value: %s, must be 0-2147483647", this.ttl);
-        this.rdata = checkNotNull(rdata, "rdata  of %s %s", name, type);
+        this.records = checkNotNull(records, "records  of %s %s", name, type);
         this.profiles = checkNotNull(profiles, "profiles of %s %s", name, type);
     }
 
@@ -112,15 +112,23 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
      * RData type shared across elements. This may be empty in the case of
      * special profile such as `alias`.
      * 
-     * @since 1.3
+     * @since 2.3
      */
+    public List<D> records() {
+        return records;
+    }
+
+    /**
+     * @deprecated please use {@link #records} as this will be removed in denominator 3.
+     */
+    @Deprecated
     public List<D> rdata() {
-        return rdata;
+        return records();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name, type, qualifier, rdata, profiles);
+        return Objects.hashCode(name, type, qualifier, records, profiles);
     }
 
     @Override
@@ -131,7 +139,7 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
             return false;
         ResourceRecordSet<?> that = ResourceRecordSet.class.cast(obj);
         return equal(this.name, that.name) && equal(this.type, that.type) && equal(this.qualifier, that.qualifier)
-                && equal(this.rdata, that.rdata) && equal(this.profiles, that.profiles);
+                && equal(this.records, that.records) && equal(this.profiles, that.profiles);
     }
 
     @Override
@@ -141,7 +149,7 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
                                    .add("type", type)
                                    .add("qualifier", qualifier.orNull())
                                    .add("ttl", ttl.orNull())
-                                   .add("rdata", rdata.isEmpty() ? null : rdata)
+                                   .add("records", records.isEmpty() ? null : records)
                                    .add("profiles", profiles.isEmpty() ? null : profiles).toString();
     }
 
@@ -160,7 +168,7 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
      */
     public static class Builder<D extends Map<String, Object>> extends AbstractRecordSetBuilder<D, D, Builder<D>> {
 
-        private ImmutableList.Builder<D> rdata = ImmutableList.builder();
+        private ImmutableList.Builder<D> records = ImmutableList.builder();
 
         /**
          * adds a value to the builder.
@@ -171,13 +179,13 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
          * builder.add(srvData);
          * </pre>
          */
-        public Builder<D> add(D rdata) {
-            this.rdata.add(checkNotNull(rdata, "rdata"));
+        public Builder<D> add(D record) {
+            this.records.add(checkNotNull(record, "record"));
             return this;
         }
 
         /**
-         * replaces all rdata values in the builder
+         * replaces all records values in the builder
          * 
          * ex.
          * 
@@ -185,13 +193,13 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
          * builder.addAll(srvData1, srvData2);
          * </pre>
          */
-        public Builder<D> addAll(D... rdata) {
-            this.rdata.addAll(ImmutableList.copyOf(checkNotNull(rdata, "rdata")));
+        public Builder<D> addAll(D... records) {
+            this.records.addAll(ImmutableList.copyOf(checkNotNull(records, "records")));
             return this;
         }
 
         /**
-         * replaces all rdata values in the builder
+         * replaces all records values in the builder
          * 
          * ex.
          * 
@@ -200,14 +208,14 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
          * builder.addAll(otherRecordSet);
          * </pre>
          */
-        public <R extends D> Builder<D> addAll(Iterable<R> rdata) {
-            this.rdata.addAll(checkNotNull(rdata, "rdata"));
+        public <R extends D> Builder<D> addAll(Iterable<R> records) {
+            this.records.addAll(checkNotNull(records, "records"));
             return this;
         }
 
         @Override
-        protected ImmutableList<D> rdataValues() {
-            return rdata.build();
+        protected ImmutableList<D> records() {
+            return records.build();
         }
     }
 }

--- a/denominator-model/src/main/java/denominator/model/ResourceRecordSets.java
+++ b/denominator-model/src/main/java/denominator/model/ResourceRecordSets.java
@@ -127,33 +127,43 @@ public class ResourceRecordSets {
     }
 
     /**
+     * @deprecated please use {@link #containsRecord} as this will be removed in denominator 3.
+     * 
+     * @since 2.3
+     */
+    @Deprecated
+    public static Predicate<ResourceRecordSet<?>> containsRData(Map<String, ?> rdata) {
+        return containsRecord(rdata);
+    }
+
+    /**
      * evaluates to true if the input {@link ResourceRecordSet} exists and
      * contains the {@code rdata} specified.
      * 
-     * @param rdata
+     * @param record
      *            the rdata in the desired record set
      */
-    public static Predicate<ResourceRecordSet<?>> containsRData(Map<String, ?> rdata) {
-        return new ContainsRData(rdata);
+    public static Predicate<ResourceRecordSet<?>> containsRecord(Map<String, ?> record) {
+        return new ContainsRecord(record);
     }
 
-    private static final class ContainsRData implements Predicate<ResourceRecordSet<?>> {
-        private final Map<String, ?> rdata;
+    private static final class ContainsRecord implements Predicate<ResourceRecordSet<?>> {
+        private final Map<String, ?> record;
 
-        public ContainsRData(Map<String, ?> rdata) {
-            this.rdata = checkNotNull(rdata, "rdata");
+        public ContainsRecord(Map<String, ?> record) {
+            this.record = checkNotNull(record, "record");
         }
 
         @Override
         public boolean apply(ResourceRecordSet<?> input) {
             if (input == null)
                 return false;
-            return input.rdata().contains(rdata);
+            return input.records().contains(record);
         }
 
         @Override
         public String toString() {
-            return "containsRData(" + rdata + ")";
+            return "containsRecord(" + record + ")";
         }
     }
 
@@ -317,7 +327,7 @@ public class ResourceRecordSets {
         return new ABuilder().name(name).ttl(ttl).addAll(addresses).build();
     }
 
-    private static class ABuilder extends StringRDataBuilder<AData> {
+    private static class ABuilder extends StringRecordBuilder<AData> {
         private ABuilder() {
             type("A");
         }
@@ -385,7 +395,7 @@ public class ResourceRecordSets {
         return new AAAABuilder().name(name).ttl(ttl).addAll(addresses).build();
     }
 
-    private static class AAAABuilder extends StringRDataBuilder<AAAAData> {
+    private static class AAAABuilder extends StringRecordBuilder<AAAAData> {
         private AAAABuilder() {
             type("AAAA");
         }
@@ -455,7 +465,7 @@ public class ResourceRecordSets {
         return new CNAMEBuilder().name(name).ttl(ttl).addAll(cnames).build();
     }
 
-    private static class CNAMEBuilder extends StringRDataBuilder<CNAMEData> {
+    private static class CNAMEBuilder extends StringRecordBuilder<CNAMEData> {
         private CNAMEBuilder() {
             type("CNAME");
         }
@@ -523,7 +533,7 @@ public class ResourceRecordSets {
         return new NSBuilder().name(name).ttl(ttl).addAll(nsdnames).build();
     }
 
-    private static class NSBuilder extends StringRDataBuilder<NSData> {
+    private static class NSBuilder extends StringRecordBuilder<NSData> {
         private NSBuilder() {
             type("NS");
         }
@@ -591,7 +601,7 @@ public class ResourceRecordSets {
         return new PTRBuilder().name(name).ttl(ttl).addAll(ptrdnames).build();
     }
 
-    private static class PTRBuilder extends StringRDataBuilder<PTRData> {
+    private static class PTRBuilder extends StringRecordBuilder<PTRData> {
         private PTRBuilder() {
             type("PTR");
         }
@@ -659,7 +669,7 @@ public class ResourceRecordSets {
         return new SPFBuilder().name(name).ttl(ttl).addAll(spfdata).build();
     }
 
-    private static class SPFBuilder extends StringRDataBuilder<SPFData> {
+    private static class SPFBuilder extends StringRecordBuilder<SPFData> {
         private SPFBuilder() {
             type("SPF");
         }
@@ -727,7 +737,7 @@ public class ResourceRecordSets {
         return new TXTBuilder().name(name).ttl(ttl).addAll(txtdata).build();
     }
 
-    private static class TXTBuilder extends StringRDataBuilder<TXTData> {
+    private static class TXTBuilder extends StringRecordBuilder<TXTData> {
         private TXTBuilder() {
             type("TXT");
         }

--- a/denominator-model/src/main/java/denominator/model/StringRecordBuilder.java
+++ b/denominator-model/src/main/java/denominator/model/StringRecordBuilder.java
@@ -17,10 +17,10 @@ import denominator.model.rdata.CNAMEData;
  * @param <D>
  *            portable type of the rdata in the {@link ResourceRecordSet}
  */
-abstract class StringRDataBuilder<D extends Map<String, Object>> extends
-        AbstractRecordSetBuilder<String, D, StringRDataBuilder<D>> implements Function<String, D> {
+abstract class StringRecordBuilder<D extends Map<String, Object>> extends
+        AbstractRecordSetBuilder<String, D, StringRecordBuilder<D>> implements Function<String, D> {
 
-    private ImmutableList.Builder<D> rdata = ImmutableList.builder();
+    private ImmutableList.Builder<D> records = ImmutableList.builder();
 
     /**
      * adds a value to the builder.
@@ -31,8 +31,8 @@ abstract class StringRDataBuilder<D extends Map<String, Object>> extends
      * builder.add(&quot;192.0.2.1&quot;);
      * </pre>
      */
-    public StringRDataBuilder<D> add(String rdata) {
-        this.rdata.add(apply(checkNotNull(rdata, "rdata")));
+    public StringRecordBuilder<D> add(String record) {
+        this.records.add(apply(checkNotNull(record, "record")));
         return this;
     }
 
@@ -45,8 +45,8 @@ abstract class StringRDataBuilder<D extends Map<String, Object>> extends
      * builder.addAll(&quot;192.0.2.1&quot;, &quot;192.0.2.2&quot;);
      * </pre>
      */
-    public StringRDataBuilder<D> addAll(String... rdata) {
-        this.rdata.addAll(transform(ImmutableList.<String> copyOf(checkNotNull(rdata, "rdata")), this));
+    public StringRecordBuilder<D> addAll(String... records) {
+        this.records.addAll(transform(ImmutableList.<String> copyOf(checkNotNull(records, "records")), this));
         return this;
     }
 
@@ -59,13 +59,13 @@ abstract class StringRDataBuilder<D extends Map<String, Object>> extends
      * builder.addAll(&quot;192.0.2.1&quot;, &quot;192.0.2.2&quot;);
      * </pre>
      */
-    public StringRDataBuilder<D> addAll(Iterable<String> rdata) {
-        this.rdata.addAll(transform(checkNotNull(rdata, "rdata"), this));
+    public StringRecordBuilder<D> addAll(Iterable<String> records) {
+        this.records.addAll(transform(checkNotNull(records, "records"), this));
         return this;
     }
 
     @Override
-    protected ImmutableList<D> rdataValues() {
-        return rdata.build();
+    protected ImmutableList<D> records() {
+        return records.build();
     }
 }

--- a/denominator-model/src/test/java/denominator/model/ResourceRecordSetTest.java
+++ b/denominator-model/src/test/java/denominator/model/ResourceRecordSetTest.java
@@ -20,10 +20,10 @@ public class ResourceRecordSetTest {
         assertEquals(record.name(), "www.denominator.io.");
         assertEquals(record.type(), "A");
         assertEquals(record.ttl().get(), Integer.valueOf(3600));
-        assertEquals(record.rdata().get(0), AData.create("192.0.2.1"));
+        assertEquals(record.records().get(0), AData.create("192.0.2.1"));
     }
 
-    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "rdata")
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "record")
     public void testNullRdataNPE() {
         ResourceRecordSet.<AData> builder().add(null);
     }

--- a/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/denominator-model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -68,19 +68,19 @@ public class ResourceRecordSetsTest {
     }
 
     public void containsRDataReturnsFalseOnNull() {
-        assertFalse(ResourceRecordSets.containsRData(aRRS.rdata().get(0)).apply(null));
+        assertFalse(ResourceRecordSets.containsRecord(aRRS.records().get(0)).apply(null));
     }
 
     public void containsRDataReturnsFalseWhenRDataDifferent() {
-        assertFalse(ResourceRecordSets.containsRData(AData.create("198.51.100.1")).apply(aRRS));
+        assertFalse(ResourceRecordSets.containsRecord(AData.create("198.51.100.1")).apply(aRRS));
     }
 
     public void containsRDataReturnsTrueWhenRDataEqual() {
-        assertTrue(ResourceRecordSets.containsRData(AData.create("192.0.2.1")).apply(aRRS));
+        assertTrue(ResourceRecordSets.containsRecord(AData.create("192.0.2.1")).apply(aRRS));
     }
 
     public void containsRDataReturnsTrueWhenRDataEqualButDifferentType() {
-        assertTrue(ResourceRecordSets.containsRData(ImmutableMap.of("address", "192.0.2.1")).apply(aRRS));
+        assertTrue(ResourceRecordSets.containsRecord(ImmutableMap.of("address", "192.0.2.1")).apply(aRRS));
     }
 
     Geo geo = Geo.create(ImmutableMultimap.of("US", "US-VA"));
@@ -292,6 +292,6 @@ public class ResourceRecordSetsTest {
         assertEquals(shortForm.name(), longForm.name());
         assertEquals(shortForm.type(), longForm.type());
         assertEquals(shortForm.ttl(), longForm.ttl());
-        assertEquals(ImmutableList.copyOf(shortForm.rdata()), ImmutableList.copyOf(longForm.rdata()));
+        assertEquals(ImmutableList.copyOf(shortForm.records()), ImmutableList.copyOf(longForm.records()));
     }
 }

--- a/denominator-model/src/test/java/denominator/model/rdata/CNAMEDataTest.java
+++ b/denominator-model/src/test/java/denominator/model/rdata/CNAMEDataTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 @Test
 public class CNAMEDataTest {
 
-    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "rdata")
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "record")
     public void testNullTarget() {
         cname("www.denominator.io.", (String) null);
     }

--- a/denominator-model/src/test/java/denominator/model/rdata/NSDataTest.java
+++ b/denominator-model/src/test/java/denominator/model/rdata/NSDataTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 @Test
 public class NSDataTest {
 
-    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "rdata")
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "record")
     public void testNullTargetNS() {
         ns("www.denominator.io.", (String) null);
     }

--- a/providers/denominator-designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
+++ b/providers/denominator-designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
@@ -55,9 +55,9 @@ class DesignateResourceRecordSetApi implements denominator.ResourceRecordSetApi 
     @Override
     public void put(ResourceRecordSet<?> rrset) {
         checkNotNull(rrset, "rrset was null");
-        checkArgument(!rrset.rdata().isEmpty(), "rrset was empty %s", rrset);
+        checkArgument(!rrset.records().isEmpty(), "rrset was empty %s", rrset);
 
-        List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset.rdata());
+        List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset.records());
 
         for (Record record : api.records(domainId)) {
             // TODO: name and type filter

--- a/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
+++ b/providers/denominator-dynect/src/main/java/denominator/dynect/DynECTResourceRecordSetApi.java
@@ -70,10 +70,10 @@ public final class DynECTResourceRecordSetApi implements denominator.ResourceRec
     @Override
     public void put(final ResourceRecordSet<?> rrset) {
         checkNotNull(rrset, "rrset was null");
-        checkArgument(!rrset.rdata().isEmpty(), "rrset was empty %s", rrset);
+        checkArgument(!rrset.records().isEmpty(), "rrset was empty %s", rrset);
         int ttlToApply = rrset.ttl().or(0);
 
-        List<Map<String, Object>> recordsLeftToCreate = Lists.newArrayList(rrset.rdata());
+        List<Map<String, Object>> recordsLeftToCreate = Lists.newArrayList(rrset.records());
 
         Iterator<Record> existingRecords = emptyIteratorOn404(new Supplier<Iterator<Record>>() {
             @Override

--- a/providers/denominator-route53/src/main/java/denominator/route53/SerializeRRS.java
+++ b/providers/denominator-route53/src/main/java/denominator/route53/SerializeRRS.java
@@ -39,7 +39,7 @@ enum SerializeRRS implements Function<ResourceRecordSet<?>, String> {
             // default ttl from the amazon console is 300
             builder.append("<TTL>").append(rrs.ttl().or(300)).append("</TTL>");
             builder.append("<ResourceRecords>");
-            for (Map<String, Object> data : rrs.rdata()) {
+            for (Map<String, Object> data : rrs.records()) {
                 String textFormat = Joiner.on(' ').join(data.values());
                 if (ImmutableSet.of("SPF", "TXT").contains(rrs.type())) {
                     textFormat = format("\"%s\"", textFormat);

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
@@ -157,7 +157,7 @@ final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordSetApi {
         directionalGroup.name = group;
         directionalGroup.regionToTerritories = regions;
 
-        List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset.rdata());
+        List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset.records());
         for (DirectionalRecord record : recordsByNameTypeAndQualifier(rrset.name(), rrset.type(), group)) {
             Map<String, Object> rdata = forTypeAndRData(record.type, record.rdata);
             if (recordsLeftToCreate.contains(rdata)) {

--- a/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
+++ b/providers/denominator-ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
@@ -73,12 +73,12 @@ final class UltraDNSResourceRecordSetApi implements denominator.ResourceRecordSe
     @Override
     public void put(ResourceRecordSet<?> rrset) {
         checkNotNull(rrset, "rrset was null");
-        checkArgument(!rrset.rdata().isEmpty(), "rrset was empty %s", rrset);
+        checkArgument(!rrset.records().isEmpty(), "rrset was empty %s", rrset);
         int ttlToApply = rrset.ttl().or(defaultTTL);
 
         List<Record> records = recordsByNameAndType(rrset.name(), rrset.type());
 
-        List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset.rdata());
+        List<Map<String, Object>> recordsLeftToCreate = newArrayList(rrset.records());
 
         for (Record record : records) {
             Map<String, Object> rdata = toRdataMap().apply(record);

--- a/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
+++ b/providers/denominator-ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
@@ -377,7 +377,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
                                                                          .type(europe.type())
                                                                          .qualifier(europe.qualifier().orNull())
                                                                          .ttl(europe.ttl().orNull())
-                                                                         .addAll(europe.rdata())
+                                                                         .addAll(europe.records())
                                                                          .addProfile(Geo.create(ImmutableMultimap.of("Europe", "Aland Islands")))                             
                                                                          .build();
             api.put(lessOfEurope);
@@ -429,7 +429,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
                                                                          .type(europe.type())
                                                                          .qualifier(europe.qualifier().orNull())
                                                                          .ttl(600)
-                                                                         .addAll(europe.rdata())
+                                                                         .addAll(europe.records())
                                                                          .addAllProfile(europe.profiles())                             
                                                                          .build();
             api.put(lessTTL);


### PR DESCRIPTION
Particularly as the next version of denominator will have json and yaml representations, we need to ensure our field names are as intuitive as possible.

`ResourceRecordSet.rdata()` currently returns a list of, for example ip addresses.
`ResourceRecordSet.records()` is more intuitive at the cost of being slightly less "spec correct" 

Thanks @kiall for the idea.
