### PR TITLE
flatten ResourceRecordSet.profiles()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ### Version 3.7
+* introduce `ResourceRecordSet.geo()` and `ResourceRecordSet.weighted()`, which deprecate `ResourceRecordSet.profiles()`
 * match java method names with soap or action names.
 
 ### Version 3.6.1

--- a/cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
+++ b/cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
@@ -7,7 +7,6 @@ import static com.google.common.collect.Iterators.singletonIterator;
 import static com.google.common.collect.Iterators.transform;
 import static denominator.cli.Denominator.idOrName;
 import static denominator.cli.Denominator.json;
-import static denominator.model.profile.Geo.asGeo;
 import static denominator.model.profile.Geos.withAdditionalRegions;
 import static java.lang.String.format;
 import io.airlift.command.Arguments;
@@ -36,7 +35,6 @@ import denominator.DNSApiManager;
 import denominator.cli.Denominator.DenominatorCommand;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetToString;
 import denominator.model.ResourceRecordSet;
-import denominator.model.profile.Geo;
 import denominator.profile.GeoResourceRecordSetApi;
 
 class GeoResourceRecordSetCommands {
@@ -142,6 +140,8 @@ class GeoResourceRecordSetCommands {
                                                  .type(type)
                                                  .qualifier(group)
                                                  .ttl(ttl)
+                                                 .weighted(rrs.weighted())
+                                                 .geo(rrs.geo())
                                                  .addAllProfile(rrs.profiles())
                                                  .addAll(rrs.records()).build());
                     }
@@ -263,9 +263,8 @@ class GeoResourceRecordSetCommands {
         public String apply(ResourceRecordSet<?> rrset) {
             ImmutableList.Builder<String> lines = ImmutableList.<String> builder();
             for (String line : Splitter.on('\n').split(ResourceRecordSetToString.INSTANCE.apply(rrset))) {
-                Geo geo = asGeo(rrset);
-                if (geo != null) {
-                    lines.add(new StringBuilder().append(line).append(' ').append(json.toJson(geo.regions()))
+                if (rrset.geo() != null) {
+                    lines.add(new StringBuilder().append(line).append(' ').append(json.toJson(rrset.geo().regions()))
                             .toString());
                 } else {
                     lines.add(line);

--- a/cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -32,7 +32,6 @@ import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetRemove;
 import denominator.cli.ResourceRecordSetCommands.ResourceRecordSetReplace;
 import denominator.mock.MockProvider;
 import denominator.model.ResourceRecordSet;
-import denominator.model.profile.Geo;
 import denominator.model.rdata.AData;
 import denominator.model.rdata.CNAMEData;
 
@@ -508,9 +507,8 @@ public class DenominatorTest {
                 ";; ok"));
 
         assertEquals(
-                json.toJson(Geo.asGeo(
-                        mgr.api().recordSetsInZone(command.zoneIdOrName)
-                                .getByNameTypeAndQualifier(command.name, command.type, command.group)).regions()),
+                json.toJson(mgr.api().recordSetsInZone(command.zoneIdOrName)
+                               .getByNameTypeAndQualifier(command.name, command.type, command.group).geo().regions()),
                 "{\"United States (US)\":[\"Alaska\",\"Arizona\"],\"Mexico\":[\"Mexico\"]}");
 
         api.put(old);
@@ -557,9 +555,8 @@ public class DenominatorTest {
                 ";; ok"));
 
         assertEquals(
-                json.toJson(Geo.asGeo(
-                        mgr.api().recordSetsInZone(command.zoneIdOrName)
-                                .getByNameTypeAndQualifier(command.name, command.type, command.group)).regions()),
+                json.toJson(mgr.api().recordSetsInZone(command.zoneIdOrName)
+                               .getByNameTypeAndQualifier(command.name, command.type, command.group).geo().regions()),
                 "{\"United States (US)\":[\"Alaska\",\"Arizona\"],\"Mexico\":[\"Mexico\"],\"South America\":[\"Ecuador\"]}");
 
         api.put(old);

--- a/core/src/main/java/denominator/config/ConcatBasicAndQualifiedResourceRecordSets.java
+++ b/core/src/main/java/denominator/config/ConcatBasicAndQualifiedResourceRecordSets.java
@@ -2,16 +2,12 @@ package denominator.config;
 
 import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Util.concat;
-import static denominator.model.ResourceRecordSets.toProfileTypes;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.inject.Singleton;
@@ -24,6 +20,8 @@ import denominator.QualifiedResourceRecordSetApi;
 import denominator.QualifiedResourceRecordSetApi.Factory;
 import denominator.ResourceRecordSetApi;
 import denominator.model.ResourceRecordSet;
+import denominator.profile.GeoResourceRecordSetApi;
+import denominator.profile.WeightedResourceRecordSetApi;
 
 /**
  * Used when basic and qualified resource record sets are distinct in the
@@ -35,35 +33,36 @@ public class ConcatBasicAndQualifiedResourceRecordSets {
     @Provides
     @Singleton
     AllProfileResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(
-            final ResourceRecordSetApi.Factory factory, final Map<Factory, Collection<String>> factoryToProfiles) {
+            final ResourceRecordSetApi.Factory factory, final Set<Factory> factories) {
         return new AllProfileResourceRecordSetApi.Factory() {
 
             @Override
             public AllProfileResourceRecordSetApi create(String idOrName) {
-                Map<QualifiedResourceRecordSetApi, Collection<String>> apiToProfiles = new LinkedHashMap<QualifiedResourceRecordSetApi, Collection<String>>();
-                for (Entry<Factory, Collection<String>> entry : factoryToProfiles.entrySet()) {
-                    QualifiedResourceRecordSetApi api = entry.getKey().create(idOrName);
-                    if (api != null)
-                        apiToProfiles.put(api, entry.getValue());
+                Set<QualifiedResourceRecordSetApi> qualifiedApis = new LinkedHashSet<QualifiedResourceRecordSetApi>();
+                for (Factory entry : factories) {
+                    QualifiedResourceRecordSetApi api = entry.create(idOrName);
+                    if (api != null) {
+                        qualifiedApis.add(api);
+                    }
                 }
-                return new ConcatBasicAndGeoResourceRecordSetApi(factory.create(idOrName), apiToProfiles);
+                return new ConcatBasicAndGeoResourceRecordSetApi(factory.create(idOrName), qualifiedApis);
             }
         };
     }
 
     private static class ConcatBasicAndGeoResourceRecordSetApi implements AllProfileResourceRecordSetApi {
         private final ResourceRecordSetApi api;
-        private final Map<QualifiedResourceRecordSetApi, Collection<String>> apiToProfiles;
+        private final Set<QualifiedResourceRecordSetApi> qualifiedApis;
 
         private ConcatBasicAndGeoResourceRecordSetApi(ResourceRecordSetApi api,
-                Map<QualifiedResourceRecordSetApi, Collection<String>> apiToProfiles) {
+                Set<QualifiedResourceRecordSetApi> qualifiedApis) {
             this.api = api;
-            this.apiToProfiles = apiToProfiles;
+            this.qualifiedApis = qualifiedApis;
         }
 
         @Override
         public Iterator<ResourceRecordSet<?>> iterator() {
-            Iterator<ResourceRecordSet<?>> iterators = concat(apiToProfiles.keySet());
+            Iterator<ResourceRecordSet<?>> iterators = concat(qualifiedApis);
             if (!iterators.hasNext())
                 return api.iterator();
             return concat(api.iterator(), iterators);
@@ -72,10 +71,10 @@ public class ConcatBasicAndQualifiedResourceRecordSets {
         @Override
         public Iterator<ResourceRecordSet<?>> iterateByName(final String name) {
             List<Iterable<ResourceRecordSet<?>>> iterables = new ArrayList<Iterable<ResourceRecordSet<?>>>();
-            for (final QualifiedResourceRecordSetApi profile : apiToProfiles.keySet()) {
+            for (final QualifiedResourceRecordSetApi api : qualifiedApis) {
                 iterables.add(new Iterable<ResourceRecordSet<?>>() {
                     public Iterator<ResourceRecordSet<?>> iterator() {
-                        return profile.iterateByName(name);
+                        return api.iterateByName(name);
                     }
                 });
             }
@@ -87,10 +86,10 @@ public class ConcatBasicAndQualifiedResourceRecordSets {
         @Override
         public Iterator<ResourceRecordSet<?>> iterateByNameAndType(final String name, final String type) {
             List<Iterable<ResourceRecordSet<?>>> iterables = new ArrayList<Iterable<ResourceRecordSet<?>>>();
-            for (final QualifiedResourceRecordSetApi profile : apiToProfiles.keySet()) {
+            for (final QualifiedResourceRecordSetApi api : qualifiedApis) {
                 iterables.add(new Iterable<ResourceRecordSet<?>>() {
                     public Iterator<ResourceRecordSet<?>> iterator() {
-                        return profile.iterateByNameAndType(name, type);
+                        return api.iterateByNameAndType(name, type);
                     }
                 });
             }
@@ -103,15 +102,15 @@ public class ConcatBasicAndQualifiedResourceRecordSets {
             return concat(iterables);
         }
 
-        Iterator<ResourceRecordSet<?>> toIterator(ResourceRecordSet<?> rrs) {
+        static Iterator<ResourceRecordSet<?>> toIterator(ResourceRecordSet<?> rrs) {
             return rrs != null ? Collections.<ResourceRecordSet<?>> singleton(rrs).iterator() : Collections
                     .<ResourceRecordSet<?>> emptyList().iterator();
         }
 
         @Override
         public ResourceRecordSet<?> getByNameTypeAndQualifier(String name, String type, String qualifier) {
-            for (QualifiedResourceRecordSetApi profile : apiToProfiles.keySet()) {
-                ResourceRecordSet<?> val = profile.getByNameTypeAndQualifier(name, type, qualifier);
+            for (QualifiedResourceRecordSetApi api : qualifiedApis) {
+                ResourceRecordSet<?> val = api.getByNameTypeAndQualifier(name, type, qualifier);
                 if (val != null)
                     return val;
             }
@@ -120,21 +119,33 @@ public class ConcatBasicAndQualifiedResourceRecordSets {
 
         @Override
         public void put(ResourceRecordSet<?> rrset) {
-            if (rrset.profiles().isEmpty()) {
+            if (rrset.qualifier() == null) {
                 api.put(rrset);
-            } else {
-                Set<String> profiles = toProfileTypes(rrset);
-                QualifiedResourceRecordSetApi qualifiedApi = tryFindQualifiedApiForProfiles(profiles);
-                checkArgument(qualifiedApi != null,
-                        "cannot put rrset %s:%s%s as it contains profiles %s which aren't supported %s", rrset.name(),
-                        rrset.type(), rrset.qualifier() != null ? ":" + rrset.qualifier() : "", profiles, apiToProfiles);
-                qualifiedApi.put(rrset);
+                return;
             }
+            for (QualifiedResourceRecordSetApi api : qualifiedApis) {
+                if (api instanceof GeoResourceRecordSetApi && rrset.geo() != null) {
+                    api.put(rrset);
+                    return;
+                } else if (api instanceof WeightedResourceRecordSetApi && rrset.weighted() != null) {
+                    api.put(rrset);
+                    return;
+                }
+            }
+            Set<String> profiles = new LinkedHashSet<String>();
+            if (rrset.geo() != null) {
+                profiles.add("geo");
+            }
+            if (rrset.weighted() != null) {
+                profiles.add("weighted");
+            }
+            checkArgument(false, "cannot put rrset %s:%s:%s as it contains profiles %s which aren't supported %s",
+                    rrset.name(), rrset.type(), rrset.qualifier(), profiles, profiles);
         }
 
         @Override
         public void deleteByNameTypeAndQualifier(String name, String type, String qualifier) {
-            for (QualifiedResourceRecordSetApi qualifiedApi : apiToProfiles.keySet()) {
+            for (QualifiedResourceRecordSetApi qualifiedApi : qualifiedApis) {
                 qualifiedApi.deleteByNameTypeAndQualifier(name, type, qualifier);
             }
         }
@@ -142,21 +153,12 @@ public class ConcatBasicAndQualifiedResourceRecordSets {
         @Override
         public void deleteByNameAndType(String name, String type) {
             api.deleteByNameAndType(name, type);
-            for (QualifiedResourceRecordSetApi qualifiedApi : apiToProfiles.keySet()) {
+            for (QualifiedResourceRecordSetApi qualifiedApi : qualifiedApis) {
                 for (Iterator<ResourceRecordSet<?>> it = qualifiedApi.iterateByNameAndType(name, type); it.hasNext();) {
                     ResourceRecordSet<?> next = it.next();
                     qualifiedApi.deleteByNameTypeAndQualifier(next.name(), next.type(), next.qualifier());
                 }
             }
-        }
-
-        private QualifiedResourceRecordSetApi tryFindQualifiedApiForProfiles(Set<String> profiles) {
-            for (Entry<QualifiedResourceRecordSetApi, Collection<String>> entry : apiToProfiles.entrySet()) {
-                if (entry.getValue().containsAll(profiles)) {
-                    return entry.getKey();
-                }
-            }
-            return null;
         }
     }
 }

--- a/core/src/main/java/denominator/mock/MockAllProfileResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/mock/MockAllProfileResourceRecordSetApi.java
@@ -1,19 +1,17 @@
 package denominator.mock;
 
-import static denominator.common.Util.and;
 import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Preconditions.checkNotNull;
+import static denominator.common.Util.and;
 import static denominator.common.Util.filter;
 import static denominator.common.Util.nextOrNull;
 import static denominator.model.ResourceRecordSets.nameAndTypeEqualTo;
 import static denominator.model.ResourceRecordSets.nameEqualTo;
 import static denominator.model.ResourceRecordSets.nameTypeAndQualifierEqualTo;
 import static denominator.model.ResourceRecordSets.notNull;
-import static denominator.model.ResourceRecordSets.toProfileTypes;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedSet;
 
 import javax.inject.Inject;
@@ -63,11 +61,6 @@ public class MockAllProfileResourceRecordSetApi implements denominator.AllProfil
 
     @Override
     public void put(ResourceRecordSet<?> rrset) {
-        Set<String> profiles = toProfileTypes(rrset);
-        checkArgument(provider.profileToRecordTypes().keySet().containsAll(profiles),
-                "cannot put rrset %s:%s%s as it contains profiles %s which aren't supported %s", rrset.name(),
-                rrset.type(), rrset.qualifier() != null ? ":" + rrset.qualifier() : "", profiles,
-                provider.profileToRecordTypes());
         put(notNull(), rrset);
     }
 

--- a/core/src/main/java/denominator/mock/MockProvider.java
+++ b/core/src/main/java/denominator/mock/MockProvider.java
@@ -129,33 +129,33 @@ public class MockProvider extends BasicProvider {
             Map<String, Collection<String>> alazona = new LinkedHashMap<String, Collection<String>>();
             alazona.put("United States (US)", Arrays.asList("Alaska", "Arizona"));
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www2.geo.denominator.io.").type("A")
-                    .qualifier("alazona").ttl(300).add(AData.create("192.0.2.1")).addProfile(Geo.create(alazona))
+                    .qualifier("alazona").ttl(300).add(AData.create("192.0.2.1")).geo(Geo.create(alazona))
                     .build());
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www.geo.denominator.io.").type("CNAME")
                     .qualifier("alazona").ttl(300).add(CNAMEData.create("a.denominator.io."))
-                    .addProfile(Geo.create(alazona)).build());
+                    .geo(Geo.create(alazona)).build());
             Map<String, Collection<String>> columbador = new LinkedHashMap<String, Collection<String>>();
             columbador.put("South America", Arrays.asList("Colombia", "Ecuador"));
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www.geo.denominator.io.").type("CNAME")
                     .qualifier("columbador").ttl(86400).add(CNAMEData.create("b.denominator.io."))
-                    .addProfile(Geo.create(columbador)).build());
+                    .geo(Geo.create(columbador)).build());
             Map<String, Collection<String>> antarctica = new LinkedHashMap<String, Collection<String>>();
             antarctica.put("Antarctica", Arrays.asList("Bouvet Island", "French Southern Territories", "Antarctica"));
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www.geo.denominator.io.").type("CNAME")
                     .qualifier("antarctica").ttl(0).add(CNAMEData.create("c.denominator.io."))
-                    .addProfile(Geo.create(antarctica)).build());
+                    .geo(Geo.create(antarctica)).build());
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www2.weighted.denominator.io.")
                     .type("A").qualifier("US-West").ttl(0).add(AData.create("192.0.2.1"))
-                    .addProfile(Weighted.create(0)).build());
+                    .weighted(Weighted.create(0)).build());
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www.weighted.denominator.io.")
                     .type("CNAME").qualifier("US-West").ttl(0).add(CNAMEData.create("a.denominator.io."))
-                    .addProfile(Weighted.create(1)).build());
+                    .weighted(Weighted.create(1)).build());
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www.weighted.denominator.io.")
                     .type("CNAME").qualifier("US-East").ttl(0).add(CNAMEData.create("b.denominator.io."))
-                    .addProfile(Weighted.create(1)).build());
+                    .weighted(Weighted.create(1)).build());
             records.add(ResourceRecordSet.<Map<String, Object>> builder().name("www.weighted.denominator.io.")
                     .type("CNAME").qualifier("EU-West").ttl(0).add(CNAMEData.create("c.denominator.io."))
-                    .addProfile(Weighted.create(1)).build());
+                    .weighted(Weighted.create(1)).build());
             Map<Zone, SortedSet<ResourceRecordSet<?>>> zoneToRecords = new LinkedHashMap<Zone, SortedSet<ResourceRecordSet<?>>>();
             zoneToRecords.put(Zone.create(idOrName), records);
             return Map.class.cast(zoneToRecords);

--- a/core/src/main/java/denominator/mock/MockResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/mock/MockResourceRecordSetApi.java
@@ -7,7 +7,7 @@ import static denominator.common.Util.filter;
 import static denominator.common.Util.nextOrNull;
 import static denominator.model.ResourceRecordSets.nameAndTypeEqualTo;
 import static denominator.model.ResourceRecordSets.nameEqualTo;
-import static denominator.model.ResourceRecordSets.withoutProfile;
+import static denominator.model.ResourceRecordSets.alwaysVisible;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -32,17 +32,17 @@ public final class MockResourceRecordSetApi implements denominator.ResourceRecor
      */
     @Override
     public Iterator<ResourceRecordSet<?>> iterator() {
-        return filter(records.iterator(), withoutProfile());
+        return filter(records.iterator(), alwaysVisible());
     }
 
     @Override
     public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
-        return filter(records.iterator(), and(nameEqualTo(name), withoutProfile()));
+        return filter(records.iterator(), and(nameEqualTo(name), alwaysVisible()));
     }
 
     @Override
     public ResourceRecordSet<?> getByNameAndType(String name, String type) {
-        return nextOrNull(filter(records.iterator(), and(nameAndTypeEqualTo(name, type), withoutProfile())));
+        return nextOrNull(filter(records.iterator(), and(nameAndTypeEqualTo(name, type), alwaysVisible())));
     }
 
     @Override

--- a/core/src/main/java/denominator/mock/MockWeightedResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/mock/MockWeightedResourceRecordSetApi.java
@@ -1,9 +1,7 @@
 package denominator.mock;
 
 import static denominator.common.Preconditions.checkArgument;
-import static denominator.model.ResourceRecordSets.profileContainsType;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.SortedSet;
 
@@ -18,15 +16,18 @@ import denominator.profile.WeightedResourceRecordSetApi;
 
 public final class MockWeightedResourceRecordSetApi extends MockAllProfileResourceRecordSetApi implements
         WeightedResourceRecordSetApi {
-    private static final Filter<ResourceRecordSet<?>> IS_WEIGHTED = profileContainsType("weighted");
+    private static final Filter<ResourceRecordSet<?>> IS_WEIGHTED = new Filter<ResourceRecordSet<?>>(){
+        @Override
+        public boolean apply(ResourceRecordSet<?> in) {
+            return in != null && in.weighted() != null;
+        }
+    };
 
-    private final Collection<String> supportedTypes;
     private final SortedSet<Integer> supportedWeights;
 
     MockWeightedResourceRecordSetApi(Provider provider, SortedSet<ResourceRecordSet<?>> records,
             SortedSet<Integer> supportedWeights) {
         super(provider, records, IS_WEIGHTED);
-        this.supportedTypes = provider.profileToRecordTypes().get("weighted");
         this.supportedWeights = supportedWeights;
     }
 
@@ -37,8 +38,6 @@ public final class MockWeightedResourceRecordSetApi extends MockAllProfileResour
 
     @Override
     public void put(ResourceRecordSet<?> rrset) {
-        checkArgument(supportedTypes.contains(rrset.type()), "%s not a supported type for weighted: %s", rrset.type(),
-                supportedTypes);
         put(IS_WEIGHTED, rrset);
     }
 

--- a/core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
+++ b/core/src/test/java/denominator/profile/BaseGeoReadOnlyLiveTest.java
@@ -2,7 +2,6 @@ package denominator.profile;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterators.size;
-import static denominator.model.profile.Geo.asGeo;
 import static java.lang.String.format;
 import static java.util.logging.Logger.getAnonymousLogger;
 import static org.testng.Assert.assertEquals;
@@ -53,7 +52,7 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
 
                 getAnonymousLogger().info(format("%s ::: geoRRS: %s", manager, geoRRS));
                 recordTypeCounts.getUnchecked(geoRRS.type()).addAndGet(geoRRS.records().size());
-                geoRecordCounts.getUnchecked(asGeo(geoRRS)).addAndGet(geoRRS.records().size());
+                geoRecordCounts.getUnchecked(geoRRS.geo()).addAndGet(geoRRS.records().size());
                 
                 Iterator<ResourceRecordSet<?>> byNameAndType = geoApi(zone).iterateByNameAndType(geoRRS.name(), geoRRS.type());
                 assertTrue(byNameAndType.hasNext(), "could not list by name and type: " + geoRRS);
@@ -69,10 +68,10 @@ public abstract class BaseGeoReadOnlyLiveTest extends BaseProviderLiveTest {
     }
 
     static void checkGeoRRS(ResourceRecordSet<?> geoRRS) {
-        assertFalse(geoRRS.profiles().isEmpty(), "Profile absent: " + geoRRS);
+        checkNotNull(geoRRS.geo(), "Geo absent: " + geoRRS);
         checkNotNull(geoRRS.qualifier(), "Qualifier: ResourceRecordSet %s", geoRRS);
 
-        Geo geo = asGeo(geoRRS);
+        Geo geo = geoRRS.geo();
         assertTrue(!geo.regions().isEmpty(), "Regions empty on Geo: " + geoRRS);
         checkNotNull(geoRRS.name(), "Name: ResourceRecordSet %s", geoRRS);
         checkNotNull(geoRRS.type(), "Type: ResourceRecordSet %s", geoRRS);

--- a/core/src/test/java/denominator/profile/BaseWeightedReadOnlyLiveTest.java
+++ b/core/src/test/java/denominator/profile/BaseWeightedReadOnlyLiveTest.java
@@ -2,7 +2,6 @@ package denominator.profile;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Ordering.usingToString;
-import static denominator.model.profile.Weighted.asWeighted;
 import static java.lang.String.format;
 import static java.util.logging.Logger.getAnonymousLogger;
 import static org.testng.Assert.assertEquals;
@@ -43,13 +42,13 @@ public abstract class BaseWeightedReadOnlyLiveTest extends BaseProviderLiveTest 
                 assertNotNull(weightedRRS.qualifier(), "Weighted record sets should include a qualifier: " + weightedRRS);
                 checkWeightedRRS(weightedRRS);
 
-                Weighted weighted = asWeighted(weightedRRS);
+                Weighted weighted = weightedRRS.weighted();
                 assertTrue(weightedApi(zone).supportedWeights().contains(weighted.weight()));
                 assertTrue(manager.provider().profileToRecordTypes().get("weighted").contains(weightedRRS.type()));
 
                 getAnonymousLogger().info(format("%s ::: weightedRRS: %s", manager, weightedRRS));
                 recordTypeCounts.getUnchecked(weightedRRS.type()).addAndGet(weightedRRS.records().size());
-                weightedRecordCounts.getUnchecked(asWeighted(weightedRRS)).addAndGet(weightedRRS.records().size());
+                weightedRecordCounts.getUnchecked(weightedRRS.weighted()).addAndGet(weightedRRS.records().size());
                 
                 Iterator<ResourceRecordSet<?>> byNameAndType = weightedApi(zone).iterateByNameAndType(weightedRRS.name(), weightedRRS.type());
                 assertTrue(byNameAndType.hasNext(), "could not list by name and type: " + weightedRRS);
@@ -65,10 +64,10 @@ public abstract class BaseWeightedReadOnlyLiveTest extends BaseProviderLiveTest 
     }
 
     static void checkWeightedRRS(ResourceRecordSet<?> weightedRRS) {
-        assertFalse(weightedRRS.profiles().isEmpty(), "Profile absent: " + weightedRRS);
+        checkNotNull(weightedRRS.weighted(), "Weighted absent: " + weightedRRS);
         checkNotNull(weightedRRS.qualifier(), "Qualifier: ResourceRecordSet %s", weightedRRS);
 
-        Weighted weighted = asWeighted(weightedRRS);
+        Weighted weighted = weightedRRS.weighted();
         assertTrue(weighted.weight() >= 0, "Weight negative on ResourceRecordSet: " + weightedRRS);
         
         checkNotNull(weightedRRS.name(), "Name: ResourceRecordSet %s", weightedRRS);

--- a/core/src/test/java/denominator/profile/BaseWeightedWriteCommandsLiveTest.java
+++ b/core/src/test/java/denominator/profile/BaseWeightedWriteCommandsLiveTest.java
@@ -2,7 +2,6 @@ package denominator.profile;
 
 import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.Maps.filterKeys;
-import static denominator.model.profile.Weighted.asWeighted;
 import static denominator.profile.BaseWeightedReadOnlyLiveTest.checkWeightedRRS;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -15,7 +14,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import denominator.BaseProviderLiveTest;
 import denominator.model.ResourceRecordSet;
@@ -60,10 +58,7 @@ public abstract class BaseWeightedWriteCommandsLiveTest extends BaseProviderLive
                                               .type(recordSet.type())
                                               .ttl(1800)
                                               .qualifier(qualifier)
-                                              // prove maps can be used as profiles
-                                              .addProfile(ImmutableMap.<String, Object> builder()//
-                                                      .put("type", "weighted")//
-                                                      .put("weight", 0).build())
+                                              .weighted(Weighted.create(0))
                                               .add(recordSet.records().get(i)).build());
     
             ResourceRecordSet<?> rrs = weightedApi(zone)
@@ -76,7 +71,7 @@ public abstract class BaseWeightedWriteCommandsLiveTest extends BaseProviderLive
             assertEquals(rrs.ttl(), Integer.valueOf(1800));
             assertEquals(rrs.type(), recordSet.type());
             assertEquals(rrs.qualifier(), qualifier);
-            assertEquals(asWeighted(rrs).weight(), 0);
+            assertEquals(rrs.weighted().weight(), 0);
             assertEquals(rrs.records().size(), 1);
             assertEquals(rrs.records().get(0), recordSet.records().get(i++));
         }
@@ -94,18 +89,18 @@ public abstract class BaseWeightedWriteCommandsLiveTest extends BaseProviderLive
                                                .type(recordSet.type())
                                                .ttl(1800)
                                                .qualifier(qualifier1)
-                                               .addProfile(Weighted.create(heaviest))
+                                               .weighted(Weighted.create(heaviest))
                                                .add(recordSet.records().get(0)).build());
 
         ResourceRecordSet<?> rrs1 = weightedApi(zone).getByNameTypeAndQualifier(
                 recordSet.name(), recordSet.type(), qualifier1);
 
-        assertEquals(asWeighted(rrs1).weight(), heaviest);
+        assertEquals(rrs1.weighted().weight(), heaviest);
 
         ResourceRecordSet<?> rrs2 = weightedApi(zone).getByNameTypeAndQualifier(
                 recordSet.name(), recordSet.type(), qualifier2);
 
-        assertEquals(asWeighted(rrs2).weight(), 0);
+        assertEquals(rrs2.weighted().weight(), 0);
     }
 
     @Test(dependsOnMethods = "replaceWeight", dataProvider = "weightedRecords")

--- a/dynect/src/main/java/denominator/dynect/DynECTGeoResourceRecordSetApi.java
+++ b/dynect/src/main/java/denominator/dynect/DynECTGeoResourceRecordSetApi.java
@@ -7,7 +7,6 @@ import static denominator.common.Util.nextOrNull;
 import static denominator.model.ResourceRecordSets.nameAndTypeEqualTo;
 import static denominator.model.ResourceRecordSets.nameEqualTo;
 import static denominator.model.ResourceRecordSets.nameTypeAndQualifierEqualTo;
-import static denominator.model.ResourceRecordSets.profileContainsType;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -23,7 +22,12 @@ import denominator.model.ResourceRecordSet;
 import denominator.profile.GeoResourceRecordSetApi;
 
 public final class DynECTGeoResourceRecordSetApi implements GeoResourceRecordSetApi {
-    private static final Filter<ResourceRecordSet<?>> IS_GEO = profileContainsType("geo");
+    private static final Filter<ResourceRecordSet<?>> IS_GEO = new Filter<ResourceRecordSet<?>>(){
+        @Override
+        public boolean apply(ResourceRecordSet<?> in) {
+            return in != null && in.geo() != null;
+        }
+    };
 
     private final Map<String, Collection<String>> regions;
     private final DynECT api;

--- a/dynect/src/main/java/denominator/dynect/DynECTProvider.java
+++ b/dynect/src/main/java/denominator/dynect/DynECTProvider.java
@@ -20,7 +20,7 @@ import dagger.Provides;
 import denominator.BasicProvider;
 import denominator.CheckConnection;
 import denominator.DNSApiManager;
-import denominator.QualifiedResourceRecordSetApi.Factory;
+import denominator.QualifiedResourceRecordSetApi;
 import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
 import denominator.config.ConcatBasicAndQualifiedResourceRecordSets;
@@ -129,12 +129,9 @@ public class DynECTProvider extends BasicProvider {
             return new DynECTResourceRecordSetApi.Factory(api);
         }
 
-        @Provides
-        @Singleton
-        Map<Factory, Collection<String>> factoryToProfiles(GeoResourceRecordSetApi.Factory in) {
-            Map<Factory, Collection<String>> factories = new LinkedHashMap<Factory, Collection<String>>();
-            factories.put(in, Arrays.asList("geo"));
-            return factories;
+        @Provides(type = SET)
+        QualifiedResourceRecordSetApi.Factory factoryToProfiles(GeoResourceRecordSetApi.Factory in) {
+            return in;
         }
     }
 

--- a/dynect/src/main/java/denominator/dynect/GeoResourceRecordSetsDecoder.java
+++ b/dynect/src/main/java/denominator/dynect/GeoResourceRecordSetsDecoder.java
@@ -90,7 +90,7 @@ class GeoResourceRecordSetsDecoder implements DynECTDecoder.Parser<Map<String, C
         private final Map<String, Collection<String>> regions;
         private final Map<String, String> countryToRegions;
 
-        private ToBuilders(@Named("geo") final Map<String, Collection<String>> regions) {
+        private ToBuilders(Map<String, Collection<String>> regions) {
             this.regions = regions;
             Map<String, String> countryToRegions = new HashMap<String, String>(regions.values().size());
             for (Entry<String, Collection<String>> entry : regions.entrySet()) {
@@ -116,11 +116,11 @@ class GeoResourceRecordSetsDecoder implements DynECTDecoder.Parser<Map<String, C
                 rrset.qualifier(creepyGeoRegionGroup.name != null ? creepyGeoRegionGroup.name
                         : creepyGeoRegionGroup.service_name);
                 rrset.ttl(ttl);
-                rrset.addProfile(geo);
+                rrset.geo(geo);
                 // weight is only present for a couple record types
                 List<Integer> weights = creepyGeoRegionGroup.weight.get(type.toLowerCase() + "_weight");
                 if (weights != null && !weights.isEmpty())
-                    rrset.addProfile(Weighted.create(weights.get(0)));
+                    rrset.weighted(Weighted.create(weights.get(0)));
 
                 for (int i = 0; i < entry.getValue().size(); i++) {
                     rrset.add(ToRecord.toRData(entry.getValue().get(i).getAsJsonObject()));

--- a/dynect/src/test/java/denominator/dynect/DynECTGeoResourceRecordSetApiMockTest.java
+++ b/dynect/src/test/java/denominator/dynect/DynECTGeoResourceRecordSetApiMockTest.java
@@ -41,7 +41,7 @@ public class DynECTGeoResourceRecordSetApiMockTest {
             .qualifier("Europe")
             .ttl(300)
             .add(CNAMEData.create("srv-000000001.eu-west-1.elb.amazonaws.com."))
-            .addProfile(Geo.create(ImmutableMultimap.of("13", "13").asMap()))
+            .geo(Geo.create(ImmutableMultimap.of("13", "13").asMap()))
             .build();
 
     ResourceRecordSet<CNAMEData> everywhereElse = ResourceRecordSet.<CNAMEData> builder()
@@ -50,13 +50,13 @@ public class DynECTGeoResourceRecordSetApiMockTest {
             .qualifier("Everywhere Else")
             .ttl(300)
             .add(CNAMEData.create("srv-000000001.us-east-1.elb.amazonaws.com."))
-            .addProfile(Geo.create(ImmutableMultimap.<String, String> builder()
-                                                    .put("11", "11")
-                                                    .put("16", "16")
-                                                    .put("12", "12")
-                                                    .put("17", "17")
-                                                    .put("15", "15")
-                                                    .put("14", "14").build().asMap()))                                                   
+            .geo(Geo.create(ImmutableMultimap.<String, String> builder()
+                                             .put("11", "11")
+                                             .put("16", "16")
+                                             .put("12", "12")
+                                             .put("17", "17")
+                                             .put("15", "15")
+                                             .put("14", "14").build().asMap()))                                                   
             .build();
     
     ResourceRecordSet<CNAMEData> fallback = ResourceRecordSet.<CNAMEData> builder()
@@ -65,9 +65,9 @@ public class DynECTGeoResourceRecordSetApiMockTest {
             .qualifier("Fallback")
             .ttl(300)
             .add(CNAMEData.create("srv-000000002.us-east-1.elb.amazonaws.com."))
-            .addProfile(Geo.create(ImmutableMultimap.<String, String> builder()
-                                                    .put("Unknown IP", "@!")
-                                                    .put("Fallback", "@@").build().asMap()))
+            .geo(Geo.create(ImmutableMultimap.<String, String> builder()
+                                             .put("Unknown IP", "@!")
+                                             .put("Fallback", "@@").build().asMap()))
             .build();
 
     @Test

--- a/dynect/src/test/java/denominator/dynect/GeoResourceRecordSetsDecoderTest.java
+++ b/dynect/src/test/java/denominator/dynect/GeoResourceRecordSetsDecoderTest.java
@@ -40,13 +40,13 @@ public class GeoResourceRecordSetsDecoderTest {
                 .qualifier("Everywhere Else")
                 .ttl(300)
                 .add(CNAMEData.create("srv-000000001.us-east-1.elb.amazonaws.com."))
-                .addProfile(Geo.create(ImmutableMultimap.<String, String> builder()
-                                                        .put("11", "11")
-                                                        .put("16", "16")
-                                                        .put("12", "12")
-                                                        .put("17", "17")
-                                                        .put("15", "15")
-                                                        .put("14", "14").build().asMap()))                                                   
+                .geo(Geo.create(ImmutableMultimap.<String, String> builder()
+                                                 .put("11", "11")
+                                                 .put("16", "16")
+                                                 .put("12", "12")
+                                                 .put("17", "17")
+                                                 .put("15", "15")
+                                                 .put("14", "14").build().asMap()))                                                   
                 .build());
         assertEquals(rrsets.get(1), ResourceRecordSet.<CNAMEData> builder()
                 .name("srv.denominator.io")
@@ -54,7 +54,7 @@ public class GeoResourceRecordSetsDecoderTest {
                 .qualifier("Europe")
                 .ttl(300)
                 .add(CNAMEData.create("srv-000000001.eu-west-1.elb.amazonaws.com."))
-                .addProfile(Geo.create(ImmutableMultimap.of("13", "13").asMap()))
+                .geo(Geo.create(ImmutableMultimap.of("13", "13").asMap()))
                 .build());
         assertEquals(rrsets.get(2),ResourceRecordSet.<CNAMEData> builder()
                 .name("srv.denominator.io")
@@ -62,9 +62,9 @@ public class GeoResourceRecordSetsDecoderTest {
                 .qualifier("Fallback")
                 .ttl(300)
                 .add(CNAMEData.create("srv-000000002.us-east-1.elb.amazonaws.com."))
-                .addProfile(Geo.create(ImmutableMultimap.<String, String> builder()
-                                                        .put("Unknown IP", "@!")
-                                                        .put("Fallback", "@@").build().asMap()))
+                .geo(Geo.create(ImmutableMultimap.<String, String> builder()
+                                                 .put("Unknown IP", "@!")
+                                                 .put("Fallback", "@@").build().asMap()))
                 .build());
     }
 }

--- a/model/src/main/java/denominator/model/AbstractRecordSetBuilder.java
+++ b/model/src/main/java/denominator/model/AbstractRecordSetBuilder.java
@@ -7,6 +7,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import denominator.model.profile.Geo;
+import denominator.model.profile.Weighted;
+
 /**
  * Capable of building record sets from rdata input types expressed as {@code E}
  * 
@@ -22,6 +25,8 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
     private String qualifier;
     private Integer ttl;
     private List<Map<String, Object>> profile = new ArrayList<Map<String, Object>>();
+    private Geo geo;
+    private Weighted weighted;
 
     /**
      * @see ResourceRecordSet#name()
@@ -67,7 +72,10 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
      * <pre>
      * builder.addProfile(geo);
      * </pre>
+     * @deprecated will be removed in version 4.0 for type-safe accessors such
+     *             as {@link #geo(Geo)} and {@link #weighted(Weighted)}.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public B addProfile(Map<String, Object> profile) {
         this.profile.add(checkNotNull(profile, "profile"));
@@ -83,7 +91,10 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
      * 
      * builder.addAllProfile(otherProfile);
      * </pre>
+     * @deprecated will be removed in version 4.0 for type-safe accessors such
+     *             as {@link #geo(Geo)} and {@link #weighted(Weighted)}.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public B addAllProfile(Collection<Map<String, Object>> profile) {
         this.profile.addAll(checkNotNull(profile, "profile"));
@@ -92,7 +103,10 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
 
     /**
      * @see ResourceRecordSet#profiles()
+     * @deprecated will be removed in version 4.0 for type-safe accessors such
+     *             as {@link #geo(Geo)} and {@link #weighted(Weighted)}.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public B profile(Collection<Map<String, Object>> profile) {
         this.profile = new ArrayList<Map<String, Object>>();
@@ -100,8 +114,26 @@ abstract class AbstractRecordSetBuilder<E, D extends Map<String, Object>, B exte
         return (B) this;
     }
 
+    /**
+     * @see ResourceRecordSet#geo()
+     */
+    @SuppressWarnings("unchecked")
+    public B geo(Geo geo) {
+        this.geo = geo;
+        return (B) this;
+    }
+
+    /**
+     * @see ResourceRecordSet#weighted()
+     */
+    @SuppressWarnings("unchecked")
+    public B weighted(Weighted weighted) {
+        this.weighted = weighted;
+        return (B) this;
+    }
+
     public ResourceRecordSet<D> build() {
-        return new ResourceRecordSet<D>(name, type, qualifier, ttl, records(), profile);
+        return new ResourceRecordSet<D>(name, type, qualifier, ttl, records(), geo, weighted, profile);
     }
 
     /**

--- a/model/src/main/java/denominator/model/ResourceRecordSets.java
+++ b/model/src/main/java/denominator/model/ResourceRecordSets.java
@@ -158,9 +158,30 @@ public class ResourceRecordSets {
     }
 
     /**
+     * Returns true if the input has no visibility qualifier. Typically
+     * indicates a basic record set.
+     */
+    public static Filter<ResourceRecordSet<?>> alwaysVisible() {
+        return new Filter<ResourceRecordSet<?>>() {
+
+            @Override
+            public boolean apply(ResourceRecordSet<?> in) {
+                return in != null && in.qualifier() == null;
+            }
+
+            @Override
+            public String toString() {
+                return "alwaysVisible()";
+            }
+        };
+    }
+
+    /**
      * returns true if the input is not null and
      * {@link ResourceRecordSet#profiles() profile} is empty.
+     * @deprecated will be removed in version 4.0 for {@link #alwaysVisible()}.
      */
+    @Deprecated
     public static Filter<ResourceRecordSet<?>> withoutProfile() {
         return new Filter<ResourceRecordSet<?>>() {
 
@@ -193,7 +214,10 @@ public class ResourceRecordSets {
      * @param profileType
      *            expected type of the profile
      * @since 1.3.1
+     * @deprecated will be removed in version 4.0 for type-safe accessors such
+     *             as {@link #geo()} and {@link #weighted()}.
      */
+    @Deprecated
     public static Filter<ResourceRecordSet<?>> profileContainsType(final String profileType) {
         checkNotNull(profileType, "profileType");
         return new Filter<ResourceRecordSet<?>>() {
@@ -216,7 +240,10 @@ public class ResourceRecordSets {
      * profile is found, null is returned
      * 
      * @since 1.3.1
+     * @deprecated will be removed in version 4.0 for type-safe accessors such
+     *             as {@link #geo()} and {@link #weighted()}.
      */
+    @Deprecated
     public static Map<String, Object> tryFindProfile(ResourceRecordSet<?> rrset, String profileType) {
         checkNotNull(rrset, "rrset");
         checkNotNull(profileType, "profileType");
@@ -229,7 +256,10 @@ public class ResourceRecordSets {
 
     /**
      * Returns the set of profile types, if present, in the {@code rrset}.
+     * @deprecated will be removed in version 4.0 for type-safe accessors such
+     *             as {@link #geo()} and {@link #weighted()}.
      */
+    @Deprecated
     public static Set<String> toProfileTypes(ResourceRecordSet<?> rrset) {
         checkNotNull(rrset, "rrset");
         Set<String> types = new LinkedHashSet<String>();

--- a/model/src/main/java/denominator/model/profile/Geo.java
+++ b/model/src/main/java/denominator/model/profile/Geo.java
@@ -2,7 +2,6 @@ package denominator.model.profile;
 
 import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Preconditions.checkNotNull;
-import static denominator.model.ResourceRecordSets.tryFindProfile;
 
 import java.beans.ConstructorProperties;
 import java.util.Collection;
@@ -29,7 +28,9 @@ public class Geo extends LinkedHashMap<String, Object> {
      * found.
      * 
      * @since 1.3.1
+     * @deprecated will be removed in version 4.0. use {@link #create(Map)}
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public static Geo asGeo(Map<String, Object> profile) {
         if (profile == null)
@@ -55,9 +56,12 @@ public class Geo extends LinkedHashMap<String, Object> {
      * returns a Geo view of the {@code rrset} or null if no geo profile found.
      * 
      * @since 1.3.1
+     * @deprecated will be removed in version 4.0. use
+     *             {@link ResourceRecordSet#geo()}
      */
+    @Deprecated
     public static Geo asGeo(ResourceRecordSet<?> rrset) {
-        return asGeo(tryFindProfile(rrset, "geo"));
+        return rrset.geo();
     }
 
     /**

--- a/model/src/main/java/denominator/model/profile/Weighted.java
+++ b/model/src/main/java/denominator/model/profile/Weighted.java
@@ -1,7 +1,6 @@
 package denominator.model.profile;
 
 import static denominator.common.Preconditions.checkArgument;
-import static denominator.model.ResourceRecordSets.tryFindProfile;
 
 import java.beans.ConstructorProperties;
 import java.util.Map;
@@ -30,7 +29,9 @@ public class Weighted extends NumbersAreUnsignedIntsLinkedHashMap {
      * profile found.
      * 
      * @since 1.3.1
+     * @deprecated will be removed in version 4.0. use {@link #create(int)}
      */
+    @Deprecated
     public static Weighted asWeighted(Map<String, Object> profile) {
         if (profile == null)
             return null;
@@ -44,9 +45,12 @@ public class Weighted extends NumbersAreUnsignedIntsLinkedHashMap {
      * profile found.
      * 
      * @since 1.3.1
+     * @deprecated will be removed in version 4.0. use
+     *             {@link ResourceRecordSet#weighted()}
      */
+    @Deprecated
     public static Weighted asWeighted(ResourceRecordSet<?> rrset) {
-        return asWeighted(tryFindProfile(rrset, "weighted"));
+        return rrset.weighted();
     }
 
     /**

--- a/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -112,7 +112,7 @@ public class ResourceRecordSetsTest {
                                                        .qualifier("US-East")
                                                        .ttl(3600)
                                                        .add(AData.create("1.1.1.1"))
-                                                       .addProfile(geo).build();
+                                                       .geo(geo).build();
 
     public void qualifierEqualToReturnsFalseOnNull() {
         assertFalse(nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), geoRRS.qualifier()).apply(null));
@@ -190,8 +190,8 @@ public class ResourceRecordSetsTest {
                 .qualifier("US-East")
                 .ttl(3600)
                 .add(AData.create("1.1.1.1"))
-                .addProfile(geo)
-                .addProfile(Weighted.create(2))
+                .geo(geo)
+                .weighted(Weighted.create(2))
                 .build();
         assertEquals(toProfileTypes(geoWeightedRRS), ImmutableSet.of("geo", "weighted"));
     }

--- a/model/src/test/java/denominator/model/profile/GeosTest.java
+++ b/model/src/test/java/denominator/model/profile/GeosTest.java
@@ -27,7 +27,7 @@ public class GeosTest {
             .qualifier("US-East")//
             .ttl(3600)//
             .add(AData.create("1.1.1.1"))//
-            .addProfile(geo).build();
+            .geo(geo).build();
 
     public void withAdditionalRegionsIdentityWhenAlreadyHaveRegions() {
         assertEquals(Geos.withAdditionalRegions(geoRRS, geo.regions()), geoRRS);
@@ -38,7 +38,7 @@ public class GeosTest {
                 .put("US", "US-OR").build().asMap());
         
         //TODO: switch to fest so we don't have to play games like this.
-        assertEquals(Geo.asGeo(withOregon).regions().toString(), ImmutableMultimap.<String, String> builder()//
+        assertEquals(withOregon.geo().regions().toString(), ImmutableMultimap.<String, String> builder()//
                 .putAll("US", "US-VA", "US-CA", "US-OR")//
                 .put("IM", "IM").build().asMap().toString());
     }
@@ -48,7 +48,7 @@ public class GeosTest {
                 .putAll("GB", "GB-SLG", "GB-LAN").build().asMap());
         
         //TODO: switch to fest so we don't have to play games like this.
-        assertEquals(Geo.asGeo(withGB).regions().toString(), ImmutableMultimap.<String, String> builder()//
+        assertEquals(withGB.geo().regions().toString(), ImmutableMultimap.<String, String> builder()//
                 .putAll("US", "US-VA", "US-CA")//
                 .put("IM", "IM")//
                 .putAll("GB", "GB-SLG", "GB-LAN").build().asMap().toString());
@@ -61,18 +61,18 @@ public class GeosTest {
                 .qualifier("US-East")//
                 .ttl(3600)//
                 .add(AData.create("1.1.1.1"))//
-                .addProfile(weighted)
-                .addProfile(geo).build();
+                .weighted(weighted)
+                .geo(geo).build();
 
         ResourceRecordSet<?> withOregon = Geos.withAdditionalRegions(geoRRS, ImmutableMultimap.<String, String> builder()//
                 .put("US", "US-OR").build().asMap());
         
         //TODO: switch to fest so we don't have to play games like this.
-        assertEquals(Geo.asGeo(withOregon).regions().toString(), ImmutableMultimap.<String, String> builder()//
+        assertEquals(withOregon.geo().regions().toString(), ImmutableMultimap.<String, String> builder()//
                 .putAll("US", "US-VA", "US-CA", "US-OR")//
                 .put("IM", "IM").build().asMap().toString());
 
-        assertEquals(Weighted.asWeighted(withOregon), weighted);
+        assertEquals(withOregon.weighted(), weighted);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "no regions specified")

--- a/route53/src/main/java/denominator/route53/ResourceRecordSetHandler.java
+++ b/route53/src/main/java/denominator/route53/ResourceRecordSetHandler.java
@@ -72,7 +72,7 @@ class ResourceRecordSetHandler extends DefaultHandler implements
         } else if (qName.equals("SetIdentifier")) {
             builder.qualifier(currentText.toString().trim());
         } else if ("Weight".equals(qName)) {
-            profiles.add(Weighted.create(Integer.parseInt(currentText.toString().trim())));
+            builder.weighted(Weighted.create(Integer.parseInt(currentText.toString().trim())));
         } else if (profileFields.contains(qName)) {
             addProfile(qName, currentText.toString().trim());
         }

--- a/route53/src/main/java/denominator/route53/Route53AllProfileResourceRecordSetApi.java
+++ b/route53/src/main/java/denominator/route53/Route53AllProfileResourceRecordSetApi.java
@@ -7,7 +7,6 @@ import static denominator.model.ResourceRecordSets.nameAndTypeEqualTo;
 import static denominator.model.ResourceRecordSets.nameEqualTo;
 import static denominator.model.ResourceRecordSets.nameTypeAndQualifierEqualTo;
 import static denominator.model.ResourceRecordSets.notNull;
-import static denominator.model.ResourceRecordSets.withoutProfile;
 import static denominator.route53.Route53.ActionOnResourceRecordSet.create;
 import static denominator.route53.Route53.ActionOnResourceRecordSet.delete;
 
@@ -15,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -70,7 +68,7 @@ public final class Route53AllProfileResourceRecordSetApi implements AllProfileRe
     }
 
     public ResourceRecordSet<?> getByNameAndType(String name, String type) {
-        return nextOrNull(filter(iterateByNameAndType(name, type), withoutProfile()));
+        return nextOrNull(filter(iterateByNameAndType(name, type), notAlias()));
     }
 
     @Override
@@ -142,12 +140,8 @@ public final class Route53AllProfileResourceRecordSetApi implements AllProfileRe
         public boolean apply(ResourceRecordSet<?> input) {
             if (!first.apply(input))
                 return false;
-            if (input.profiles().isEmpty())
+            if (input.records().isEmpty())
                 return true;
-            for (Map<String, Object> profile : input.profiles()) {
-                if ("alias".equals(profile.get("type")))
-                    return false;
-            }
             return true;
         }
     }

--- a/route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
+++ b/route53/src/main/java/denominator/route53/Route53ResourceRecordSetApi.java
@@ -1,7 +1,7 @@
 package denominator.route53;
 
 import static denominator.common.Util.filter;
-import static denominator.model.ResourceRecordSets.withoutProfile;
+import static denominator.model.ResourceRecordSets.alwaysVisible;
 import static denominator.route53.Route53.ActionOnResourceRecordSet.delete;
 
 import java.util.Arrays;
@@ -27,17 +27,18 @@ public final class Route53ResourceRecordSetApi implements ResourceRecordSetApi {
 
     @Override
     public Iterator<ResourceRecordSet<?>> iterator() {
-        return filter(allApi.iterator(), withoutProfile());
+        return filter(allApi.iterator(), alwaysVisible());
     }
 
     @Override
     public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
-        return filter(allApi.iterateByName(name), withoutProfile());
+        return filter(allApi.iterateByName(name), alwaysVisible());
     }
 
     @Override
     public ResourceRecordSet<?> getByNameAndType(String name, String type) {
-        return allApi.getByNameAndType(name, type);
+        ResourceRecordSet<?> rrset = allApi.getByNameAndType(name, type);
+        return alwaysVisible().apply(rrset) ? rrset : null;
     }
 
     @Override

--- a/route53/src/main/java/denominator/route53/Route53WeightedResourceRecordSetApi.java
+++ b/route53/src/main/java/denominator/route53/Route53WeightedResourceRecordSetApi.java
@@ -2,7 +2,6 @@ package denominator.route53;
 
 import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Util.filter;
-import static denominator.model.ResourceRecordSets.profileContainsType;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -17,7 +16,12 @@ import denominator.model.ResourceRecordSet;
 import denominator.profile.WeightedResourceRecordSetApi;
 
 final class Route53WeightedResourceRecordSetApi implements WeightedResourceRecordSetApi {
-    private static final Filter<ResourceRecordSet<?>> IS_WEIGHTED = profileContainsType("weighted");
+    private static final Filter<ResourceRecordSet<?>> IS_WEIGHTED = new Filter<ResourceRecordSet<?>>(){
+        @Override
+        public boolean apply(ResourceRecordSet<?> in) {
+            return in != null && in.weighted() != null;
+        }
+    };
 
     private final Collection<String> supportedTypes;
     private final SortedSet<Integer> supportedWeights;

--- a/route53/src/main/java/denominator/route53/SerializeRRS.java
+++ b/route53/src/main/java/denominator/route53/SerializeRRS.java
@@ -23,8 +23,8 @@ enum SerializeRRS {
                     .append(rrs.qualifier())//
                     .append("</SetIdentifier>");
         // note lowercase as this is a supported profile
-        if (ext.containsKey("weight"))
-            builder.append("<Weight>").append(ext.get("weight")).append("</Weight>");
+        if (rrs.weighted() != null)
+            builder.append("<Weight>").append(rrs.weighted().get("weight")).append("</Weight>");
         if (ext.containsKey("Region"))
             builder.append("<Region>").append(ext.get("Region")).append("</Region>");
         if (ext.containsKey("HostedZoneId")) {

--- a/route53/src/test/java/denominator/route53/Route53DecoderTest.java
+++ b/route53/src/test/java/denominator/route53/Route53DecoderTest.java
@@ -92,7 +92,7 @@ public class Route53DecoderTest {
                 .name("apple.myzone.com.")//
                 .type("A")//
                 .qualifier("foobar").ttl(300)//
-                .addProfile(Weighted.create(1)).add(AData.create("1.2.3.4")).build());
+                .weighted(Weighted.create(1)).add(AData.create("1.2.3.4")).build());
 
         // alias has no rdata!
         assertEquals(result.get(1), ResourceRecordSet.<AData> builder()//

--- a/route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
+++ b/route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
@@ -25,7 +25,7 @@ public class Route53ResourceRecordSetApiMockTest {
     String weightedRecords = "<ListResourceRecordSetsResponse><ResourceRecordSets><ResourceRecordSet><Name>www.denominator.io.</Name><Type>CNAME</Type><SetIdentifier>Route53Service:us-east-1:PLATFORMSERVICE:i-7f0aec0d:20130313205017</SetIdentifier><Weight>1</Weight><TTL>0</TTL><ResourceRecords><ResourceRecord><Value>www1.denominator.io.</Value></ResourceRecord></ResourceRecords></ResourceRecordSet><ResourceRecordSet><Name>www.denominator.io.</Name><Type>CNAME</Type><SetIdentifier>Route53Service:us-east-1:PLATFORMSERVICE:i-fbe41089:20130312203418</SetIdentifier><Weight>1</Weight><TTL>0</TTL><ResourceRecords><ResourceRecord><Value>www2.denominator.io.</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets></ListResourceRecordSetsResponse>";
 
     @Test
-    public void weighedRecordSetsAreFilteredOut() throws IOException, InterruptedException {
+    public void weightedRecordSetsAreFilteredOut() throws IOException, InterruptedException {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody(weightedRecords));
         server.play();

--- a/ultradns/src/main/java/denominator/ultradns/GroupGeoRecordByNameTypeIterator.java
+++ b/ultradns/src/main/java/denominator/ultradns/GroupGeoRecordByNameTypeIterator.java
@@ -83,7 +83,7 @@ class GroupGeoRecordByNameTypeIterator implements Iterator<ResourceRecordSet<?>>
             cache.put(record.geoGroupId,profile);
         }
 
-        builder.addProfile(cache.get(record.geoGroupId));
+        builder.geo(cache.get(record.geoGroupId));
         while (hasNext()) {
             DirectionalRecord next = peekingIterator.peek();
             if (typeTTLAndGeoGroupEquals(next, record)) {

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
@@ -8,7 +8,6 @@ import static denominator.common.Util.filter;
 import static denominator.common.Util.nextOrNull;
 import static denominator.model.ResourceRecordSets.nameAndTypeEqualTo;
 import static denominator.model.ResourceRecordSets.profileContainsType;
-import static denominator.model.profile.Geo.asGeo;
 import static denominator.ultradns.UltraDNSFunctions.forTypeAndRData;
 
 import java.util.ArrayList;
@@ -30,7 +29,12 @@ import denominator.ultradns.UltraDNS.DirectionalGroup;
 import denominator.ultradns.UltraDNS.DirectionalRecord;
 
 final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordSetApi {
-    private static final Filter<ResourceRecordSet<?>> IS_GEO = profileContainsType("geo");
+    private static final Filter<ResourceRecordSet<?>> IS_GEO = new Filter<ResourceRecordSet<?>>(){
+        @Override
+        public boolean apply(ResourceRecordSet<?> in) {
+            return in != null && in.geo() != null;
+        }
+    };
     private static final int DEFAULT_TTL = 300;
 
     private final Collection<String> supportedTypes;
@@ -140,7 +144,7 @@ final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordSetApi {
         int ttlToApply = rrset.ttl() != null ? rrset.ttl() : DEFAULT_TTL;
         String group = rrset.qualifier();
 
-        Map<String, Collection<String>> regions = asGeo(rrset).regions();
+        Map<String, Collection<String>> regions = rrset.geo().regions();
         DirectionalGroup directionalGroup = new DirectionalGroup();
         directionalGroup.name = group;
         directionalGroup.regionToTerritories = regions;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
@@ -30,7 +30,7 @@ import dagger.Provides;
 import denominator.BasicProvider;
 import denominator.CheckConnection;
 import denominator.DNSApiManager;
-import denominator.QualifiedResourceRecordSetApi.Factory;
+import denominator.QualifiedResourceRecordSetApi;
 import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
 import denominator.config.ConcatBasicAndQualifiedResourceRecordSets;
@@ -152,12 +152,9 @@ public class UltraDNSProvider extends BasicProvider {
             return factory;
         }
 
-        @Provides
-        @Singleton
-        Map<Factory, Collection<String>> factoryToProfiles(GeoResourceRecordSetApi.Factory in) {
-            Map<Factory, Collection<String>> factories = new LinkedHashMap<Factory, Collection<String>>();
-            factories.put(in, Arrays.asList("geo"));
-            return factories;
+        @Provides(type = SET)
+        QualifiedResourceRecordSetApi.Factory factoryToProfiles(GeoResourceRecordSetApi.Factory in) {
+            return in;
         }
     }
 

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
@@ -49,21 +49,18 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
             .qualifier("Europe")
             .ttl(300)
             .add(CNAMEData.create("www-000000001.eu-west-1.elb.amazonaws.com."))
-            .addProfile(
-                    Geo.create(ImmutableMultimap
-                            .<String, String> builder()
-                            .orderKeysBy(Ordering.natural())
-                            .putAll("Europe", "Aland Islands", "Albania", "Andorra", "Armenia", "Austria",
-                                    "Azerbaijan", "Belarus", "Belgium", "Bosnia-Herzegovina", "Bulgaria", "Croatia",
-                                    "Czech Republic", "Denmark", "Estonia", "Faroe Islands", "Finland", "France",
-                                    "Georgia", "Germany", "Gibraltar", "Greece", "Guernsey", "Hungary", "Iceland",
-                                    "Ireland", "Isle of Man", "Italy", "Jersey", "Latvia", "Liechtenstein",
-                                    "Lithuania", "Luxembourg", "Macedonia, the former Yugoslav Republic of", "Malta",
-                                    "Moldova, Republic of", "Monaco", "Montenegro", "Netherlands", "Norway", "Poland",
-                                    "Portugal", "Romania", "San Marino", "Serbia", "Slovakia", "Slovenia", "Spain",
-                                    "Svalbard and Jan Mayen", "Sweden", "Switzerland", "Ukraine", "Undefined Europe",
-                                    "United Kingdom - England, Northern Ireland, Scotland, Wales", "Vatican City")
-                            .build().asMap())).build();
+            .geo(Geo.create(ImmutableMultimap.<String, String> builder().orderKeysBy(Ordering.natural())
+                    .putAll("Europe", "Aland Islands", "Albania", "Andorra", "Armenia", "Austria",
+                            "Azerbaijan", "Belarus", "Belgium", "Bosnia-Herzegovina", "Bulgaria", "Croatia",
+                            "Czech Republic", "Denmark", "Estonia", "Faroe Islands", "Finland", "France",
+                            "Georgia", "Germany", "Gibraltar", "Greece", "Guernsey", "Hungary", "Iceland",
+                            "Ireland", "Isle of Man", "Italy", "Jersey", "Latvia", "Liechtenstein",
+                            "Lithuania", "Luxembourg", "Macedonia, the former Yugoslav Republic of", "Malta",
+                            "Moldova, Republic of", "Monaco", "Montenegro", "Netherlands", "Norway", "Poland",
+                            "Portugal", "Romania", "San Marino", "Serbia", "Slovakia", "Slovenia", "Spain",
+                            "Svalbard and Jan Mayen", "Sweden", "Switzerland", "Ukraine", "Undefined Europe",
+                            "United Kingdom - England, Northern Ireland, Scotland, Wales", "Vatican City")
+                    .build().asMap())).build();
 
     ResourceRecordSet<CNAMEData> us = ResourceRecordSet
             .<CNAMEData> builder()
@@ -72,21 +69,19 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
             .qualifier("US")
             .ttl(300)
             .add(CNAMEData.create("www-000000001.us-east-1.elb.amazonaws.com."))
-            .addProfile(
-                    Geo.create(ImmutableMultimap
-                            .<String, String> builder()
-                            .putAll("United States (US)", "Alabama", "Alaska", "Arizona", "Arkansas",
-                                    "Armed Forces Americas", "Armed Forces Europe, Middle East, and Canada",
-                                    "Armed Forces Pacific", "California", "Colorado", "Connecticut", "Delaware",
-                                    "District of Columbia", "Florida", "Georgia", "Hawaii", "Idaho", "Illinois",
-                                    "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", "Maryland",
-                                    "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana",
-                                    "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York",
-                                    "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon", "Pennsylvania",
-                                    "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas",
-                                    "Undefined United States", "United States Minor Outlying Islands", "Utah",
-                                    "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming")
-                            .build().asMap())).build();
+            .geo(Geo.create(ImmutableMultimap.<String, String> builder()
+                    .putAll("United States (US)", "Alabama", "Alaska", "Arizona", "Arkansas",
+                            "Armed Forces Americas", "Armed Forces Europe, Middle East, and Canada",
+                            "Armed Forces Pacific", "California", "Colorado", "Connecticut", "Delaware",
+                            "District of Columbia", "Florida", "Georgia", "Hawaii", "Idaho", "Illinois",
+                            "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", "Maryland",
+                            "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana",
+                            "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York",
+                            "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon", "Pennsylvania",
+                            "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas",
+                            "Undefined United States", "United States Minor Outlying Islands", "Utah",
+                            "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming")
+                    .build().asMap())).build();
 
     ResourceRecordSet<CNAMEData> everywhereElse = ResourceRecordSet
             .<CNAMEData> builder()
@@ -95,64 +90,61 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
             .qualifier("Everywhere Else")
             .ttl(60)
             .add(CNAMEData.create("www-000000002.us-east-1.elb.amazonaws.com."))
-            .addProfile(
-                    Geo.create(ImmutableMultimap
-                            .<String, String> builder()
-                            .orderKeysBy(Ordering.natural())
-                            .put("Anonymous Proxy (A1)", "Anonymous Proxy")
-                            .put("Mexico", "Mexico")
-                            .put("Satellite Provider (A2)", "Satellite Provider")
-                            .put("Unknown / Uncategorized IPs", "Unknown / Uncategorized IPs")
-                            .putAll("Canada (CA)", "Alberta", "British Columbia", "Greenland", "Manitoba",
-                                    "New Brunswick", "Newfoundland and Labrador", "Northwest Territories",
-                                    "Nova Scotia", "Nunavut", "Ontario", "Prince Edward Island", "Quebec",
-                                    "Saint Pierre and Miquelon", "Saskatchewan", "Undefined Canada", "Yukon")
-                            .putAll("The Caribbean", "Anguilla", "Antigua and Barbuda", "Aruba", "Bahamas", "Barbados",
-                                    "Bermuda", "British Virgin Islands", "Cayman Islands", "Cuba", "Dominica",
-                                    "Dominican Republic", "Grenada", "Guadeloupe", "Haiti", "Jamaica", "Martinique",
-                                    "Montserrat", "Netherlands Antilles", "Puerto Rico", "Saint Barthelemy",
-                                    "Saint Martin", "Saint Vincent and the Grenadines", "St. Kitts and Nevis",
-                                    "St. Lucia", "Trinidad and Tobago", "Turks and Caicos Islands",
-                                    "U.S. Virgin Islands")
-                            .putAll("Central America", "Belize", "Costa Rica", "El Salvador", "Guatemala", "Honduras",
-                                    "Nicaragua", "Panama", "Undefined Central America")
-                            .putAll("South America", "Argentina", "Bolivia", "Brazil", "Chile", "Colombia", "Ecuador",
-                                    "Falkland Islands", "French Guiana", "Guyana", "Paraguay", "Peru",
-                                    "South Georgia and the South Sandwich Islands", "Suriname",
-                                    "Undefined South America", "Uruguay", "Venezuela, Bolivarian Republic of")
-                            .put("Russian Federation", "Russian Federation")
-                            .putAll("Middle East", "Afghanistan", "Bahrain", "Cyprus", "Iran", "Iraq", "Israel",
-                                    "Jordan", "Kuwait", "Lebanon", "Oman", "Palestinian Territory, Occupied", "Qatar",
-                                    "Saudi Arabia", "Syrian Arab Republic", "Turkey, Republic of",
-                                    "Undefined Middle East", "United Arab Emirates", "Yemen")
-                            .putAll("Africa", "Algeria", "Angola", "Benin", "Botswana", "Burkina Faso", "Burundi",
-                                    "Cameroon", "Cape Verde", "Central African Republic", "Chad", "Comoros", "Congo",
-                                    "Cote d'Ivoire", "Democratic Republic of the Congo", "Djibouti", "Egypt",
-                                    "Equatorial Guinea", "Eritrea", "Ethiopia", "Gabon", "Gambia", "Ghana", "Guinea",
-                                    "Guinea-Bissau", "Kenya", "Lesotho", "Liberia", "Libyan Arab Jamahiriya",
-                                    "Madagascar", "Malawi", "Mali", "Mauritania", "Mauritius", "Mayotte", "Morocco",
-                                    "Mozambique", "Namibia", "Niger", "Nigeria", "Reunion", "Rwanda",
-                                    "Sao Tome and Principe", "Senegal", "Seychelles", "Sierra Leone", "Somalia",
-                                    "South Africa", "St. Helena", "Sudan", "Swaziland", "Tanzania, United Republic of",
-                                    "Togo", "Tunisia", "Uganda", "Undefined Africa", "Western Sahara", "Zambia",
-                                    "Zimbabwe")
-                            .putAll("Asia", "Bangladesh", "Bhutan", "British Indian Ocean Territory - Chagos Islands",
-                                    "Brunei Darussalam", "Cambodia", "China", "Hong Kong", "India", "Indonesia",
-                                    "Japan", "Kazakhstan", "Korea, Democratic People's Republic of",
-                                    "Korea, Republic of", "Kyrgyzstan", "Lao People's Democratic Republic", "Macao",
-                                    "Malaysia", "Maldives", "Mongolia", "Myanmar", "Nepal", "Pakistan", "Philippines",
-                                    "Singapore", "Sri Lanka", "Taiwan", "Tajikistan", "Thailand",
-                                    "Timor-Leste, Democratic Republic of", "Turkmenistan", "Undefined Asia",
-                                    "Uzbekistan", "Vietnam")
-                            .putAll("Australia / Oceania", "American Samoa", "Australia", "Christmas Island",
-                                    "Cocos (Keeling) Islands", "Cook Islands", "Fiji", "French Polynesia", "Guam",
-                                    "Heard Island and McDonald Islands", "Kiribati", "Marshall Islands",
-                                    "Micronesia , Federated States of", "Nauru", "New Caledonia", "New Zealand",
-                                    "Niue", "Norfolk Island", "Northern Mariana Islands, Commonwealth of", "Palau",
-                                    "Papua New Guinea", "Pitcairn", "Samoa", "Solomon Islands", "Tokelau", "Tonga",
-                                    "Tuvalu", "Undefined Australia / Oceania", "Vanuatu", "Wallis and Futuna")
-                            .putAll("Antarctica", "Antarctica", "Bouvet Island", "French Southern Territories").build()
-                            .asMap())).build();
+            .geo(Geo.create(ImmutableMultimap.<String, String> builder().orderKeysBy(Ordering.natural())
+                    .put("Anonymous Proxy (A1)", "Anonymous Proxy")
+                    .put("Mexico", "Mexico")
+                    .put("Satellite Provider (A2)", "Satellite Provider")
+                    .put("Unknown / Uncategorized IPs", "Unknown / Uncategorized IPs")
+                    .putAll("Canada (CA)", "Alberta", "British Columbia", "Greenland", "Manitoba",
+                            "New Brunswick", "Newfoundland and Labrador", "Northwest Territories",
+                            "Nova Scotia", "Nunavut", "Ontario", "Prince Edward Island", "Quebec",
+                            "Saint Pierre and Miquelon", "Saskatchewan", "Undefined Canada", "Yukon")
+                    .putAll("The Caribbean", "Anguilla", "Antigua and Barbuda", "Aruba", "Bahamas", "Barbados",
+                            "Bermuda", "British Virgin Islands", "Cayman Islands", "Cuba", "Dominica",
+                            "Dominican Republic", "Grenada", "Guadeloupe", "Haiti", "Jamaica", "Martinique",
+                            "Montserrat", "Netherlands Antilles", "Puerto Rico", "Saint Barthelemy",
+                            "Saint Martin", "Saint Vincent and the Grenadines", "St. Kitts and Nevis",
+                            "St. Lucia", "Trinidad and Tobago", "Turks and Caicos Islands",
+                            "U.S. Virgin Islands")
+                    .putAll("Central America", "Belize", "Costa Rica", "El Salvador", "Guatemala", "Honduras",
+                            "Nicaragua", "Panama", "Undefined Central America")
+                    .putAll("South America", "Argentina", "Bolivia", "Brazil", "Chile", "Colombia", "Ecuador",
+                            "Falkland Islands", "French Guiana", "Guyana", "Paraguay", "Peru",
+                            "South Georgia and the South Sandwich Islands", "Suriname",
+                            "Undefined South America", "Uruguay", "Venezuela, Bolivarian Republic of")
+                    .put("Russian Federation", "Russian Federation")
+                    .putAll("Middle East", "Afghanistan", "Bahrain", "Cyprus", "Iran", "Iraq", "Israel",
+                            "Jordan", "Kuwait", "Lebanon", "Oman", "Palestinian Territory, Occupied", "Qatar",
+                            "Saudi Arabia", "Syrian Arab Republic", "Turkey, Republic of",
+                            "Undefined Middle East", "United Arab Emirates", "Yemen")
+                    .putAll("Africa", "Algeria", "Angola", "Benin", "Botswana", "Burkina Faso", "Burundi",
+                            "Cameroon", "Cape Verde", "Central African Republic", "Chad", "Comoros", "Congo",
+                            "Cote d'Ivoire", "Democratic Republic of the Congo", "Djibouti", "Egypt",
+                            "Equatorial Guinea", "Eritrea", "Ethiopia", "Gabon", "Gambia", "Ghana", "Guinea",
+                            "Guinea-Bissau", "Kenya", "Lesotho", "Liberia", "Libyan Arab Jamahiriya",
+                            "Madagascar", "Malawi", "Mali", "Mauritania", "Mauritius", "Mayotte", "Morocco",
+                            "Mozambique", "Namibia", "Niger", "Nigeria", "Reunion", "Rwanda",
+                            "Sao Tome and Principe", "Senegal", "Seychelles", "Sierra Leone", "Somalia",
+                            "South Africa", "St. Helena", "Sudan", "Swaziland", "Tanzania, United Republic of",
+                            "Togo", "Tunisia", "Uganda", "Undefined Africa", "Western Sahara", "Zambia",
+                            "Zimbabwe")
+                    .putAll("Asia", "Bangladesh", "Bhutan", "British Indian Ocean Territory - Chagos Islands",
+                            "Brunei Darussalam", "Cambodia", "China", "Hong Kong", "India", "Indonesia",
+                            "Japan", "Kazakhstan", "Korea, Democratic People's Republic of",
+                            "Korea, Republic of", "Kyrgyzstan", "Lao People's Democratic Republic", "Macao",
+                            "Malaysia", "Maldives", "Mongolia", "Myanmar", "Nepal", "Pakistan", "Philippines",
+                            "Singapore", "Sri Lanka", "Taiwan", "Tajikistan", "Thailand",
+                            "Timor-Leste, Democratic Republic of", "Turkmenistan", "Undefined Asia",
+                            "Uzbekistan", "Vietnam")
+                    .putAll("Australia / Oceania", "American Samoa", "Australia", "Christmas Island",
+                            "Cocos (Keeling) Islands", "Cook Islands", "Fiji", "French Polynesia", "Guam",
+                            "Heard Island and McDonald Islands", "Kiribati", "Marshall Islands",
+                            "Micronesia , Federated States of", "Nauru", "New Caledonia", "New Zealand",
+                            "Niue", "Norfolk Island", "Northern Mariana Islands, Commonwealth of", "Palau",
+                            "Papua New Guinea", "Pitcairn", "Samoa", "Solomon Islands", "Tokelau", "Tonga",
+                            "Tuvalu", "Undefined Australia / Oceania", "Vanuatu", "Wallis and Futuna")
+                    .putAll("Antarctica", "Antarctica", "Bouvet Island", "French Southern Territories").build()
+                    .asMap())).build();
 
     static String getDirectionalDNSGroupDetailsResponseEverywhereElse = ""//
             + "<?xml version=\"1.0\"?>\n"//
@@ -364,7 +356,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
                     .qualifier(europe.qualifier())//
                     .ttl(europe.ttl())//
                     .addAll(europe.records())//
-                    .addProfile(Geo.create(ImmutableMultimap.of("Europe", "Aland Islands").asMap())).build();
+                    .geo(Geo.create(ImmutableMultimap.of("Europe", "Aland Islands").asMap())).build();
             api.put(lessOfEurope);
 
             assertEquals(server.getRequestCount(), 4);
@@ -401,7 +393,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
                     .qualifier(europe.qualifier())//
                     .ttl(600)//
                     .addAll(europe.records())//
-                    .addAllProfile(europe.profiles()).build();
+                    .geo(europe.geo()).build();
             api.put(lessTTL);
 
             assertEquals(server.getRequestCount(), 3);


### PR DESCRIPTION
Introduce `ResourceRecordSet.geo()` and `ResourceRecordSet.weighted()`, which deprecate ResourceRecordSet.profiles()

full rationale here:

https://groups.google.com/forum/#!topic/denominator-dev/rGHqWR3ENys

This change is to be applied to 3.7 as a bridge for removal of `ResourceRecordSet.profiles()` in 4.0
