### PR TITLE
example http daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 4.5
+* Adds example server
+
 ### Version 4.4.2
 * Updates to feign 8.1
 

--- a/example-daemon/README.md
+++ b/example-daemon/README.md
@@ -1,0 +1,192 @@
+# DenominatorD Example
+
+DenominatorD is an example HTTP server that proxies a connection to your DNS provider.  Technically, it is a [MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver).  Once built, denominatord is a [really executable jar](http://skife.org/java/unix/2011/06/20/really_executable_jars.html), weighing in at 1.25MB, and starting up in <200ms on a modern laptop.
+
+## Building
+To build the daemon, execute `gradle clean build`.  The binary will end up at `./build/denominatord`.  If you don't have gradle, install it.
+
+## Running
+The syntax is simple.  First arg is the name of the provider.  For example, clouddns, dynect, mock, route53, or ultradns.  The remaining args are any credentials to that provider.
+
+Ex. If you have no account, you can use mock.
+
+```bash
+$ build/denominatord mock
+     16 - proxying MockProvider{name=mock,url=mem:mock}
+    136 - MockWebServer[8080] starting to accept connections
+```
+
+Ex. To connect to a real cloud, you'll specify your credentials.  You'll notice status messages for each outbound request.
+
+```bash
+$ build/denominatord route53 accessKey secretKey
+     14 - proxying Route53Provider{name=route53,url=https://route53.amazonaws.com}
+    181 - MockWebServer[8080] starting to accept connections
+   2395 - [Route53#listHostedZones] ---> GET https://route53.amazonaws.com/2012-12-12/hostedzone HTTP/1.1
+   3155 - [Route53#listHostedZones] <--- HTTP/1.1 200 OK (759ms)
+   3193 - MockWebServer[8080] received request: GET /zones HTTP/1.1 and responded: HTTP/1.1 200 OK
+```
+
+By default, denominatord listens on port 8080.  Export `DENOMINATORD_PORT` to use a different port.
+
+## API
+The api is read-only, and based on [OpenStack Designate V2](https://wiki.openstack.org/wiki/Designate/APIv2).
+
+Output is always json, and there's really only a few error cases.
+  * 404 for an invalid request.
+  * 400 for a valid request, but bad data.
+  * 500 when the server blows up.
+
+Here are the resources exposed.
+
+### HealthCheck
+
+#### GET /healthcheck
+Returns 200 when the dns provider is healthy, 503 if not.
+
+Ex. you might want to put a guard in a shell script to fail when health is bad.
+```bash
+$ curl -f http://localhost:8080/healthcheck
+```
+
+### Zones
+
+#### GET /zones
+Returns a possibly empty array of your zones.
+
+Ex. for clouds like ultradns, you'll only see the zone name.
+```bash
+$ curl http://localhost:8080/zones
+[
+  {
+    "name": "denominator.io."
+  }
+]
+```
+
+Ex. for clouds like route53, zones are not unique by name, so you'll see an `id`.
+
+```bash
+$ curl http://localhost:8080/zones
+[
+  {
+    "name": "myzone.com.",
+    "id": "ABCDEFGHIJK"
+  }
+]
+```
+
+### Record Sets
+All record set commands require the zone specified as a path parameter.  This is either the id of the zone,
+or when there is no id, it is the name.
+
+```
+/zones/{zoneIdOrName}/recordsets
+```
+
+**Pay attention to trailing dots!**
+
+Ex. for clouds like ultradns, the zone parameter is the zone name.
+
+```
+/zones/denominator.io./recordsets
+```
+
+Where for clouds like route53, you'd use the id.
+
+```
+/zones/Z1V14BIB35Q8HU/recordsets
+```
+
+#### GET /zones/{zoneIdOrName}/recordsets?name={name}&type={type}&qualifier={qualifier}
+Returns a possibly empty array of your record sets.
+
+Supported Query params:
+  * name - optional - ex. `www.domain.com.`
+  * type - optional unless you specify name - ex. `A`
+  * qualifier - optional unless you specify type - ex. `US-West`
+
+Ex. for route53, where the zone has an id
+
+```bash
+$ curl http://localhost:8080/zones/Z1V14BIB35Q8HU/recordsets
+[
+  {
+    "name": "denominator.io.",
+    "type": "NS",
+    "ttl": 172800,
+    "records": [
+      {
+        "nsdname": "ns-1707.awsdns-21.co.uk."
+      },
+      {
+        "nsdname": "ns-1359.awsdns-41.org."
+      },
+      {
+        "nsdname": "ns-981.awsdns-58.net."
+      },
+      {
+        "nsdname": "ns-86.awsdns-10.com."
+      }
+    ]
+  },
+--snip--
+```
+
+Ex. refining results by name, type, and qualifier.
+
+```bash
+$ curl 'http://localhost:8080/zones/denominator.io./recordsets?name=www2.geo.denominator.io.&type=A&qualifier=alazona'
+[
+  {
+    "name": "www2.geo.denominator.io.",
+    "type": "A",
+    "qualifier": "alazona",
+    "ttl": 300,
+    "records": [
+      {
+        "address": "192.0.2.1"
+      }
+    ],
+    "geo": {
+      "regions": {
+        "United States (US)": [
+          "Alaska",
+          "Arizona"
+        ]
+      }
+    }
+  }
+]
+```
+
+#### PUT /zones/{zoneIdOrName}/recordsets
+Adds or replaces a record set and returns `204`.
+
+Ex. to add or replace an MX record.
+```bash
+$ curl -X PUT http://localhost:8080/zones/Z3I0BTR7N27QRM/recordsets -d'{
+  "name": "test.myzone.com.",
+  "type": "TXT",
+  "ttl": 1800,
+  "records": [{
+    "txtdata": "made in norway"
+  }, {
+    "txtdata": "made in sweden"
+  }]
+}'
+```
+
+#### DELETE /zones/{zoneIdOrName}/recordsets?name={name}&type={type}&qualifier={qualifier}
+Deletes a record set if present and returns `204`.
+
+Supported Query params:
+  * name - required - ex. `www.domain.com.`
+  * type - required - ex. `A`
+  * qualifier - required if an advanced record set - ex. `US-West`
+
+Ex. to delete a normal MX record
+
+```bash
+$ curl -X DELETE 'http://localhost:8080/zones/Z3I0BTR7N27QRM/recordsets?name=test.myzone.com.&type=TXT'
+```

--- a/example-daemon/build.gradle
+++ b/example-daemon/build.gradle
@@ -1,0 +1,76 @@
+apply plugin: 'java'
+apply from: ('../dagger.gradle') // to configure denominator logging
+
+repositories { mavenLocal()
+               mavenCentral() }
+
+dependencies {
+  compile     'com.netflix.denominator:denominator-core:4.4.2'
+  compile     'com.netflix.denominator:denominator-dynect:4.4.2'
+  compile     'com.netflix.denominator:denominator-ultradns:4.4.2'
+  compile     'com.netflix.denominator:denominator-route53:4.4.2'
+  compile     'com.netflix.denominator:denominator-clouddns:4.4.2'
+  compile     'com.netflix.feign:feign-core:8.1.0'
+  compile    ('com.squareup.okhttp:mockwebserver:2.2.0') {
+    exclude group: 'org.bouncycastle'
+  }
+  compile     'com.google.code.gson:gson:2.2.4'
+  testCompile 'junit:junit:4.12'
+  testCompile 'org.assertj:assertj-core:1.7.1'
+  testCompile 'com.netflix.feign:feign-gson:8.1.0'
+}
+
+// create a self-contained jar that is executable
+// the output is both a 'fat' project artifact and
+// a convenience file named "build/denominatord"
+task fatJar(dependsOn: classes, type: Jar) { 
+  classifier 'fat'
+
+  // until better groovy, hard-code the list, which must be updated
+  // when providers are added.
+  def providerFile = "META-INF/services/denominator.Provider"
+  from "supportedProviders.txt"
+  rename "supportedProviders.txt", providerFile
+
+  doFirst {
+    // Delay evaluation until the compile configuration is ready
+    from {
+      configurations.compile.collect { zipTree(it).matching { 
+          exclude "**/${providerFile}"
+          // remove all signature files
+          exclude "META-INF/*.SF"
+          exclude "META-INF/*.DSA"
+          exclude "META-INF/*.RSA"
+      } }
+    }
+  }
+
+  from (sourceSets*.output.classesDir) {
+    exclude "**/${providerFile}"
+  }
+
+  // really executable jar
+  // http://skife.org/java/unix/2011/06/20/really_executable_jars.html
+
+  manifest {
+    attributes 'Main-Class': 'denominator.denominatord.DenominatorD'
+  }
+
+  // for convenience, we make a file in the build dir named denominator with no extension
+  doLast {
+    def srcFile = new File("${buildDir}/libs/${archiveName}")
+    def shortcutFile = new File("${buildDir}/denominatord")
+    shortcutFile.delete()
+    shortcutFile << "#!/usr/bin/env sh\n"
+    shortcutFile << 'exec java -jar $0 "$@"' + "\n"
+    shortcutFile << srcFile.bytes
+    shortcutFile.setExecutable(true, true)
+    srcFile.delete()
+    srcFile << shortcutFile.bytes   
+    srcFile.setExecutable(true, true)
+  }
+}
+
+artifacts {
+  archives fatJar
+}

--- a/example-daemon/src/main/java/denominator/denominatord/DenominatorD.java
+++ b/example-daemon/src/main/java/denominator/denominatord/DenominatorD.java
@@ -1,0 +1,118 @@
+package denominator.denominatord;
+
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import java.io.IOException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import dagger.Module;
+import dagger.Provides;
+import denominator.DNSApiManager;
+import denominator.Denominator;
+import denominator.Provider;
+import denominator.Providers;
+import feign.Feign;
+
+import static denominator.CredentialsConfiguration.anonymous;
+import static denominator.CredentialsConfiguration.credentials;
+import static denominator.common.Preconditions.checkArgument;
+import static java.lang.System.currentTimeMillis;
+
+public class DenominatorD {
+
+  private static final String SYNTAX = "syntax: provider credentialArg1 credentialArg2 ...";
+  private static final Logger log = Logger.getLogger(DenominatorD.class.getName());
+
+  private final MockWebServer server;
+
+  public DenominatorD(DNSApiManager mgr) {
+    this.server = new MockWebServer();
+    server.setDispatcher(new DenominatorDispatcher(mgr, new JsonCodec()));
+  }
+
+  public int start() throws IOException {
+    server.play();
+    return server.getPort();
+  }
+
+  public void start(int port) throws IOException {
+    server.play(port);
+  }
+
+  public void stop() throws IOException {
+    server.shutdown();
+  }
+
+  /**
+   * Presents a {@link DenominatorDApi REST api} to users, by default listening on port 8080.
+   */
+  public static void main(final String... args) throws IOException {
+    checkArgument(args.length > 0, SYNTAX);
+    setupLogging();
+
+    String portOverride = System.getenv("DENOMINATORD_PORT");
+    int port = portOverride != null ? Integer.parseInt(portOverride) : 8080;
+    Provider provider = Providers.getByName(args[0]);
+    log.info("proxying " + provider);
+    Object credentials = credentialsFromArgs(args);
+
+    DNSApiManager mgr = Denominator.create(provider, credentials, new JavaLogger());
+    new DenominatorD(mgr).start(port);
+  }
+
+  static Object credentialsFromArgs(String[] args) {
+    switch (args.length) {
+      case 4:
+        return credentials(args[1], args[2], args[3]);
+      case 3:
+        return credentials(args[1], args[2]);
+      case 1:
+        return anonymous();
+      default:
+        throw new IllegalArgumentException(SYNTAX);
+    }
+  }
+
+  @Module(library = true, overrides = true)
+  static class JavaLogger {
+
+    @Provides
+    feign.Logger.Level provideLevel() {
+      return feign.Logger.Level.BASIC;
+    }
+
+    @Provides
+    feign.Logger logger() {
+      return new feign.Logger.JavaLogger();
+    }
+  }
+
+  static void setupLogging() {
+    final long start = currentTimeMillis();
+    ConsoleHandler handler = new ConsoleHandler();
+    handler.setLevel(Level.FINE);
+    handler.setFormatter(new Formatter() {
+      @Override
+      public String format(LogRecord record) {
+        return String.format("%7d - %s%n", record.getMillis() - start, record.getMessage());
+      }
+    });
+
+    Logger[] loggers = {
+        Logger.getLogger(DenominatorD.class.getPackage().getName()),
+        Logger.getLogger(feign.Logger.class.getName()),
+        Logger.getLogger(MockWebServer.class.getName())
+    };
+
+    for (Logger logger : loggers) {
+      logger.setLevel(Level.FINE);
+      logger.setUseParentHandlers(false);
+      logger.addHandler(handler);
+    }
+  }
+}

--- a/example-daemon/src/main/java/denominator/denominatord/DenominatorDApi.java
+++ b/example-daemon/src/main/java/denominator/denominatord/DenominatorDApi.java
@@ -1,0 +1,56 @@
+package denominator.denominatord;
+
+import java.util.List;
+
+import denominator.model.ResourceRecordSet;
+import denominator.model.Zone;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Response;
+
+/**
+ * Defines the interface of {@link DenominatorD}, where all responses are in json. <p/> All
+ * responses throw a 400 if there is a problem with the request data. <p/> 404 would be unexpected
+ * as that implies a malformed request.
+ */
+public interface DenominatorDApi {
+
+  @RequestLine("GET /healthcheck")
+  Response healthcheck();
+
+  @RequestLine("GET /zones")
+  List<Zone> zones();
+
+  @RequestLine("GET /zones/{zoneIdOrName}/recordsets")
+  List<ResourceRecordSet<?>> recordSets(@Param("zoneIdOrName") String zoneIdOrName);
+
+  @RequestLine("GET /zones/{zoneIdOrName}/recordsets?name={name}")
+  List<ResourceRecordSet<?>> recordSetsByName(@Param("zoneIdOrName") String zoneIdOrName,
+                                              @Param("name") String name);
+
+  @RequestLine("GET /zones/{zoneIdOrName}/recordsets?name={name}&type={type}")
+  List<ResourceRecordSet<?>> recordSetsByNameAndType(@Param("zoneIdOrName") String zoneIdOrName,
+                                                     @Param("name") String name,
+                                                     @Param("type") String type);
+
+  @RequestLine("GET /zones/{zoneIdOrName}/recordsets?name={name}&type={type}&qualifier={qualifier}")
+  List<ResourceRecordSet<?>> recordsetsByNameAndTypeAndQualifier(
+      @Param("zoneIdOrName") String zoneIdOrName, @Param("name") String name,
+      @Param("type") String type, @Param("qualifier") String qualifier);
+
+  @RequestLine("PUT /zones/{zoneIdOrName}/recordsets?name={name}")
+  @Headers("Content-Type: application/json")
+  void putRecordSet(@Param("zoneIdOrName") String zoneIdOrName, ResourceRecordSet<?> update);
+
+  @RequestLine("DELETE /zones/{zoneIdOrName}/recordsets?name={name}&type={type}")
+  void deleteRecordSetByNameAndType(@Param("zoneIdOrName") String zoneIdOrName,
+                                    @Param("name") String name,
+                                    @Param("type") String type);
+
+  @RequestLine("DELETE /zones/{zoneIdOrName}/recordsets?name={name}&type={type}&qualifier={qualifier}")
+  void deleteRecordSetByNameTypeAndQualifier(@Param("zoneIdOrName") String zoneIdOrName,
+                                             @Param("name") String name,
+                                             @Param("type") String type,
+                                             @Param("qualifier") String qualifier);
+}

--- a/example-daemon/src/main/java/denominator/denominatord/DenominatorDispatcher.java
+++ b/example-daemon/src/main/java/denominator/denominatord/DenominatorDispatcher.java
@@ -1,0 +1,49 @@
+package denominator.denominatord;
+
+import com.squareup.okhttp.mockwebserver.Dispatcher;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+import denominator.DNSApiManager;
+
+import static denominator.denominatord.RecordSetDispatcher.RECORDSET_PATTERN;
+
+public class DenominatorDispatcher extends Dispatcher {
+
+  private final DNSApiManager mgr;
+  private final JsonCodec codec;
+  private final Dispatcher recordSets;
+
+  DenominatorDispatcher(DNSApiManager mgr, JsonCodec codec) {
+    this.mgr = mgr;
+    this.codec = codec;
+    this.recordSets = new RecordSetDispatcher(mgr, codec);
+  }
+
+  @Override
+  public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+    try {
+      if ("/healthcheck".equals(request.getPath())) {
+        if (!request.getMethod().equals("GET")) {
+          return new MockResponse().setResponseCode(405);
+        }
+        return new MockResponse().setResponseCode(mgr.checkConnection() ? 200 : 503);
+      } else if ("/zones".equals(request.getPath())) {
+        if (!request.getMethod().equals("GET")) {
+          return new MockResponse().setResponseCode(405);
+        }
+        return codec.toJsonArray(mgr.api().zones().iterator());
+      } else if (RECORDSET_PATTERN.matcher(request.getPath()).matches()) {
+        return recordSets.dispatch(request);
+      } else {
+        return new MockResponse().setResponseCode(404);
+      }
+    } catch (InterruptedException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      return new MockResponse().setResponseCode(e instanceof IllegalArgumentException ? 400 : 500)
+          .addHeader("Content-Type", "text/plain")
+          .setBody(e.getMessage() + "\n"); // curl nice
+    }
+  }
+}

--- a/example-daemon/src/main/java/denominator/denominatord/JsonCodec.java
+++ b/example-daemon/src/main/java/denominator/denominatord/JsonCodec.java
@@ -1,0 +1,48 @@
+package denominator.denominatord;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonWriter;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Iterator;
+
+class JsonCodec {
+
+  private final Gson json;
+
+  JsonCodec() {
+    this.json = new GsonBuilder().setPrettyPrinting().create();
+  }
+
+  <T> T readJson(RecordedRequest request, Class<T> clazz) {
+    return json.fromJson(request.getUtf8Body(), clazz);
+  }
+
+  <T> MockResponse toJsonArray(Iterator<T> elements) {
+    elements.hasNext(); // defensive to make certain error cases eager.
+
+    StringWriter out = new StringWriter(); // MWS cannot do streaming responses.
+    try {
+      JsonWriter writer = new JsonWriter(out);
+      writer.setIndent("  ");
+      writer.beginArray();
+      while (elements.hasNext()) {
+        Object next = elements.next();
+        json.toJson(next, next.getClass(), writer);
+      }
+      writer.endArray();
+      writer.flush();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return new MockResponse().setResponseCode(200)
+        .addHeader("Content-Type", "application/json")
+        .setBody(out.toString() + "\n"); // curl nice
+  }
+}

--- a/example-daemon/src/main/java/denominator/denominatord/Query.java
+++ b/example-daemon/src/main/java/denominator/denominatord/Query.java
@@ -1,0 +1,62 @@
+package denominator.denominatord;
+
+import java.net.URI;
+import java.util.List;
+
+import denominator.common.Util;
+import denominator.model.ResourceRecordSet;
+
+import static denominator.common.Preconditions.checkArgument;
+
+class Query {
+
+  static Query from(String path) {
+    String decoded = URI.create(path).getQuery();
+    if (decoded == null) {
+      return new Query(null, null, null);
+    }
+    String name = null;
+    String type = null;
+    String qualifier = null;
+    for (String nameValueString : Util.split('&', decoded)) {
+      List<String> nameValue = Util.split('=', nameValueString);
+      String queryName = nameValue.get(0);
+      String queryValue = nameValue.size() > 1 ? nameValue.get(1) : null;
+      if (queryName.equals("name")) {
+        name = queryValue;
+      } else if (queryName.equals("type")) {
+        type = queryValue;
+      } else if (queryName.equals("qualifier")) {
+        qualifier = queryValue;
+      }
+    }
+    return new Query(name, type, qualifier);
+  }
+
+  static Query from(ResourceRecordSet<?> recordSet) {
+    return new Query(recordSet.name(), recordSet.type(), recordSet.qualifier());
+  }
+
+  final String name;
+  final String type;
+  final String qualifier;
+
+  private Query(String name, String type, String qualifier) {
+    this.name = name;
+    this.type = type;
+    this.qualifier = qualifier;
+    if (qualifier != null) {
+      checkArgument(type != null && name != null, "name and type query required with qualifier");
+    } else if (type != null) {
+      checkArgument(name != null, "name query required with type");
+    }
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder()
+        .append("name=").append(name)
+        .append(", type=").append(type)
+        .append(", qualifier=").append(qualifier).toString();
+  }
+}

--- a/example-daemon/src/main/java/denominator/denominatord/RecordSetDispatcher.java
+++ b/example-daemon/src/main/java/denominator/denominatord/RecordSetDispatcher.java
@@ -1,0 +1,88 @@
+package denominator.denominatord;
+
+
+import com.squareup.okhttp.mockwebserver.Dispatcher;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+import java.util.Iterator;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import denominator.AllProfileResourceRecordSetApi;
+import denominator.DNSApiManager;
+import denominator.ReadOnlyResourceRecordSetApi;
+import denominator.model.ResourceRecordSet;
+
+import static denominator.common.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+
+public class RecordSetDispatcher extends Dispatcher {
+
+  static final Pattern RECORDSET_PATTERN = Pattern.compile("/zones/([\\.\\w]+)/recordsets(\\?.*)?");
+
+  private final Logger log = Logger.getLogger(Dispatcher.class.getName());
+  private final DNSApiManager mgr;
+  private final JsonCodec codec;
+
+  RecordSetDispatcher(DNSApiManager mgr, JsonCodec codec) {
+    this.mgr = mgr;
+    this.codec = codec;
+  }
+
+  @Override
+  public MockResponse dispatch(RecordedRequest request) {
+    Matcher matcher = RECORDSET_PATTERN.matcher(request.getPath());
+    if (!matcher.matches()) {
+      return new MockResponse().setResponseCode(404);
+    }
+    String zoneIdOrName = matcher.group(1);
+    AllProfileResourceRecordSetApi api = mgr.api().recordSetsInZone(zoneIdOrName);
+    checkArgument(api != null, "cannot control record sets in zone %s", zoneIdOrName);
+    if (request.getMethod().equals("GET")) {
+      Query query = Query.from(request.getPath());
+      return codec.toJsonArray(recordSetsForQuery(api, query));
+    } else if (request.getMethod().equals("PUT")) {
+      ResourceRecordSet<?> recordSet = codec.readJson(request, ResourceRecordSet.class);
+      Query query = Query.from(recordSet);
+      long s = currentTimeMillis();
+      log.info(format("replacing recordset %s", query));
+      api.put(recordSet);
+      log.info(format("replaced recordset %s in %sms", query, currentTimeMillis() - s));
+      return new MockResponse().setResponseCode(204);
+    } else if (request.getMethod().equals("DELETE")) {
+      Query query = Query.from(request.getPath());
+      long s = currentTimeMillis();
+      log.info(format("deleting recordset %s ", query));
+      if (query.qualifier != null) {
+        api.deleteByNameTypeAndQualifier(query.name, query.type, query.qualifier);
+      } else if (query.type != null) {
+        checkArgument(query.name != null, "name query required with type");
+        api.deleteByNameAndType(query.name, query.type);
+      } else if (query.name != null) {
+        throw new IllegalArgumentException("you must specify both name and type when deleting");
+      }
+      log.info(format("deleted recordset %s in %sms", query, currentTimeMillis() - s));
+      return new MockResponse().setResponseCode(204);
+    } else {
+      return new MockResponse().setResponseCode(405);
+    }
+  }
+
+  static Iterator<?> recordSetsForQuery(ReadOnlyResourceRecordSetApi api, Query query) {
+    if (query.qualifier != null) {
+      ResourceRecordSet<?> rrset =
+          api.getByNameTypeAndQualifier(query.name, query.type, query.qualifier);
+      return rrset != null ? singleton(rrset).iterator() : emptySet().iterator();
+    } else if (query.type != null) {
+      return api.iterateByNameAndType(query.name, query.type);
+    } else if (query.name != null) {
+      return api.iterateByName(query.name);
+    }
+    return api.iterator();
+  }
+}

--- a/example-daemon/src/main/resources/logging.properties
+++ b/example-daemon/src/main/resources/logging.properties
@@ -1,0 +1,21 @@
+# Non-Root loggers
+loggers=denominator.denominatord
+
+# Root logger configuration
+logger.level=INFO
+logger.handlers=CONSOLE
+
+# Console handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush,target
+handler.CONSOLE.target=SYSTEM_ERR
+handler.CONSOLE.level=ALL
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+# The log format pattern
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p (%t) [%c] <%F:%L> %m%n
+
+denominator.denominatord.level=DEBUG

--- a/example-daemon/src/test/java/denominator/denominatord/DenominatorDTest.java
+++ b/example-daemon/src/test/java/denominator/denominatord/DenominatorDTest.java
@@ -1,0 +1,175 @@
+package denominator.denominatord;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import denominator.DNSApiManager;
+import denominator.Denominator;
+import denominator.mock.MockProvider;
+import denominator.model.ResourceRecordSet;
+import denominator.model.profile.Geo;
+import denominator.model.rdata.CNAMEData;
+import feign.Feign;
+import feign.FeignException;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DenominatorDTest {
+
+  static DNSApiManager mock;
+  static DenominatorD server;
+  static DenominatorDApi client;
+
+  @BeforeClass
+  public static void start() throws IOException {
+    mock = Denominator.create(new MockProvider());
+    server = new DenominatorD(mock);
+    int port = server.start();
+    client = Feign.builder()
+        .encoder(new GsonEncoder())
+        .decoder(new GsonDecoder())
+        .target(DenominatorDApi.class, "http://localhost:" + port);
+  }
+
+  @AfterClass
+  public static void stop() throws IOException {
+    server.stop();
+  }
+
+  @Test
+  public void healthcheckOK() {
+    assertThat(client.healthcheck().status()).isEqualTo(200);
+  }
+
+  @Test
+  public void zones() {
+    assertThat(client.zones())
+        .isNotEmpty()
+        .containsAll(mock.api().zones());
+  }
+
+  @Test
+  public void recordSets() {
+    assertThat(client.recordSets("denominator.io.")).isNotEmpty();
+  }
+
+  @Test
+  public void recordSetsWrongZoneIs400() {
+    try {
+      client.recordSets("moomoo.io.");
+    } catch (FeignException e) {
+      assertThat(e.getMessage()).startsWith("status 400");
+    }
+  }
+
+  @Test
+  public void recordSetsByName() {
+    assertThat(client.recordSetsByName("denominator.io.", "www.denominator.io."))
+        .isNotEmpty()
+        .containsAll(toList(
+            mock.api().recordSetsInZone("denominator.io.").iterateByName("www.denominator.io.")));
+  }
+
+  @Test
+  public void recordSetsByNameWhenNotFound() {
+    assertThat(client.recordSetsByName("denominator.io.", "moomoo.denominator.io.")).isEmpty();
+  }
+
+  @Test
+  public void recordSetsByNameAndType() {
+    assertThat(client.recordSetsByNameAndType("denominator.io.", "denominator.io.", "NS"))
+        .isNotEmpty()
+        .containsAll(toList(mock.api().recordSetsInZone("denominator.io.")
+                                .iterateByNameAndType("denominator.io.", "NS")));
+  }
+
+  @Test
+  public void recordSetsByNameAndTypeWhenNotFound() {
+    assertThat(client.recordSetsByNameAndType("denominator.io.", "denominator.io.", "A")).isEmpty();
+  }
+
+  @Test
+  public void recordSetsByNameTypeAndQualifier() {
+    assertThat(client.recordsetsByNameAndTypeAndQualifier("denominator.io.",
+                                                          "www.weighted.denominator.io.", "CNAME",
+                                                          "EU-West"))
+        .isNotEmpty()
+        .containsOnly(mock.api().recordSetsInZone("denominator.io.")
+                          .getByNameTypeAndQualifier("www.weighted.denominator.io.", "CNAME",
+                                                     "EU-West"));
+  }
+
+  @Test
+  public void recordSetsByNameTypeAndQualifierWhenNotFound() {
+    assertThat(client.recordsetsByNameAndTypeAndQualifier("denominator.io.",
+                                                          "www.weighted.denominator.io.", "CNAME",
+                                                          "AU-West")).isEmpty();
+  }
+
+  @Test
+  public void deleteRecordSetByNameAndType() {
+    client.deleteRecordSetByNameAndType("denominator.io.", "www1.denominator.io.", "A");
+    assertThat(client.recordSetsByNameAndType("denominator.io.", "www1.denominator.io.", "A"))
+        .isEmpty();
+  }
+
+  @Test
+  public void deleteRecordSetByNameAndTypeWhenNotFound() {
+    client.deleteRecordSetByNameAndType("denominator.io.", "denominator.io.", "A");
+  }
+
+  @Test
+  public void deleteRecordSetByNameTypeAndQualifier() {
+    client.deleteRecordSetByNameTypeAndQualifier("denominator.io.", "www.weighted.denominator.io.",
+                                                 "CNAME", "US-West");
+    assertThat(client.recordsetsByNameAndTypeAndQualifier("denominator.io.",
+                                                          "www.weighted.denominator.io.", "CNAME",
+                                                          "US-West")).isEmpty();
+  }
+
+  @Test
+  public void deleteRecordSetByNameTypeAndQualifierWhenNotFound() {
+    client.deleteRecordSetByNameTypeAndQualifier("denominator.io.", "www.weighted.denominator.io.",
+                                                 "CNAME", "AU-West");
+  }
+
+  @Test
+  public void putRecordSet() {
+    Map<String, Collection<String>> antarctica = new LinkedHashMap<String, Collection<String>>();
+    antarctica.put("Antarctica",
+                   Arrays.asList("Bouvet Island", "French Southern Territories", "Antarctica"));
+
+    ResourceRecordSet<CNAMEData> recordSet = ResourceRecordSet.<CNAMEData>builder()
+        .name("www.beta.denominator.io.")
+        .type("CNAME")
+        .qualifier("Antarctica")
+        .ttl(300)
+        .add(CNAMEData.create("www-south.denominator.io."))
+        .geo(Geo.create(antarctica))
+        .build();
+    client.putRecordSet("denominator.io.", recordSet);
+    assertThat(
+        client.recordSetsByNameAndType("denominator.io.", recordSet.name(), recordSet.type()))
+        .containsOnly(recordSet);
+  }
+
+  static List<ResourceRecordSet<?>> toList(Iterator<ResourceRecordSet<?>> iterator) {
+    List<ResourceRecordSet<?>> inMock = new ArrayList<ResourceRecordSet<?>>();
+    while (iterator.hasNext()) {
+      inMock.add(iterator.next());
+    }
+    return inMock;
+  }
+}

--- a/example-daemon/supportedProviders.txt
+++ b/example-daemon/supportedProviders.txt
@@ -1,0 +1,9 @@
+# Update this file to add more default providers to the fat jar.
+# Note that these providers must be specified as a fatJarProviders dependency
+# At build time, this will become META-INF/services/denominator.Provider
+# see http://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html
+denominator.clouddns.CloudDNSProvider
+denominator.dynect.DynECTProvider
+denominator.mock.MockProvider
+denominator.route53.Route53Provider
+denominator.ultradns.UltraDNSProvider


### PR DESCRIPTION
# DenominatorD Example

DenominatorD is an example HTTP server that proxies a connection to your DNS provider.  Technically, it is a [MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver).  Once built, denominatord is a [really executable jar](http://skife.org/java/unix/2011/06/20/really_executable_jars.html), weighing in at 1.25MB, and starting up in <200ms on a modern laptop.

## Building
To build the daemon, execute `gradle clean build`.  The binary will end up at `./build/denominatord`.  If you don't have gradle, install it.

## Running
The syntax is simple.  First arg is the name of the provider.  For example, clouddns, dynect, mock, route53, or ultradns.  The remaining args are any credentials to that provider.

Ex. If you have no account, you can use mock.

```bash
$ build/denominatord mock
     16 - proxying MockProvider{name=mock,url=mem:mock}
    136 - MockWebServer[8080] starting to accept connections
```

Ex. To connect to a real cloud, you'll specify your credentials.  You'll notice status messages for each outbound request.

```bash
$ build/denominatord route53 accessKey secretKey
     14 - proxying Route53Provider{name=route53,url=https://route53.amazonaws.com}
    181 - MockWebServer[8080] starting to accept connections
   2395 - [Route53#listHostedZones] ---> GET https://route53.amazonaws.com/2012-12-12/hostedzone HTTP/1.1
   3155 - [Route53#listHostedZones] <--- HTTP/1.1 200 OK (759ms)
   3193 - MockWebServer[8080] received request: GET /zones HTTP/1.1 and responded: HTTP/1.1 200 OK
```

By default, denominatord listens on port 8080.  Export `DENOMINATORD_PORT` to use a different port.

## API
The api is read-only, and based on [OpenStack Designate V2](https://wiki.openstack.org/wiki/Designate/APIv2).

Output is always json, and there's really only a few error cases.
  * 404 for an invalid request.
  * 400 for a valid request, but bad data.
  * 500 when the server blows up.

Here are the resources exposed.

### HealthCheck

#### GET /healthcheck
Returns 200 when the dns provider is healthy, 503 if not.

Ex. you might want to put a guard in a shell script to fail when health is bad.
```bash
$ curl -f http://localhost:8080/healthcheck
```

### Zones

#### GET /zones
Returns a possibly empty array of your zones.

Ex. for clouds like ultradns, you'll only see the zone name.
```bash
$ curl http://localhost:8080/zones
[
  {
    "name": "denominator.io."
  }
]
```

Ex. for clouds like route53, zones are not unique by name, so you'll see an `id`.

```bash
$ curl http://localhost:8080/zones
[
  {
    "name": "myzone.com.",
    "id": "ABCDEFGHIJK"
  }
]
```

### Record Sets
All record set commands require the zone specified as a path parameter.  This is either the id of the zone,
or when there is no id, it is the name.

```
/zones/{zoneIdOrName}/recordsets
```

**Pay attention to trailing dots!**

Ex. for clouds like ultradns, the zone parameter is the zone name.

```
/zones/denominator.io./recordsets
```

Where for clouds like route53, you'd use the id.

```
/zones/Z1V14BIB35Q8HU/recordsets
```

#### GET /zones/{zoneIdOrName}/recordsets?name={name}&type={type}&qualifier={qualifier}
Returns a possibly empty array of your record sets.

Supported Query params:
  * name - optional - ex. `www.domain.com.`
  * type - optional unless you specify name - ex. `A`
  * qualifier - optional unless you specify type - ex. `US-West`

Ex. for route53, where the zone has an id

```bash
$ curl http://localhost:8080/zones/Z1V14BIB35Q8HU/recordsets
[
  {
    "name": "denominator.io.",
    "type": "NS",
    "ttl": 172800,
    "records": [
      {
        "nsdname": "ns-1707.awsdns-21.co.uk."
      },
      {
        "nsdname": "ns-1359.awsdns-41.org."
      },
      {
        "nsdname": "ns-981.awsdns-58.net."
      },
      {
        "nsdname": "ns-86.awsdns-10.com."
      }
    ]
  },
--snip--
```

Ex. refining results by name, type, and qualifier.

```bash
$ curl 'http://localhost:8080/zones/denominator.io./recordsets?name=www2.geo.denominator.io.&type=A&qualifier=alazona'
[
  {
    "name": "www2.geo.denominator.io.",
    "type": "A",
    "qualifier": "alazona",
    "ttl": 300,
    "records": [
      {
        "address": "192.0.2.1"
      }
    ],
    "geo": {
      "regions": {
        "United States (US)": [
          "Alaska",
          "Arizona"
        ]
      }
    }
  }
]
```

#### PUT /zones/{zoneIdOrName}/recordsets
Adds or replaces a record set and returns `204`.

Ex. to add or replace an MX record.
```bash
$ curl -X PUT http://localhost:8080/zones/Z3I0BTR7N27QRM/recordsets -d'{
  "name": "test.myzone.com.",
  "type": "TXT",
  "ttl": 1800,
  "records": [{
    "txtdata": "made in norway"
  }, {
    "txtdata": "made in sweden"
  }]
}'
```

#### DELETE /zones/{zoneIdOrName}/recordsets?name={name}&type={type}&qualifier={qualifier}
Deletes a record set if present and returns `204`.

Supported Query params:
  * name - required - ex. `www.domain.com.`
  * type - required - ex. `A`
  * qualifier - required if an advanced record set - ex. `US-West`

Ex. to delete a normal MX record

```bash
$ curl -X DELETE 'http://localhost:8080/zones/Z3I0BTR7N27QRM/recordsets?name=test.myzone.com.&type=TXT'
```