### PR TITLE
remove map from known types except rdata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### Version 4.0.1
+* remove map implementation from known types except rdata.
+
 ### Version 4.0
 * remove `ResourceRecordSet.profiles()`
 

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -19,5 +19,4 @@ dependencies {
   testCompile 'com.google.guava:guava:14.0.1'
   testCompile 'org.testng:testng:6.8.5'
   testCompile 'com.google.code.gson:gson:2.2.4'
-  testCompile 'com.fasterxml.jackson.core:jackson-databind:2.2.0'
 }

--- a/model/src/main/java/denominator/common/Util.java
+++ b/model/src/main/java/denominator/common/Util.java
@@ -17,6 +17,10 @@ public class Util {
     private Util() { // no instances
     }
 
+    public static boolean equal(Object a, Object b) {
+        return a == b || (a != null && a.equals(b));
+    }
+    
     /** returns the {@code reader} as a string without closing it. */
     public static String slurp(Reader reader) throws IOException {
         StringBuilder to = new StringBuilder();

--- a/model/src/main/java/denominator/model/Zone.java
+++ b/model/src/main/java/denominator/model/Zone.java
@@ -1,9 +1,9 @@
 package denominator.model;
 
 import static denominator.common.Preconditions.checkNotNull;
+import static denominator.common.Util.equal;
 
 import java.beans.ConstructorProperties;
-import java.util.LinkedHashMap;
 
 /**
  * A zone is a delegated portion of DNS. We use the word {@code zone} instead of
@@ -11,7 +11,7 @@ import java.util.LinkedHashMap;
  * 
  * @since 1.2 See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class Zone extends LinkedHashMap<String, Object> {
+public class Zone {
 
     /**
      * Represent a zone without an {@link #id() id}.
@@ -35,16 +35,13 @@ public class Zone extends LinkedHashMap<String, Object> {
         return new Zone(name, id);
     }
 
+    private final String name;
+    private final String id;
+
     @ConstructorProperties({ "name", "id" })
     Zone(String name, String id) {
-        put("name", checkNotNull(name, "name"));
-        if (id != null)
-            put("id", id);
-    }
-
-    @SuppressWarnings("unused")
-    private Zone(){
-        // for serializers
+        this.name = checkNotNull(name, "name");
+        this.id = id;
     }
 
     /**
@@ -52,7 +49,7 @@ public class Zone extends LinkedHashMap<String, Object> {
      * includes a trailing dot, ex. "{@code netflix.com.}"
      */
     public String name() {
-        return get("name").toString();
+        return name;
     }
 
     /**
@@ -64,7 +61,7 @@ public class Zone extends LinkedHashMap<String, Object> {
      * @see #idOrName()
      */
     public String id() {
-        return (String) get("id");
+        return id;
     }
 
     /**
@@ -85,5 +82,33 @@ public class Zone extends LinkedHashMap<String, Object> {
         return id() != null ? id() : name();
     }
 
-    private static final long serialVersionUID = 1L;
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof Zone))
+            return false;
+        Zone that = Zone.class.cast(o);
+        return equal(name(), that.name()) && equal(id(), that.id());
+    }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + name().hashCode();
+        result = prime * result + ((id() == null) ? 0 : id().hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Zone [");
+        builder.append("name=").append(name());
+        if (id() != null)
+            builder.append(", ").append("id=").append(id());
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/model/src/main/java/denominator/model/profile/Geo.java
+++ b/model/src/main/java/denominator/model/profile/Geo.java
@@ -4,7 +4,7 @@ import static denominator.common.Preconditions.checkNotNull;
 
 import java.beans.ConstructorProperties;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -18,7 +18,7 @@ import java.util.Map;
  * Geo profile = Geo.create(Map.of(&quot;United States (US)&quot;, Collection.of(&quot;Maryland&quot;)));
  * </pre>
  */
-public class Geo extends LinkedHashMap<String, Object> {
+public class Geo {
 
     /**
      * @param regions
@@ -30,9 +30,11 @@ public class Geo extends LinkedHashMap<String, Object> {
         return new Geo(regions);
     }
 
+    private final Map<String, Collection<String>> regions;
+
     @ConstructorProperties({ "regions" })
     private Geo(Map<String, Collection<String>> regions) {
-        put("regions", checkNotNull(regions, "regions"));
+        this.regions = Collections.unmodifiableMap(checkNotNull(regions, "regions"));
     }
 
     /**
@@ -42,10 +44,27 @@ public class Geo extends LinkedHashMap<String, Object> {
      * 
      * @since 1.3
      */
-    @SuppressWarnings("unchecked")
     public Map<String, Collection<String>> regions() {
-        return Map.class.cast(get("regions"));
+        return regions;
     }
 
-    private static final long serialVersionUID = 1L;
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof Geo))
+            return false;
+        Geo that = Geo.class.cast(o);
+        return regions().equals(that.regions());
+    }
+
+    @Override
+    public int hashCode() {
+        return regions().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder().append("Geo [regions=").append(regions()).append("]").toString();
+    }
 }

--- a/model/src/main/java/denominator/model/profile/Weighted.java
+++ b/model/src/main/java/denominator/model/profile/Weighted.java
@@ -4,8 +4,6 @@ import static denominator.common.Preconditions.checkArgument;
 
 import java.beans.ConstructorProperties;
 
-import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
-
 /**
  * Record sets with this profile are load balanced, differentiated by an integer
  * {@code weight}.
@@ -20,7 +18,7 @@ import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
  * 
  * @since 1.3
  */
-public class Weighted extends NumbersAreUnsignedIntsLinkedHashMap {
+public class Weighted {
 
     /**
      * @param weight
@@ -30,10 +28,12 @@ public class Weighted extends NumbersAreUnsignedIntsLinkedHashMap {
         return new Weighted(weight);
     }
 
+    private final int weight;
+
     @ConstructorProperties({ "weight" })
     private Weighted(int weight) {
         checkArgument(weight >= 0, "weight must be positive");
-        put("weight", weight);
+        this.weight = weight;
     }
 
     /**
@@ -52,8 +52,26 @@ public class Weighted extends NumbersAreUnsignedIntsLinkedHashMap {
      * 
      */
     public int weight() {
-        return Integer.class.cast(get("weight"));
+        return weight;
     }
 
-    private static final long serialVersionUID = 1L;
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof Weighted))
+            return false;
+        Weighted that = Weighted.class.cast(o);
+        return weight() == that.weight();
+    }
+
+    @Override
+    public int hashCode() {
+        return 37 * 17 + weight();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder().append("Weighted [weight=").append(weight()).append("]").toString();
+    }
 }

--- a/model/src/test/java/denominator/common/UtilTest.java
+++ b/model/src/test/java/denominator/common/UtilTest.java
@@ -2,6 +2,7 @@ package denominator.common;
 
 import static denominator.common.Util.and;
 import static denominator.common.Util.concat;
+import static denominator.common.Util.equal;
 import static denominator.common.Util.filter;
 import static denominator.common.Util.join;
 import static denominator.common.Util.nextOrNull;
@@ -45,6 +46,15 @@ public class UtilTest {
     public void joinNadaReturnsEmpty() {
         assertEquals(join(';', (Object[]) null), "");
         assertEquals(join(';', new Object[] {}), "");
+    }
+
+    @Test
+    public void equalTest() {
+        assertTrue(equal(null, null));
+        assertTrue(equal("1", "1"));
+        assertFalse(equal(null, "1"));
+        assertFalse(equal("1", null));
+        assertFalse(equal("1", "2"));
     }
 
     @Test

--- a/model/src/test/java/denominator/model/ResourceRecordSetTest.java
+++ b/model/src/test/java/denominator/model/ResourceRecordSetTest.java
@@ -3,12 +3,8 @@ package denominator.model;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.testng.annotations.Test;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import denominator.model.rdata.AData;
 
@@ -29,12 +25,12 @@ public class ResourceRecordSetTest {
         assertEquals(record.records().get(0), AData.create("192.0.2.1"));
     }
 
-    public void serializeNaturallyAsJson() throws JsonProcessingException {
-        assertEquals(new ObjectMapper().writeValueAsString(record), asJson);
+    public void serializeNaturallyAsJson() {
+        assertEquals(ResourceRecordSetsTest.gson.toJson(record), asJson);
     }
 
-    public void equalToDeserializedMap() throws IOException {
-        assertEquals(new ObjectMapper().readValue(asJson, Map.class), record);
+    public void deserializesNaturallyFromJson() throws IOException {
+        assertEquals(ResourceRecordSetsTest.gson.fromJson(asJson, ResourceRecordSet.class), record);
     }
 
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "record")

--- a/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -23,8 +23,6 @@ import java.util.Map.Entry;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -270,15 +268,9 @@ public class ResourceRecordSetsTest {
         assertEquals(shortForm.type(), longForm.type());
         assertEquals(shortForm.ttl(), longForm.ttl());
         assertEquals(ImmutableList.copyOf(shortForm.records()), ImmutableList.copyOf(longForm.records()));
-        assertEquals(new ObjectMapper().writeValueAsString(shortForm), json);
-        assertEquals(new ObjectMapper().readValue(json, Map.class), shortForm);
-        assertEquals(new ObjectMapper().readValue(json, TypeFactory.defaultInstance().constructType(MAP_STRING_OBJECT.getType())),
-                shortForm);
-        assertEquals(new ObjectMapper().readValue(json, TypeFactory.defaultInstance().constructType(RRSET_STRING_OBJECT.getType())),
-                shortForm);assertEquals(gson.toJson(shortForm), json);
-        assertEquals(gson.fromJson(json, Map.class), shortForm);
-        assertEquals(gson.fromJson(json, MAP_STRING_OBJECT.getType()), shortForm);
+        assertEquals(gson.toJson(shortForm), json);
         assertEquals(gson.fromJson(json, RRSET_STRING_OBJECT.getType()), shortForm);
+        assertEquals(gson.fromJson(json, ResourceRecordSet.class), shortForm);
     }
 
     private static final TypeToken<Map<String, Object>> MAP_STRING_OBJECT = new TypeToken<Map<String, Object>>() {
@@ -287,7 +279,7 @@ public class ResourceRecordSetsTest {
     private static final TypeToken<ResourceRecordSet<Map<String, Object>>> RRSET_STRING_OBJECT = new TypeToken<ResourceRecordSet<Map<String, Object>>>() {
     };
 
-    private final TypeAdapter<Map<String, Object>> doubleToInt = new TypeAdapter<Map<String, Object>>() {
+    private static final TypeAdapter<Map<String, Object>> doubleToInt = new TypeAdapter<Map<String, Object>>() {
         TypeAdapter<Map<String, Object>> delegate = new MapTypeAdapterFactory(new ConstructorConstructor(
                 Collections.<Type, InstanceCreator<?>> emptyMap()), false).create(new Gson(), MAP_STRING_OBJECT);
 
@@ -309,7 +301,7 @@ public class ResourceRecordSetsTest {
     }.nullSafe();
 
     // deals with scenario where gson Object type treats all numbers as doubles.
-    protected final Gson gson = new GsonBuilder()//
+    public final static Gson gson = new GsonBuilder()//
             .disableHtmlEscaping()//
             .registerTypeAdapter(Map.class, doubleToInt)//
             .registerTypeAdapter(MAP_STRING_OBJECT.getType(), doubleToInt).create();

--- a/model/src/test/java/denominator/model/ZoneTest.java
+++ b/model/src/test/java/denominator/model/ZoneTest.java
@@ -5,12 +5,8 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.testng.annotations.Test;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Test
 public class ZoneTest {
@@ -21,7 +17,7 @@ public class ZoneTest {
         assertNull(name.id());
         assertEquals(name, new Zone("denominator.io.", null));
         assertEquals(name.hashCode(), new Zone("denominator.io.", null).hashCode());
-        assertEquals(name.toString(), "{name=denominator.io.}");
+        assertEquals(name.toString(), "Zone [name=denominator.io.]");
 
         Zone id = Zone.create("denominator.io.", "ABCD");
 
@@ -29,23 +25,23 @@ public class ZoneTest {
         assertEquals(id.id(), "ABCD");
         assertEquals(id, new Zone("denominator.io.", "ABCD"));
         assertEquals(id.hashCode(), new Zone("denominator.io.", "ABCD").hashCode());
-        assertEquals(id.toString(), "{name=denominator.io., id=ABCD}");
+        assertEquals(id.toString(), "Zone [name=denominator.io., id=ABCD]");
 
         assertNotEquals(name, id);
         assertNotEquals(name.hashCode(), id.hashCode());
     }
 
-    public void serializeNaturallyAsJson() throws JsonProcessingException {
-        assertEquals(new ObjectMapper().writeValueAsString(Zone.create("denominator.io.")),
+    public void serializeNaturallyAsJson() {
+        assertEquals(ResourceRecordSetsTest.gson.toJson(Zone.create("denominator.io.")),
                 "{\"name\":\"denominator.io.\"}");
-        assertEquals(new ObjectMapper().writeValueAsString(Zone.create("denominator.io.", "ABCD")),
+        assertEquals(ResourceRecordSetsTest.gson.toJson(Zone.create("denominator.io.", "ABCD")),
                 "{\"name\":\"denominator.io.\",\"id\":\"ABCD\"}");
     }
 
-    public void equalToDeserializedMap() throws IOException {
-        assertEquals(new ObjectMapper().readValue("{\"name\":\"denominator.io.\"}", Map.class),
+    public void deserializesNaturallyFromJson() throws IOException {
+        assertEquals(ResourceRecordSetsTest.gson.fromJson("{\"name\":\"denominator.io.\"}", Zone.class),
                 Zone.create("denominator.io."));
-        assertEquals(new ObjectMapper().readValue("{\"name\":\"denominator.io.\",\"id\":\"ABCD\"}", Map.class),
+        assertEquals(ResourceRecordSetsTest.gson.fromJson("{\"name\":\"denominator.io.\",\"id\":\"ABCD\"}", Zone.class),
                 Zone.create("denominator.io.", "ABCD"));
     }
 

--- a/model/src/test/java/denominator/model/profile/GeoTest.java
+++ b/model/src/test/java/denominator/model/profile/GeoTest.java
@@ -3,13 +3,12 @@ package denominator.model.profile;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMultimap;
+
+import denominator.model.ResourceRecordSetsTest;
 
 @Test
 public class GeoTest {
@@ -21,11 +20,11 @@ public class GeoTest {
 
     String asJson = "{\"regions\":{\"US\":[\"US-VA\",\"US-CA\"],\"IM\":[\"IM\"]}}";
 
-    public void serializeNaturallyAsJson() throws JsonProcessingException {
-        assertEquals(new ObjectMapper().writeValueAsString(geo), asJson);
+    public void serializeNaturallyAsJson() {
+        assertEquals(ResourceRecordSetsTest.gson.toJson(geo), asJson);
     }
 
-    public void equalToDeserializedMap() throws IOException {
-        assertEquals(new ObjectMapper().readValue(asJson, Map.class), geo);
+    public void deserializesNaturallyFromJson() throws IOException {
+        assertEquals(ResourceRecordSetsTest.gson.fromJson(asJson, Geo.class), geo);
     }
 }

--- a/model/src/test/java/denominator/model/profile/WeightedTest.java
+++ b/model/src/test/java/denominator/model/profile/WeightedTest.java
@@ -3,14 +3,11 @@ package denominator.model.profile;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import denominator.model.ResourceRecordSet;
+import denominator.model.ResourceRecordSetsTest;
 import denominator.model.rdata.AData;
 
 @Test
@@ -24,12 +21,12 @@ public class WeightedTest {
 
     String asJson = "{\"weight\":2}";
 
-    public void serializeNaturallyAsJson() throws JsonProcessingException {
-        assertEquals(new ObjectMapper().writeValueAsString(weighted), asJson);
+    public void serializeNaturallyAsJson() {
+        assertEquals(ResourceRecordSetsTest.gson.toJson(weighted), asJson);
     }
 
-    public void equalToDeserializedMap() throws IOException {
-        assertEquals(new ObjectMapper().readValue(asJson, Map.class), weighted);
+    public void deserializesNaturallyFromJson() throws IOException {
+        assertEquals(ResourceRecordSetsTest.gson.fromJson(asJson, Weighted.class), weighted);
     }
 
     static ResourceRecordSet<AData> weightedRRS = ResourceRecordSet.<AData> builder()//

--- a/route53/src/main/java/denominator/route53/SerializeRRS.java
+++ b/route53/src/main/java/denominator/route53/SerializeRRS.java
@@ -20,7 +20,7 @@ enum SerializeRRS {
                     .append("</SetIdentifier>");
         // note lowercase as this is a supported profile
         if (rrs.weighted() != null) {
-            builder.append("<Weight>").append(rrs.weighted().get("weight")).append("</Weight>");
+            builder.append("<Weight>").append(rrs.weighted().weight()).append("</Weight>");
         }
         // default ttl from the amazon console is 300
         builder.append("<TTL>").append(rrs.ttl() == null ? 300 : rrs.ttl()).append("</TTL>");


### PR DESCRIPTION
Extending map leads to either complicated eq/hashCode or potential for masking fields.  This was caught downstream where the "geo" field in ResourceRecordSet was masked by an identical key in the map.  Most predictable solution is to not extend map on statically defined types.

The only exception is rdata.  rdata is wide open and we only have java classes for a small number of types.  Until we enforce a supported subset, using Map to back rdata is still a valid compromise.  That said, it implies the cost of test code to ensure map and java objects are equiv (entries == field values).
