### PR TITLE
Adding Verisign MDNS provider to Denominator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,9 @@ buildscript {
 allprojects {
     repositories { mavenLocal()
                    mavenCentral()
-                   maven { url 'https://oss.sonatype.org/content/repositories/releases/' }}
+                   maven { url 'https://oss.sonatype.org/content/repositories/releases/' }
+    }
+	
 }
 
 apply from: file('gradle/convention.gradle')

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -23,6 +23,8 @@ dependencies {
   compile      project(':denominator-clouddns')
   compile      project(':denominator-designate')
   compile      project(':denominator-discoverydns')
+  compile      project(':denominator-verisignmdns')
+  
   testCompile 'org.testng:testng:6.8.5'
   testCompile 'com.google.mockwebserver:mockwebserver:20130706'
 }

--- a/cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
+++ b/cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
@@ -56,7 +56,7 @@ class ResourceRecordSetCommands {
             Iterator<ResourceRecordSet<?>> iterator;
             if (name != null && type != null)
                 iterator = mgr.api().recordSetsInZone(idOrName(mgr, zoneIdOrName)).iterateByNameAndType(name, type);
-            if (name != null)
+            else if (name != null)
                 iterator = mgr.api().basicRecordSetsInZone(idOrName(mgr, zoneIdOrName)).iterateByName(name);
             else
                 iterator = mgr.api().recordSetsInZone(idOrName(mgr, zoneIdOrName)).iterator();

--- a/cli/supportedProviders.txt
+++ b/cli/supportedProviders.txt
@@ -9,3 +9,4 @@ denominator.mock.MockProvider
 denominator.route53.Route53Provider
 denominator.ultradns.UltraDNSProvider
 denominator.discoverydns.DiscoveryDNSProvider
+denominator.verisignmdns.VrsnDNSProvider

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name='denominator'
 
-include 'model', 'core', 'route53', 'ultradns', 'dynect', 'clouddns', 'designate', 'discoverydns', 'cli'
+include 'model', 'core', 'route53', 'ultradns', 'dynect', 'clouddns', 'designate', 'discoverydns', 'verisignmdns', 'cli'
 
 rootProject.children.each { childProject ->
     childProject.name = 'denominator-' + childProject.name

--- a/verisignmdns/Denominator_MDNS_ Plugin.txt
+++ b/verisignmdns/Denominator_MDNS_ Plugin.txt
@@ -1,0 +1,129 @@
+
+ Denominator MDNS Plugin 
+
+Sample Configuration file 
+Following is the sample configuration file (denominator.yaml) snippet. 
+--- 
+name: testconf 
+provider: vrsnmndns 
+url: https://api.dns-tool.com/dnsa-ws/V2.0/dnsaapi 
+credentials: 
+username: ?<username>? 
+password: "<?password?>" 
+--- 
+
+Verisign MDNS CLI Examples
+Add, List and Delete records from zone requires to configure denominator.yaml file as per above format with valid credentials.
+
+Adding records to Zone: 
+A record add : 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -nds2 -tA -d44.44.44.44 
+
+AAAA record add : 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -nds3 -tAAAA -d2600:1800:0::1 
+CNAME add: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -ntest2 -tCNAME -dmyhost2 
+
+PTR add: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -npt2 -tPTR -dexample.com 
+
+MX add: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -nds2 -tMX -d"3 mx3" 
+
+DS add: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -nds2 -tDS -d"60485 5 2 (d4b7d520e7bb5f0f67674a0cceb1e3e0614b93c4f9e99b8383f6a1e4469da50a)" 
+
+SRV add: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -n_ldap._tcp2 -tSRV -d"10 20 5060 exmaple.com.example.com." 
+
+NAPTR add: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -nnaptr3 -tNAPTR -d "100 50 'a' 'z3950n2ln2c' '' cidserver.example.com." 
+
+TXT add: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com add -ntestTxT -tTXT -d "This is a test TXT record" 
+List records from Zone: 
+
+List RRs after all additions: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com list 
+
+List by name and type: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com list -nnaptr3 -tNAPTR 
+
+Removing records from Zone: 
+Now removing records from zone 'example.com' 
+
+Delete A record with name ds2: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -nds2 -tA 
+
+Delete AAAA record with name ds3: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -nds3 -tAAAA 
+
+Delete CNAME record with name test2: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -ntest2 -tCNAME 
+
+Delete PTR record with name pt2: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -npt2 -tPTR 
+
+Delete MX record with name MX: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -nds2 -tMX 
+
+Delete DS record with name ds2: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -nds2 -tDS 
+
+Delete SRV record with name _ldap._tcp2: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -n_ldap._tcp2 -tSRV 
+
+Delete NAPTR with name naptr3: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -nnaptr3 -tNAPTR 
+
+Delete TXT with name testTxT: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com delete -ntestTxT -tTXT 
+
+List RRs after all deletions: 
+java -jar denominator-cli-5.0.0-SNAPSHOT-fat.jar -p vrsnmndns -C ./denominator.yaml -ntestconf record -z example.com list 
+Verisign MDNS API 
+
+
+
+Zone list Java Examples 
+Following is the sample test client written in Java language to get Zone list. 
+
+
+package denominator.vrsn; 
+import static denominator.CredentialsConfiguration.credentials; 
+import denominator.DNSApiManager; 
+import denominator.Denominator; 
+import denominator.model.ResourceRecordSet; 
+import denominator.model.Zone; 
+public class TestZoneList { 
+public static void main(String[] args) { 
+    DNSApiManager manager = Denominator.create("vrsnmndns", 
+        credentials(?<UserName>?,?<Password>?)); 
+    for (Zone zone : manager.api().zones()) { 
+        for (ResourceRecordSet<?> rrs : manager.api().recordSetsInZone(zone.idOrName())) { 
+            System.out.println(rrs.name()); 
+        } 
+    } 
+    } 
+} 
+
+
+Zone Resource Records list Java Example Following is the sample test client written in Java language to get Zone Resource Records list. 
+
+package denominator.vrsn; 
+import static denominator.CredentialsConfiguration.credentials; 
+import denominator.DNSApiManager; 
+import denominator.Denominator; 
+import denominator.model.ResourceRecordSet; 
+import denominator.model.Zone; 
+public class TestZoneRRList { 
+    public static void main(String[] args) { 
+        DNSApiManager manager = Denominator.create("vrsnmndns", 
+                                credentials(?<UserName>?,?<Password>?)); 
+        for (Zone zone : manager.api().zones()) { 
+            for (ResourceRecordSet<?> rrs : manager.api().recordSetsInZone(zone.idOrName())) { 
+                System.out.println(rrs.toString()); 
+            } 
+        } 
+    } 
+}

--- a/verisignmdns/README.md
+++ b/verisignmdns/README.md
@@ -1,0 +1,12 @@
+Verisign MDNS plug-in for Denominator
+
+Document version 1.0
+
+This plug-in provides access to Verisign Managed DNS using Denominator.  
+The plug-in enables zone list and resource record set management through Denominator cli and through java API.
+
+This plugin currently supports 'put', 'iterator', 'iterate by name and type', 'get by name and type', and  'delete by name and type' operations for CNAME, A, AAAA, NS, NAPTR, PTR, MX, DS, SRV and TXT record types. 
+
+Please see accompanying document Veisign_MDNS_Plugin.txt containing sample cli commands and java API usage code.
+
+

--- a/verisignmdns/build.gradle
+++ b/verisignmdns/build.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'java'
+apply plugin: 'eclipse'
+apply from: rootProject.file('dagger.gradle')
+
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
+
+eclipse {
+  classpath {
+    downloadSources = true
+    downloadJavadoc = true
+  }
+}
+
+test {
+  useTestNG()
+  systemProperty 'vmdns.url', System.getProperty('vmdns.url', '')
+  systemProperty 'vmdns.username', System.getProperty('vmdns.username', '')
+  systemProperty 'vmdns.password', System.getProperty('vmdns.password', '')
+  systemProperty 'vmdns.zone', System.getProperty('vmdns.zone', '')
+}
+
+dependencies {
+  compile      project(':denominator-core')
+  compile     'com.netflix.feign:feign-core:6.1.2'
+  compile     'com.netflix.feign:feign-sax:6.1.2'
+  testCompile  project(':denominator-core').sourceSets.test.output
+  testCompile 'com.google.guava:guava:14.0.1'
+  testCompile 'org.testng:testng:6.8.5'
+  testCompile 'com.google.code.gson:gson:2.2.4'
+  testCompile 'com.google.mockwebserver:mockwebserver:20130706'
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnAllProfileResourceRecordSetApi.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnAllProfileResourceRecordSetApi.java
@@ -1,0 +1,145 @@
+package denominator.verisignmdns;
+
+import static denominator.common.Preconditions.checkArgument;
+import static denominator.common.Preconditions.checkNotNull;
+import static denominator.model.ResourceRecordSets.notNull;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+
+
+import denominator.AllProfileResourceRecordSetApi;
+import denominator.Credentials;
+import denominator.common.Filter;
+import denominator.model.ResourceRecordSet;
+import denominator.model.Zone;
+import denominator.verisignmdns.VrsnMdns.Record;
+
+public class VrsnAllProfileResourceRecordSetApi implements denominator.AllProfileResourceRecordSetApi {
+    private final String username;
+    private final String password;
+    private final String domainName;
+    private final VrsnMdns api;
+	
+
+    VrsnAllProfileResourceRecordSetApi(String aUsername, String aPassword,  String aDomainName,  VrsnMdns anApi) {
+        username = aUsername;
+        password = aPassword;
+        this.domainName = aDomainName;
+        this.api = anApi;
+    }
+
+    /**
+     * sorted to help tests from breaking
+     */
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterator() {
+
+        List<Record> recordList = api.getResourceRecordsList(username, password, domainName);
+       
+    	return VrsnContentConversionHelper.getSortedSetForDenominator(recordList).iterator();
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
+    	checkNotNull(name, "name was null");
+    	throw new VrsnMdnsException("Method Not Implemented" , -1);
+    }
+
+    protected void put(Filter<ResourceRecordSet<?>> valid, ResourceRecordSet<?> rrset) {
+ 
+    	checkNotNull(rrset, "rrset was null");
+        checkArgument(rrset.qualifier() != null, "no qualifier on: %s", rrset);
+        checkArgument(valid.apply(rrset), "%s failed on: %s", valid, rrset);
+        
+        
+        //@TODO IMPLEMENT -- in future development phase  /////////
+        throw new VrsnMdnsException("Method Not Implemented" , -1);
+        
+    }
+
+    @Override
+    public void put(ResourceRecordSet<?> rrset) {
+    	//@ Keeping MOCK code for now...
+    	//@TODO IMPLEMENT -- in future development phase  /////////
+    	put(notNull(), rrset);
+    	throw new VrsnMdnsException("Method Not Implemented" , -1);
+    }
+
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type) {
+ 
+
+    	checkNotNull(type, "type was null");
+    	checkNotNull(name, "name was null");
+
+    	List<Record> recordList = api.getResourceRecordsListForTypeAndName(username, password, domainName, type, name);
+    	Iterator<ResourceRecordSet<?>> result =  VrsnContentConversionHelper.getSortedSetForDenominator(recordList).iterator();
+    	return result;
+    }
+
+    /**
+     * NOTE- for MDNS get only required ResourceRecordId ie. qualifier.
+     *  Parameters name and type are ignored.
+     */
+    @Override
+    public ResourceRecordSet<?> getByNameTypeAndQualifier(String name, String type, String qualifier) {
+    	ResourceRecordSet<?> result = null;
+    	List<Record> recordList =  api.getResourceRecordByQualifier(username, password, qualifier);
+    	SortedSet<ResourceRecordSet<?>> rrSet =  VrsnContentConversionHelper.getSortedSetForDenominator(recordList);
+    	if (!rrSet.isEmpty()) {
+    		result = rrSet.first();
+    	}
+    	return result;
+    }
+
+    @Override
+    public void deleteByNameTypeAndQualifier(String name, String type, String qualifier) {
+    	//@ Keeping MOCK code for now...
+    	
+   	
+    	//@TODO IMPLEMENT -- in future development phase /////////
+    	throw new VrsnMdnsException("Method Not Implemented" , -1);
+    	
+    }
+
+    @Override
+    public void deleteByNameAndType(String name, String type) {
+    	throw new VrsnMdnsException("Method Not Implemented" , -1);
+    }
+
+    static class Factory implements denominator.AllProfileResourceRecordSetApi.Factory {
+        private  Map<Zone, SortedSet<ResourceRecordSet<?>>> records;
+        private  String domainName;
+        private  VrsnMdns api;
+        private static String username; 
+        private static String password; 
+          
+        // unbound wildcards are not currently injectable in dagger
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        @Inject
+        Factory(Provider<Credentials> credentials, denominator.Provider provider,  VrsnMdns api) {
+            
+      	
+        	this.records = Map.class.cast(records);
+        	Map <String, String> mapCreds = VrsnUtils.getMapOfCredentials(credentials);
+        	username = mapCreds.get(VrsnConstants.CREDENITAL_USERNAME_KEY);
+        	password = mapCreds.get(VrsnConstants.CREDENTIAL_PASSWORD_KEY);
+        	String url = provider.url();
+        	this.api = api;
+        }
+
+        @Override
+        public AllProfileResourceRecordSetApi create(String idOrName) {
+            Zone zone = Zone.create(idOrName);
+            
+            return new VrsnAllProfileResourceRecordSetApi(username, password, idOrName,  api);
+        }
+    }
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnConstants.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnConstants.java
@@ -1,0 +1,57 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnConstants {
+	public static final String SERVICE_QNAME_NAMESPACE = "urn:com:verisign:dnsa:api:wsdl:1";
+	public static final String SERVICE_QNAME_LOCAL = "DNSA";
+	
+	
+	// String constants 
+	public static final String STRING_EMPTY =  "";
+	public static final String STRING_SPACE =  " ";
+	public static final String STRING_DOUBLE_QUOTE =  "\"";
+	public static final String STRING_SINGLE_QUOTE =  "\'";
+	public static final String STRING_COMMA = ",";
+	
+	// RR Type String Names
+	public static final String RR_TYPE_A = "A";
+	public static final String RR_TYPE_AAAA = "AAAA";
+	public static final String RR_TYPE_NS = "NS";
+	public static final String RR_TYPE_CNAME = "CNAME";
+	public static final String RR_TYPE_PTR = "PTR";
+	public static final String RR_TYPE_SRV = "SRV";
+	public static final String RR_TYPE_NAPTR = "NAPTR";
+	public static final String RR_TYPE_TXT = "TXT";
+	public static final String RR_TYPE_MX = "MX";
+	public static final String RR_TYPE_DS = "DS";
+	
+	public static final String CREDENITAL_USERNAME_KEY = "username";
+	public static final String CREDENTIAL_PASSWORD_KEY = "password";
+	
+	
+	public static final String MDNS_ERROR_INVALID_INPUT = "ERROR_MISSING_INVALID_INPUT";
+	public static final String MDNS_ERROR_RULE_VALIDATION = "ERROR_RULE_VALIDATION";
+	public static final String MDNS_ERROR_OPERATION_FAILURE = "ERROR_OPERATION_FAILURE";
+	public static final String MDNS_ERROR_INTERNAL_ERROR = "ERROR_INTERNAL_ERROR";
+	
+	public static final Map <String, Integer> MDNS_ERROR_TO_INT_CODE_MAP 
+												= new HashMap<String, Integer>();
+	static {
+		MDNS_ERROR_TO_INT_CODE_MAP.put(MDNS_ERROR_INVALID_INPUT, new Integer(1));
+		MDNS_ERROR_TO_INT_CODE_MAP.put(MDNS_ERROR_RULE_VALIDATION, new Integer(2));
+		MDNS_ERROR_TO_INT_CODE_MAP.put(MDNS_ERROR_OPERATION_FAILURE, new Integer(3));
+		MDNS_ERROR_TO_INT_CODE_MAP.put(MDNS_ERROR_INTERNAL_ERROR, new Integer(4));
+	}
+	
+	
+	
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnContentConversionHelper.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnContentConversionHelper.java
@@ -1,0 +1,103 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+
+import static denominator.model.ResourceRecordSets.a;
+import static denominator.model.ResourceRecordSets.aaaa;
+import static denominator.model.ResourceRecordSets.cname;
+import static denominator.model.ResourceRecordSets.txt;
+import static denominator.model.ResourceRecordSets.mx;
+import static denominator.model.ResourceRecordSets.naptr;
+import static denominator.model.ResourceRecordSets.ptr;
+import static denominator.model.ResourceRecordSets.srv;
+import static denominator.model.ResourceRecordSets.ns;
+import static denominator.model.ResourceRecordSets.ds;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import denominator.model.ResourceRecordSet;
+import denominator.verisignmdns.VrsnMdns.Record;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnContentConversionHelper {
+	
+	/**
+	 * Convernts Resource Record returned by MDNS Api to Denominator ResourceRecordSet
+	 * @param aMDNSRecord
+	 * @return
+	 */
+	public static ResourceRecordSet<?> convertMDNSRecordToDenominator(Record aMDNSRecord) {
+  	  ResourceRecordSet<?> result = null;
+ 
+		if (aMDNSRecord != null && aMDNSRecord.type != null) {
+			if (VrsnConstants.RR_TYPE_A.equals(aMDNSRecord.type)) {
+				result = a(aMDNSRecord.name, aMDNSRecord.ttl, aMDNSRecord.rdata);
+
+			}
+			if (VrsnConstants.RR_TYPE_AAAA.equals(aMDNSRecord.type)) {
+				result = aaaa(aMDNSRecord.name, aMDNSRecord.ttl, aMDNSRecord.rdata);
+			}
+			
+			if (VrsnConstants.RR_TYPE_NS.equals(aMDNSRecord.type)) {
+				result = ns(aMDNSRecord.name, aMDNSRecord.ttl, aMDNSRecord.rdata);
+			}
+			
+			if (VrsnConstants.RR_TYPE_CNAME.equals(aMDNSRecord.type)) {
+				result = cname(aMDNSRecord.name, aMDNSRecord.ttl, aMDNSRecord.rdata);
+			}
+			if (VrsnConstants.RR_TYPE_TXT.equals(aMDNSRecord.type)) {
+				result = txt(aMDNSRecord.name, aMDNSRecord.ttl, aMDNSRecord.rdata);
+			}
+			if (VrsnConstants.RR_TYPE_MX.equals(aMDNSRecord.type)) {
+				result = mx(aMDNSRecord.name, aMDNSRecord.ttl,aMDNSRecord.rdata);
+				
+			}
+			if (VrsnConstants.RR_TYPE_PTR.equals(aMDNSRecord.type)) {
+				result = ptr(aMDNSRecord.name, aMDNSRecord.ttl, aMDNSRecord.rdata);
+
+			}
+			if (VrsnConstants.RR_TYPE_NAPTR.equals(aMDNSRecord.type)) {
+				
+				List<String> tempRdata = aMDNSRecord.rdata;
+				result = naptr(aMDNSRecord.name, aMDNSRecord.ttl,	tempRdata);
+			}
+			if (VrsnConstants.RR_TYPE_SRV.equals(aMDNSRecord.type)) {
+				result = srv(aMDNSRecord.name, aMDNSRecord.ttl,
+						aMDNSRecord.rdata);
+			}
+			
+			if (VrsnConstants.RR_TYPE_DS.equals(aMDNSRecord.type)) {
+				result = ds(aMDNSRecord.name, aMDNSRecord.ttl,
+						aMDNSRecord.rdata);
+			}
+		}
+  	  
+  	  return result;
+	}
+
+    public static SortedSet<ResourceRecordSet<?>> getSortedSetForDenominator(List<Record> aMDNSRecordList) {
+  	  Comparator<ResourceRecordSet<?>> toStringComparator = new Comparator<ResourceRecordSet<?>>() {
+            @Override
+            public int compare(ResourceRecordSet<?> arg0, ResourceRecordSet<?> arg1) {
+                return arg0.toString().compareTo(arg1.toString());
+            }
+        };
+        SortedSet<ResourceRecordSet<?>> result = new ConcurrentSkipListSet<ResourceRecordSet<?>>(toStringComparator);
+        if (aMDNSRecordList != null) {
+      	  for (Record rr : aMDNSRecordList) {
+      		  result.add(convertMDNSRecordToDenominator(rr));
+      	  }
+        }
+
+        return result;
+    }
+    
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnDNSProvider.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnDNSProvider.java
@@ -1,0 +1,159 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+
+import denominator.BasicProvider;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import dagger.Provides;
+import denominator.AllProfileResourceRecordSetApi;
+import denominator.CheckConnection;
+import denominator.DNSApiManager;
+import denominator.ResourceRecordSetApi;
+import denominator.ZoneApi;
+import denominator.config.GeoUnsupported;
+import denominator.config.NothingToClose;
+import denominator.config.WeightedUnsupported;
+
+
+import denominator.verisignmdns.VrsnMdnsContentHandler.RecordListHandler;
+import denominator.verisignmdns.VrsnMdnsContentHandler.ZoneListHandler;
+import denominator.verisignmdns.VrsnMdnsErrorDecoder.VrsnMdnsError;
+import feign.Feign;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+import feign.sax.SAXDecoder;
+
+
+/**
+ * This class is provider for Verisign MDNS.
+ * 
+ * @author smahurpawar
+ *
+ */
+public class VrsnDNSProvider extends BasicProvider {
+	private final String url;
+
+    public VrsnDNSProvider() {
+        this(null);
+    }
+
+    /**
+     * @param url
+     * if empty or null use default
+     */
+    public VrsnDNSProvider(String url) {
+    	this.url = url == null || url.isEmpty() ? "https://api.dns-tool.com/dnsa-ws/V2.0/dnsaapi" : url;
+    }
+
+    @Override
+    public String url() {
+        return url;
+    }
+
+    @Override
+    public Map<String, Collection<String>> credentialTypeToParameterNames() {
+        Map<String, Collection<String>> options = new LinkedHashMap<String, Collection<String>>();
+        options.put("password", Arrays.asList("username", "password"));
+        return options;
+    }
+
+    
+    /**
+     * Commented for now we are not concerned about profile records
+     * @author smahurpawar
+     *
+     */
+    @Override
+    public Map<String, Collection<String>> profileToRecordTypes() {
+        Map<String, Collection<String>> profileToRecordTypes = new LinkedHashMap<String, Collection<String>>();
+        return profileToRecordTypes;
+    }
+
+    // normally, we'd set package private visibility, but this module is helpful
+    // in tests, so we mark it public
+    @dagger.Module(injects = DNSApiManager.class, complete = false, // denominator.Provider
+    		includes = {NothingToClose.class,
+        				GeoUnsupported.class,
+        				WeightedUnsupported.class, FeignModule.class
+        				})
+    public static final class Module {
+
+        @Provides
+        CheckConnection alwaysOK() {
+            return new CheckConnection() {
+                public boolean ok() {
+                    return true;
+                }
+            };
+        }
+
+        @Provides
+        @Singleton
+        ZoneApi provideZoneApi(VrsnZoneApi in) {
+            return in;
+        }
+
+
+        @Provides
+        ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(VrsnResourceRecordSetApi.Factory in) {
+            return in;
+        }
+
+        @Provides
+        AllProfileResourceRecordSetApi.Factory provideAllProfileResourceRecordSetApiFactory(
+                VrsnAllProfileResourceRecordSetApi.Factory in) {
+            return in;
+        }
+    }
+    
+    @dagger.Module(//
+    injects = {VrsnResourceRecordSetApi.Factory.class},
+    complete = false, 
+    overrides = true,
+    includes = { Feign.Defaults.class, XMLCodec.class })
+    public static final class FeignModule {
+	
+        @Singleton
+        @Provides VrsnMdns vrsnMdns(Feign feign, VrsnMdnsTarget target) {
+            return feign.newInstance(target);
+        }
+    }
+   
+    @dagger.Module(//
+    	    injects = { Encoder.class, Decoder.class, ErrorDecoder.class },//
+    	    overrides = true, // ErrorDecoder
+    	    complete = false,
+    	    addsTo = Feign.Defaults.class//
+    	    )
+    	    static final class XMLCodec {
+
+    	        @Provides
+    	        Encoder formEncoder() {
+    	            return new VrsnMdnsFormEncoder();
+    	        }
+
+    	        @Provides
+    	        Decoder saxDecoder() {
+    	            return SAXDecoder.builder()//
+    	                    .registerContentHandler(ZoneListHandler.class)//
+    	                    .registerContentHandler(RecordListHandler.class)//
+    	                    .registerContentHandler(VrsnMdnsError.class)
+    	                    .build();
+    	        }
+
+    	        @Provides
+    	        ErrorDecoder errorDecoders(VrsnMdnsErrorDecoder errorDecoder) {
+    	            return errorDecoder;
+    	        }
+    	    }
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdns.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdns.java
@@ -1,0 +1,186 @@
+/**
+ *
+ */
+package denominator.verisignmdns;
+
+
+import java.util.List;
+import denominator.model.Zone;
+
+import javax.inject.Named;
+
+import feign.Body;
+import feign.RequestLine;
+
+/**
+ * This class provides interface for invoking request on Verisign MDNS provider
+ * @author smahurpawar
+ *
+ */
+public interface VrsnMdns {
+
+	/**
+	 * Get list of zone authorized for user
+	 * @param aUsername String
+	 * @param aPassword String
+	 * @return List<Zone>
+	 */
+    @RequestLine("POST")
+    @Body("<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'><S:Header><ns2:authInfo xmlns='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns2='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'><ns2:userToken><ns2:userName>{aUsername}</ns2:userName><ns2:password>{aPassword}</ns2:password></ns2:userToken></ns2:authInfo></S:Header><S:Body><ns3:getZoneList xmlns='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns2='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'><ns3:listPagingInfo><ns3:pageNumber>1</ns3:pageNumber><ns3:pageSize>50</ns3:pageSize></ns3:listPagingInfo></ns3:getZoneList></S:Body></S:Envelope>")
+    List<Zone> getZonesForUser(@Named("aUsername")String aUsername, @Named("aPassword")String  aPassword);
+    
+    /**
+     * Get list of resource records for the zone
+     *
+     * @param aUsername
+     * @param aPassword
+     * @param aZonename
+     * @return List<Record>
+     */
+    @RequestLine("POST")
+    @Body("<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+    		+ "<soap:Header>"
+    		+ "<urn1:authInfo>"
+    		+ "<urn1:userToken>"
+    		+ "<urn1:userName>{aUsername}</urn1:userName>"
+    		+ "<urn1:password>{aPassword}</urn1:password>"
+    		+ "</urn1:userToken>"
+    		+ "</urn1:authInfo>"
+    		+ "</soap:Header>"
+    		+ "<soap:Body>"
+    		+ "<urn2:getResourceRecordList>"
+    		+ "<urn2:domainName>{aZonename}</urn2:domainName>"
+    		+ "</urn2:getResourceRecordList>"
+    		+ "</soap:Body>"
+    		+ "</soap:Envelope>")
+    List<Record> getResourceRecordsList(@Named("aUsername")String aUsername, @Named("aPassword")String  aPassword, @Named("aZonename") String aZonename);
+
+    /**
+     * Get resource record list for given zone, type and name
+     * @param aUsername
+     * @param aPassword
+     * @param aZonename
+     * @param aType
+     * @param aName
+     * @return List<Record>
+     */
+    @RequestLine("POST")
+    @Body("<?xml version='1.0' encoding='UTF-8'?>"
+    		+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+    		+ "<S:Header>"
+    		+ "<ns2:authInfo xmlns='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns2='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'>"
+    		+ "<ns2:userToken>"
+    		+ "<ns2:userName>{aUsername}</ns2:userName>"
+    		+ "<ns2:password>{aPassword}</ns2:password>"
+    		+ "</ns2:userToken>"
+    		+ "</ns2:authInfo>"
+    		+ "</S:Header>"
+    		+ "<S:Body>"
+    		+ "<ns3:getResourceRecordList xmlns='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns2='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'>"
+    		+ "<ns3:domainName>{aZonename}</ns3:domainName>"
+    		+ "<ns3:resourceRecordType>{aType}</ns3:resourceRecordType>"
+    		+ "<ns3:owner>{aName}</ns3:owner>"
+    		+ "</ns3:getResourceRecordList>"
+    		+ "</S:Body>"
+    		+ "</S:Envelope>")
+    List<Record> getResourceRecordsListForTypeAndName(@Named("aUsername")String aUsername, @Named("aPassword")String  aPassword, @Named("aZonename") String aZonename, @Named("aType") String aType, @Named("aName") String aName);
+    
+    /**
+     * NOTE - We are using qualifier parameter as id of resource record in MDNS
+     * @param aUsername String
+     * @param aPassword String
+     * @param aQualifier String
+     * @return List<Record>
+     */
+    @RequestLine("POST")
+	@Body("<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<soap:Header>" 
+			+ "<urn1:authInfo>" 
+			+ "<urn1:userToken>"
+			+ "<urn1:userName>{aUsername}</urn1:userName>"
+			+ "<urn1:password>{aPassword}</urn1:password>" 
+			+ "</urn1:userToken>"
+			+ "</urn1:authInfo>" 
+			+ "</soap:Header>" 
+			+ "<soap:Body>"
+			+ "<urn2:getResourceRecord>"
+			+ "<urn2:resourceRecordId>{anId}</urn2:resourceRecordId>"
+			+ "</urn2:getResourceRecord>" 
+			+ "</soap:Body>" 
+			+ "</soap:Envelope>")
+    List<Record> getResourceRecordByQualifier(@Named("aUsername")String aUsername, @Named("aPassword")String  aPassword, @Named("anId") String aQualifier);
+    
+    /**
+     * Add a resource record in zone
+     * @param aUsername
+     * @param aPassword
+     * @param aZonename
+     * @param aType
+     * @param aName
+     * @param aTtl
+     * @param aRdata
+     */
+    @RequestLine("POST")
+    @Body("<?xml version='1.0' encoding='UTF-8'?>"
+    		+ "<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+    		+ "<soap:Header>"
+    		+ "<urn1:authInfo>"
+    		+ "<urn1:userToken>"
+    		+ "<urn1:userName>{aUsername}</urn1:userName>"
+    		+ "<urn1:password>{aPassword}</urn1:password>"
+    		+ "</urn1:userToken>"
+    		+ "</urn1:authInfo>"
+    		+ "</soap:Header>"
+    		+ "<soap:Body>"
+    		+ "<urn2:createResourceRecords>"
+    		+ "<urn2:domainName>{aZonename}</urn2:domainName>"
+    		+ "<urn2:resourceRecord allowanyIP='false'>"
+    		+ "<urn2:owner>{aName}</urn2:owner>"
+    		+ "<urn2:type>{aType}</urn2:type>"
+    		+ "<urn2:ttl>{aTtl}</urn2:ttl>"
+    		+ "<urn2:rData>{aRdata}</urn2:rData>"
+    		+ "</urn2:resourceRecord>"
+    		+ "</urn2:createResourceRecords>"
+    		+ "</soap:Body>"
+    		+ "</soap:Envelope>")
+    void createResourceRecord(@Named("aUsername")String aUsername, @Named("aPassword")String  aPassword
+    							 , @Named("aZonename") String aZonename, @Named("aType") String aType
+    							 ,@Named("aName") String aName, @Named("aTtl") String aTtl, @Named("aRdata") String aRdata); 
+
+    /**
+     * Delete resource record record from zone using record Id
+     * @param aUsername
+     * @param aPassword
+     * @param aZonename
+     * @param anId
+     */
+    @RequestLine("POST")
+    @Body("<?xml version='1.0' encoding='UTF-8'?>"  
+    + "<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+    + "<soap:Header>"
+    + "<urn1:authInfo>"
+    + "<urn1:userToken>"
+    + "<urn1:userName>{aUsername}</urn1:userName>"
+    + "<urn1:password>{aPassword}</urn1:password>"
+    + "</urn1:userToken>"
+    + "</urn1:authInfo>"
+    + "</soap:Header>"
+    + "<soap:Body>"
+    + "<urn2:deleteResourceRecords>"
+    + "<urn2:domainName>{aZonename}</urn2:domainName>"
+    + "<urn2:resourceRecordId>{anId}</urn2:resourceRecordId>"
+    + "</urn2:deleteResourceRecords>"
+    + "</soap:Body>"
+    + "</soap:Envelope>")
+    void deleteRecourceRecord(@Named("aUsername")String aUsername, @Named("aPassword")String  aPassword
+			 , @Named("aZonename") String aZonename, @Named("anId") String anId);
+    
+    static class Record {
+        String id;
+        String name;
+        String type;
+        int ttl;
+        List<String> rdata;
+    }
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsContentHandler.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsContentHandler.java
@@ -1,0 +1,190 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import denominator.model.Zone;
+import denominator.verisignmdns.VrsnMdns.Record;
+import feign.sax.SAXDecoder.ContentHandlerWithResult;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnMdnsContentHandler {
+	
+	//MSDN response elements for RR List, these are last elements of qname  (i.e. qname ends with ":xxxx")
+	public static final String ELEMENT_DOMAIN_NAME = ":domainName";
+	public static final String ELEMENT_RESOURCE_RECORD = ":resourceRecord";
+	public static final String ELEMENT_RESOURCE_ID = ":resourceRecordId"; 
+	public static final String ELEMENT_OWNER = ":owner";
+	public static final String ELEMENT_TYPE = ":type";
+	public static final String ELEMENT_TTL = ":ttl";
+	public static final String ELEMENT_RDATA = ":rData";
+	
+	
+    static class ZoneListHandler extends DefaultHandler implements ContentHandlerWithResult<List<Zone>> {
+        @Inject
+        ZoneListHandler() {
+        }
+
+        private final List<Zone> zones = new ArrayList<Zone>();
+
+        private boolean domainElementFound = false;  // flag for getting the value...
+
+        
+        @Override
+        public List<Zone> result() {
+            return zones;
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attrs) {
+
+        	if (qName != null && qName.endsWith(ELEMENT_DOMAIN_NAME)) {
+            	domainElementFound = true;
+            }
+        }
+        
+        @Override
+        public void characters (char ch[], int start, int length)
+                throws SAXException {
+        	if (domainElementFound) {
+        		zones.add(Zone.create(new String(ch, start, length )));
+        	}
+       }
+        
+        @Override
+        public void endElement (String uri, String localName, String qName)
+                throws SAXException {
+        	if (qName != null && qName.endsWith(ELEMENT_DOMAIN_NAME)) {
+            	domainElementFound = false;
+            }
+       }
+    }
+	
+    
+    static class RecordListHandler extends DefaultHandler implements ContentHandlerWithResult<List<Record>> {
+        private final List<Record> rrs = new ArrayList<Record>();
+       @Inject
+        RecordListHandler() {
+        }
+
+        private Record rr = new Record();
+        private boolean processingRR = false;  //flag indicating currently inside resource record element..
+        private String currentElementName = VrsnConstants.STRING_EMPTY;
+        private String rDataString = VrsnConstants.STRING_EMPTY;
+
+        @Override
+        public List<Record> result() {
+            return rrs;
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attrs) {
+
+        	if (qName.endsWith(ELEMENT_RESOURCE_RECORD)) {
+                rr = new Record();
+                processingRR = true;
+                currentElementName = ELEMENT_RESOURCE_RECORD;
+            }
+            if (processingRR && qName.endsWith(ELEMENT_RESOURCE_ID)) {
+            	currentElementName = ELEMENT_RESOURCE_ID;
+            }
+            if (processingRR && qName.endsWith(ELEMENT_OWNER)) {
+            	currentElementName = ELEMENT_OWNER;
+            }
+            if (processingRR && qName.endsWith(ELEMENT_TYPE)) {
+            	currentElementName = ELEMENT_TYPE;
+            }
+            if (processingRR && qName.endsWith(ELEMENT_TTL)) {
+            	currentElementName = ELEMENT_TTL;
+            }
+            if (processingRR && qName.endsWith(ELEMENT_RDATA)) {
+            	currentElementName = ELEMENT_RDATA;
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String name, String qName) {
+
+        	if (qName.endsWith(ELEMENT_RESOURCE_RECORD)) {
+                rrs.add(rr);
+                processingRR = false;
+            }
+        	
+        	if (qName.endsWith(ELEMENT_RDATA)) {
+        		 String[] tempArray = rDataString.split(",");
+        		 rr.rdata = getArrayList(tempArray);
+    			 rDataString = VrsnConstants.STRING_EMPTY;
+        	}
+            currentElementName = VrsnConstants.STRING_EMPTY;
+        }
+       
+       /**
+        *  This method is to ensure all space characters are accounted for 
+    	*    while processing rData
+    	*     
+        */
+       @Override
+       public void ignorableWhitespace(char[] ch, int start, int length)
+                  throws SAXException {
+        	if (currentElementName.equals(ELEMENT_RDATA)) {
+        		String tempStr = new String(ch, start, length);
+        		rDataString +=  tempStr;
+        	}
+        }
+        
+       
+        @Override
+        public void characters (char ch[], int start, int length)
+                throws SAXException {
+        	if (processingRR && length > 0) {
+        		if (currentElementName.equals(ELEMENT_RESOURCE_ID)) {
+        			rr.id = new String(ch, start, length);
+        		}
+        		if (currentElementName.equals(ELEMENT_OWNER)) {
+        			rr.name = new String(ch, start, length);
+        		}
+        		if (currentElementName.equals(ELEMENT_TYPE)) {
+        			rr.type = new String(ch, start, length);
+        		}
+        		
+        		if (currentElementName.equals(ELEMENT_TTL)) {
+        			try {
+        				String temp = new String(ch, start, length);
+        				rr.ttl = Integer.parseInt(temp);
+        			} catch(Exception ex) {
+        				//DO NOTHING..?
+        			}
+        		}
+        		if (currentElementName.equals(ELEMENT_RDATA)) {
+        			 String tempStr = new String(ch, start, length);
+        			 rDataString +=  tempStr;
+        		}
+        		
+        	}
+       }
+    }
+    
+    private static ArrayList<String> getArrayList(String[] anInput) {
+    	ArrayList<String> result  = new ArrayList<String>();
+    	if (anInput != null) {
+    		for (int i = 0; i < anInput.length; i++) {
+    			result.add(anInput[i]);
+    		}
+    	}
+        return result;
+    }
+    
+    
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsErrorDecoder.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsErrorDecoder.java
@@ -1,0 +1,107 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+import javax.inject.Inject;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
+import feign.sax.SAXDecoder.ContentHandlerWithResult;
+import static feign.Util.UTF_8;
+import static denominator.common.Util.slurp;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnMdnsErrorDecoder implements ErrorDecoder {
+	private static final String ERROR_RESPONSE_REASON_ELEMENT = ":reason";
+	private static final String ERROR_RESPONSE_ATTRIBUTE_CODE = "code";
+	private static final String ERROR_RESPONSE_ATTRIBUTE_DESCRIPTION = "description";
+	
+    private final Decoder decoder;
+
+    @Inject
+    VrsnMdnsErrorDecoder(Decoder decoder) {
+        this.decoder = decoder;
+    }
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        try {
+            // in case of error parsing, we can access the original contents.
+            response = bufferResponse(response);
+            VrsnMdnsError error = VrsnMdnsError.class.cast(decoder.decode(response, VrsnMdnsError.class));
+            if (error == null)
+                return FeignException.errorStatus(methodKey, response);
+            String message = format("%s failed", methodKey);
+            if (error.code != -1)
+                message = format("%s with error %s", message, error.code);
+            if (error.description != null)
+                message = format("%s: %s", message, error.description);
+           
+            return new VrsnMdnsException(message, error.code);
+        } catch (IOException ignored) {
+            return FeignException.errorStatus(methodKey, response);
+        } catch (Exception propagate) {
+            return propagate;
+        }
+    }
+
+    static class VrsnMdnsError extends DefaultHandler implements ContentHandlerWithResult<VrsnMdnsError> {
+        @Inject
+        VrsnMdnsError() {
+        }
+
+        private StringBuilder currentText = new StringBuilder();
+        private int code = -1;
+        private String description;
+
+        @Override
+        public VrsnMdnsError result() {
+            return (code == -1 && description == null) ? null : this;
+        }
+
+        @Override
+        public void startElement (String uri, String localName,
+                String qName, Attributes attributes) throws SAXException {
+        	if (qName.endsWith(ERROR_RESPONSE_REASON_ELEMENT)) {
+        		try {
+             	   Integer tempCode = 
+             			VrsnConstants.MDNS_ERROR_TO_INT_CODE_MAP.get(attributes.getValue(ERROR_RESPONSE_ATTRIBUTE_CODE));
+             	   code = tempCode.intValue();
+             	   
+                } catch (Exception ex) {
+             	   //ignore
+                }
+        		description = attributes.getValue(ERROR_RESPONSE_ATTRIBUTE_DESCRIPTION);
+        	}
+        	currentText = new StringBuilder();
+        }
+        
+
+        @Override
+        public void characters(char ch[], int start, int length) {
+            currentText.append(ch, start, length);
+        }
+    }
+
+    static Response bufferResponse(Response response) throws IOException {
+        if (response.body() == null)
+            return response;
+        String body = slurp(response.body().asReader());
+        return Response.create(response.status(), response.reason(), response.headers(), body, UTF_8);
+    }
+
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsException.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsException.java
@@ -1,0 +1,29 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import feign.FeignException;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnMdnsException extends FeignException {
+    private static final long serialVersionUID = 1L;
+	
+	private final int code;
+
+    VrsnMdnsException(String message, int code) {
+        super(message);
+        this.code = code;
+    }
+
+    /**
+     * The error code. ex {@code 1801}
+     */
+    public int code() {
+        return code;
+    }
+    
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsFormEncoder.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsFormEncoder.java
@@ -1,0 +1,26 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnMdnsFormEncoder implements Encoder {
+
+	/* (non-Javadoc)
+	 * @see feign.codec.Encoder#encode(java.lang.Object, feign.RequestTemplate)
+	 */
+	@Override
+	public void encode(Object aObject, RequestTemplate aTemplate)
+			throws EncodeException {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsRequestHelper.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsRequestHelper.java
@@ -1,0 +1,98 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import java.util.Map;
+
+import denominator.model.ResourceRecordSet;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnMdnsRequestHelper {
+	private static final String NAPTR_KEY_ORDER = "order";
+    private static final String NAPTR_KEY_PREFERNCE = "preference";
+    private static final String NAPTR_KEY_FLAGS = "flags";
+    private static final String NAPTR_KEY_SERVICE = "services";
+    private static final String NAPTR_KEY_REGEXP = "regexp";
+    private static final String NAPTR_KEY_REPLACEMENT = "replacement";
+			
+
+			
+	/**
+	 * This method parses ResourceRecordSet.record data to construct 
+	 * rData string
+	 * @param aRRSet ResourceRecordSet
+	 * @return String
+	 */
+	public static String getNAPTRData(ResourceRecordSet aRRSet) {
+		StringBuilder sb = new StringBuilder();
+		if (aRRSet != null) {
+			for (Object obj : aRRSet.records()) {
+    			Map<String, ?> attributeMap = (Map<String, String>) obj;
+				if (sb.length() > 0) {
+        			sb.append(VrsnConstants.STRING_COMMA);
+        		}
+    			sb.append(attributeMap.get(NAPTR_KEY_ORDER).toString()).append(VrsnConstants.STRING_SPACE);
+    			sb.append(attributeMap.get(NAPTR_KEY_PREFERNCE).toString()).append(VrsnConstants.STRING_SPACE);
+    			String tempStr = attributeMap.get(NAPTR_KEY_FLAGS).toString();
+    			sb.append(encloseInDoubleQuotes(tempStr)).append(VrsnConstants.STRING_SPACE);
+    			tempStr = attributeMap.get(NAPTR_KEY_SERVICE).toString();
+    			sb.append(encloseInDoubleQuotes(tempStr)).append(VrsnConstants.STRING_SPACE);
+    			tempStr = attributeMap.get(NAPTR_KEY_REGEXP).toString();
+    			sb.append(encloseInDoubleQuotes(tempStr)).append(VrsnConstants.STRING_SPACE);
+    			sb.append(attributeMap.get(NAPTR_KEY_REPLACEMENT).toString());
+			}	
+		}
+		return sb.toString();
+	}
+	
+	/**
+	 * Some of rData attribute required by MDNS to be enclosed in Double Quotes
+	 * This method wraps string in double quotes, also removes wrapping single quote if present
+	 * before applying double quotes.
+	 * (single quote might be present in case of denominator-cli request)
+	 * @param anInput String
+	 * @return String
+	 */
+	private static String encloseInDoubleQuotes(String anInput) {
+		StringBuilder sb = new StringBuilder();
+		if (anInput != null) {
+			String trimmed = anInput.trim();
+			trimmed = takeOutOfSingleQuote(trimmed);
+			if (trimmed.isEmpty()) {
+				sb.append(VrsnConstants.STRING_DOUBLE_QUOTE).append(VrsnConstants.STRING_DOUBLE_QUOTE);
+				return sb.toString();
+			} else if (!trimmed.startsWith(VrsnConstants.STRING_DOUBLE_QUOTE)){
+				sb.append(VrsnConstants.STRING_DOUBLE_QUOTE);
+				sb.append(trimmed);
+				sb.append(VrsnConstants.STRING_DOUBLE_QUOTE);
+				return sb.toString();
+			}
+		}
+		return anInput;
+	}
+	
+	/**
+	 * if string is begins and ends with single quote character
+	 * these quotes will be removed in returned string.
+	 * @param anInput
+	 * @return String
+	 */
+	private static String takeOutOfSingleQuote(String anInput) {
+		StringBuilder sb = new StringBuilder();
+		if (anInput != null) {
+			String trimmed = anInput.trim();
+			if(trimmed.startsWith(VrsnConstants.STRING_SINGLE_QUOTE)
+					&& trimmed.endsWith(VrsnConstants.STRING_SINGLE_QUOTE)) {
+			sb.append(trimmed.substring(1, trimmed.lastIndexOf(VrsnConstants.STRING_SINGLE_QUOTE)));
+		    } else {
+		    	sb.append(anInput);
+		    }
+			return sb.toString();	
+		}
+		return anInput;
+	}
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsTarget.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnMdnsTarget.java
@@ -1,0 +1,61 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import javax.inject.Inject;
+
+import denominator.Credentials;
+import denominator.Provider;
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Target;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnMdnsTarget implements Target<VrsnMdns> {
+
+	private final Provider provider;
+    private final javax.inject.Provider<Credentials> credentials;
+
+    @Inject VrsnMdnsTarget(Provider provider, javax.inject.Provider<Credentials> credentials) {
+    	this.provider = provider;
+        this.credentials = credentials;
+    }
+	/* (non-Javadoc)
+	 * @see feign.Target#type()
+	 */
+	@Override
+	public Class<VrsnMdns> type() {
+		return VrsnMdns.class;
+	}
+
+	/* (non-Javadoc)
+	 * @see feign.Target#name()
+	 */
+	@Override
+	public String name() {
+		return provider.name();
+	}
+
+	/* (non-Javadoc)
+	 * @see feign.Target#url()
+	 */
+	@Override
+	public String url() {
+		return provider.url();
+	}
+
+	/* (non-Javadoc)
+	 * @see feign.Target#apply(feign.RequestTemplate)
+	 */
+	@Override
+	public Request apply(RequestTemplate anInput) {
+		anInput.insert(0, url());
+		anInput.header("Content-Type", "application/soap+xml");
+		return anInput.request();
+	}
+
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnResourceRecordSetApi.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnResourceRecordSetApi.java
@@ -1,0 +1,181 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+
+import static denominator.common.Preconditions.checkNotNull;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+
+
+
+
+import denominator.Credentials;
+import denominator.ResourceRecordSetApi;
+import denominator.common.Util;
+import denominator.model.ResourceRecordSet;
+import denominator.model.Zone;
+import denominator.verisignmdns.VrsnMdns.Record;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public final class VrsnResourceRecordSetApi implements ResourceRecordSetApi {
+    private final String username;
+    private final String password;
+    private final String domainName;
+    private final VrsnMdns api;
+	
+
+    VrsnResourceRecordSetApi(String aUsername, String aPassword,  String aDomainName,  VrsnMdns anApi) {
+        username = aUsername;
+        password = aPassword;
+        this.domainName = aDomainName;
+        this.api = anApi;
+    }
+
+    /**
+     * sorted to help tests from breaking
+     */
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterator() {  
+
+    	List<Record> recordList = api.getResourceRecordsList(username, password, domainName);
+    	return VrsnContentConversionHelper.getSortedSetForDenominator(recordList).iterator();
+    }
+
+
+    public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type) {
+    	checkNotNull(type, "type was null");
+    	checkNotNull(name, "name was null");
+
+     	List<Record> recordList = api.getResourceRecordsListForTypeAndName(username, password, domainName, type, name);
+    	Iterator<ResourceRecordSet<?>> result =  VrsnContentConversionHelper.getSortedSetForDenominator(recordList).iterator();
+    	return result;
+    }
+    
+    @Override
+    public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
+    	try {
+    	   throw new VrsnMdnsException("Method Not Implemented" , -1);
+
+    	} catch (Exception ex) {
+    		ex.printStackTrace();
+    		throw new RuntimeException(ex);
+    	}
+    }
+
+    @Override
+    public ResourceRecordSet<?> getByNameAndType(String name, String type) {
+
+    	checkNotNull(type, "type was null");
+    	checkNotNull(name, "name was null");
+
+    	ResourceRecordSet<?> result = null;
+    	List<Record> recordList = api.getResourceRecordsListForTypeAndName(username, password, domainName, type, name);
+    	SortedSet<ResourceRecordSet<?>> tempSet = VrsnContentConversionHelper.getSortedSetForDenominator(recordList);
+    	if (tempSet != null && tempSet.size() > 0) {
+    		result = tempSet.first();
+    	}
+    	return result;
+    }
+
+    @Override
+    public void put(ResourceRecordSet<?> rrset) {
+
+        checkNotNull(rrset, "Resource Record was null");
+        checkNotNull(rrset.name(), "Resource Record Name was null");
+        checkNotNull(rrset.type(), "Resource Record Type was null");
+        
+        // At this point disable delete
+        // as we might delete multiple records for name and type.
+        // Need to decide if that is correct
+        //ResourceRecordSet<?> rrsMatch = getByNameAndType(rrset.name(), rrset.type());
+        //if (rrsMatch != null) {
+        //   deleteByNameAndType(rrset.name(), rrset.type());
+        //}
+        	int ttlInt = 86000;
+        	Integer ttlRRSet = rrset.ttl();
+        	if (ttlRRSet != null) {
+        		ttlInt = ttlRRSet.intValue();
+        	}
+        	String rData = getRDataStringFromRRSet(rrset);
+        	api.createResourceRecord(username, password, domainName, rrset.type(), rrset.name(), "" + ttlInt, rData);
+
+    }
+
+    @Override
+    public void deleteByNameAndType(String name, String type) {
+
+    	List<Record> recordList = api.getResourceRecordsListForTypeAndName(username, password, domainName, type, name);
+        if (recordList != null && !recordList.isEmpty()) {
+        	//delete all records in recordList
+        	for(Record record : recordList) {
+        		api.deleteRecourceRecord(username, password, domainName, record.id);
+        	}
+        	
+        } else {
+        		throw new RuntimeException("deleteByNameAndType() failled to delete record for domain :"
+    					+ domainName + " type :" + type + " No Record Found");
+         }
+    }
+
+    public static final class Factory implements denominator.ResourceRecordSetApi.Factory {
+    	    	
+        private  Map<Zone, SortedSet<ResourceRecordSet<?>>> records;
+        private  String domainName;
+        private  VrsnMdns api;
+        private static String username; 
+        private static String password; 
+          
+        // unbound wildcards are not currently injectable in dagger
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        @Inject
+        Factory(Provider<Credentials> credentials, denominator.Provider provider,  VrsnMdns api) {
+            
+        	this.records = Map.class.cast(records);
+        	Map <String, String> mapCreds = VrsnUtils.getMapOfCredentials(credentials);
+        	username = mapCreds.get(VrsnConstants.CREDENITAL_USERNAME_KEY);
+        	password = mapCreds.get(VrsnConstants.CREDENTIAL_PASSWORD_KEY);
+        	String url = provider.url();
+        	this.api = api;
+        }
+
+        @Override
+        public ResourceRecordSetApi create(String idOrName) {
+            Zone zone = Zone.create(idOrName);
+            
+            return new VrsnResourceRecordSetApi(username, password, idOrName,  api);
+        }
+    }
+
+    private String getRDataStringFromRRSet(ResourceRecordSet aRRSet) {
+    	StringBuilder sb = new StringBuilder();
+    	if (aRRSet != null && aRRSet.records() != null) {
+    		if (aRRSet.type().equals(VrsnConstants.RR_TYPE_NAPTR)) {
+    			sb.append(VrsnMdnsRequestHelper.getNAPTRData(aRRSet));
+    		} else {
+    		for (Object obj : aRRSet.records()) {
+    			if (sb.length() > 0) {
+        			sb.append(VrsnConstants.STRING_COMMA);
+        		}
+    			if (obj instanceof Map) {
+    				sb.append(Util.flatten((Map<String, Object>)obj));
+    			} else {
+    				sb.append(obj.toString());
+    			}
+    		}
+    		}
+    	} 
+    	return sb.toString();
+    }
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnUtils.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnUtils.java
@@ -1,0 +1,41 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Provider;
+import denominator.Credentials;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnUtils {
+
+	 /**
+	  * Converts Provider<Credentials> object into Map<String,String> ie credential name, credential value.
+	  * @param aCredentials Provider<Credentials>
+	  * @return Map<String, String>
+	  */
+	 public static Map<String, String> getMapOfCredentials(Provider<Credentials> aCredentials) {
+		 Map<String, String> result = new HashMap<String, String>();
+		 if (aCredentials != null) {
+			 Credentials currentCreds = aCredentials.get();
+			 if (currentCreds instanceof List && ((List) currentCreds).size() >= 2) {
+				 List tempCredList = List.class.cast(currentCreds);
+				 result.put(VrsnConstants.CREDENITAL_USERNAME_KEY, (String)tempCredList.get(0));
+				 result.put(VrsnConstants.CREDENTIAL_PASSWORD_KEY, (String)tempCredList.get(1));
+			 } else if (currentCreds instanceof Map) {
+				 // it must be map
+				result = Map.class.cast(currentCreds);
+			 }
+		 }
+		 return result;
+	 }
+	
+    
+}

--- a/verisignmdns/src/main/java/denominator/verisignmdns/VrsnZoneApi.java
+++ b/verisignmdns/src/main/java/denominator/verisignmdns/VrsnZoneApi.java
@@ -1,0 +1,41 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import denominator.Credentials;
+import denominator.model.Zone;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public final class VrsnZoneApi implements denominator.ZoneApi {
+	 private final VrsnMdns api;
+	 private final String username;
+	 private final String password;
+
+
+    
+	 @Inject VrsnZoneApi(VrsnMdns anApi, Provider<Credentials> aCredentials) {
+    	Map <String, String> mapCreds = VrsnUtils.getMapOfCredentials(aCredentials);
+    	username = mapCreds.get(VrsnConstants.CREDENITAL_USERNAME_KEY);
+    	password = mapCreds.get(VrsnConstants.CREDENTIAL_PASSWORD_KEY);
+    	api = anApi;
+    }
+
+	/* (non-Javadoc)
+	 * @see denominator.ZoneApi#iterator()
+	 */
+	@Override
+	public Iterator<Zone> iterator() {
+		return api.getZonesForUser(username, password).iterator();
+	}
+	
+}

--- a/verisignmdns/src/main/resources/META-INF/services/denominator.Provider
+++ b/verisignmdns/src/main/resources/META-INF/services/denominator.Provider
@@ -1,0 +1,1 @@
+denominator.verisignmdns.VrsnDNSProvider

--- a/verisignmdns/src/main/resources/denominator.yaml
+++ b/verisignmdns/src/main/resources/denominator.yaml
@@ -1,0 +1,21 @@
+name: blah1
+provider: route53
+credentials:
+  accessKey: foo1
+  secretKey: foo2
+---
+name: blah2
+provider: mock
+url: mem:mock2
+credentials:
+  accessKey: foo3
+  secretKey: foo4
+  sessionToken: foo5
+---
+name: testconf
+provider: vrsndns
+url: https://api.dns-tool.com/dnsa-ws/V2.0/dnsaapi
+credentials:
+  username: please_put_your_username
+  password: please_put_your_password
+  sessionToken: :XXXX

--- a/verisignmdns/src/test/java/denominator/verisignmdns/TestZoneList.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/TestZoneList.java
@@ -1,0 +1,22 @@
+package denominator.verisignmdns;
+
+import static denominator.CredentialsConfiguration.credentials;
+import denominator.DNSApiManager;
+import denominator.Denominator;
+import denominator.model.ResourceRecordSet;
+import denominator.model.Zone;
+
+public class TestZoneList {
+
+	public static void main(String[] args) {
+		DNSApiManager manager = Denominator.create("vrsndns",
+				credentials("username", "password"));
+
+		for (Zone zone : manager.api().zones()) {
+			  for (ResourceRecordSet<?> rrs : manager.api().recordSetsInZone(zone.idOrName())) {
+			    System.out.println(rrs.name());
+			  }
+			}
+	}
+
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/TestZoneRRDetails.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/TestZoneRRDetails.java
@@ -1,0 +1,22 @@
+package denominator.verisignmdns;
+
+import static denominator.CredentialsConfiguration.credentials; 
+import denominator.DNSApiManager;
+import denominator.Denominator;
+import denominator.model.ResourceRecordSet;
+import denominator.model.Zone;
+
+public class TestZoneRRDetails {
+
+	public static void main(String[] args) {
+		DNSApiManager manager = Denominator.create("vrsndns",
+				credentials("userName", "password"));
+
+		for (Zone zone : manager.api().zones()) {
+			  for (ResourceRecordSet<?> rrs : manager.api().recordSetsInZone(zone.idOrName())) {
+			    System.out.println(rrs.toString());
+			  }
+			}
+	}
+
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnAllProfileResourceRecordSetApiTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnAllProfileResourceRecordSetApiTest.java
@@ -1,0 +1,122 @@
+package denominator.verisignmdns;
+
+import static denominator.verisignmdns.VrsnMDNSTest.RESOURCE_RECORD_ID;
+import static denominator.verisignmdns.VrsnMDNSTest.TEST_PASSWORD;
+import static denominator.verisignmdns.VrsnMDNSTest.TEST_USER_NAME;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_OWNER1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_RDATA1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_RR_TYPE1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_TTL1;
+import static denominator.verisignmdns.VrsnMDNSTest.mockAllProfileResourceRecordSetApi;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListCNAMETypesResponse;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListCNAMETypesTemplete;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListValildResponse;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.testng.annotations.Test;
+
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+
+import denominator.model.ResourceRecordSet;
+import denominator.model.rdata.CNAMEData;
+import denominator.verisignmdns.VrsnAllProfileResourceRecordSetApi;
+
+public class VrsnAllProfileResourceRecordSetApiTest {
+
+	@Test
+	public void getByNameTypeAndQualifier() throws IOException,
+			InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListCNAMETypesResponse));
+		server.play();
+
+		try {
+			VrsnAllProfileResourceRecordSetApi vrsnAllProfileResourceRecordSetApi = mockAllProfileResourceRecordSetApi(server
+					.getPort());
+
+			ResourceRecordSet<?> actualResult = vrsnAllProfileResourceRecordSetApi
+					.getByNameTypeAndQualifier(TEST_USER_NAME, VALID_RR_TYPE1,
+							RESOURCE_RECORD_ID);
+			assertNotNull(actualResult);
+
+			String expectedRequest = format(rrListCNAMETypesTemplete,
+					TEST_USER_NAME, TEST_PASSWORD, RESOURCE_RECORD_ID);
+
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	@Test
+	public void iterateByNameAndType() throws IOException, InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListValildResponse));
+		server.play();
+
+		try {
+			VrsnAllProfileResourceRecordSetApi vrsnAllProfileResourceRecordSetApi = mockAllProfileResourceRecordSetApi(server
+					.getPort());
+
+			Iterator<ResourceRecordSet<?>> actulResult = vrsnAllProfileResourceRecordSetApi
+					.iterateByNameAndType(VALID_OWNER1, VALID_RR_TYPE1);
+			assertNotNull(actulResult);
+
+			ResourceRecordSet<?> rrSet = actulResult.next();
+			assertNotNull(rrSet);
+			assertEquals(rrSet.ttl(), new Integer(Integer.parseInt(VALID_TTL1)));
+			assertEquals(rrSet.type(), VALID_RR_TYPE1);
+			assertEquals(rrSet.name(), VALID_OWNER1);
+			Object entry = rrSet.records().get(0);
+
+			assertTrue(entry instanceof CNAMEData);
+			CNAMEData cnameData = (CNAMEData) entry;
+			assertEquals(cnameData.values().iterator().next(), VALID_RDATA1);
+
+			// verify we have 2 records as expected.
+			assertTrue(actulResult.hasNext());
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	@Test
+	public void iterator() throws IOException, InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListValildResponse));
+		server.play();
+
+		try {
+			VrsnAllProfileResourceRecordSetApi vrsnAllProfileResourceRecordSetApi = mockAllProfileResourceRecordSetApi(server
+					.getPort());
+
+			Iterator<ResourceRecordSet<?>> actulResult = vrsnAllProfileResourceRecordSetApi
+					.iterator();
+			assertNotNull(actulResult);
+
+			ResourceRecordSet<?> rrSet = actulResult.next();
+			assertNotNull(rrSet);
+			assertEquals(rrSet.ttl(), new Integer(Integer.parseInt(VALID_TTL1)));
+			assertEquals(rrSet.type(), VALID_RR_TYPE1);
+			assertEquals(rrSet.name(), VALID_OWNER1);
+			Object entry = rrSet.records().get(0);
+
+			assertTrue(entry instanceof CNAMEData);
+			CNAMEData cnameData = (CNAMEData) entry;
+			assertEquals(cnameData.values().iterator().next(), VALID_RDATA1);
+
+			// verify we have 2 records as expected.
+			assertTrue(actulResult.hasNext());
+		} finally {
+			server.shutdown();
+		}
+	}
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnContentConversionHelperTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnContentConversionHelperTest.java
@@ -1,0 +1,53 @@
+package denominator.verisignmdns;
+
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_OWNER1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_RR_TYPE3;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_TTL1;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+
+import org.testng.annotations.Test;
+
+import denominator.model.ResourceRecordSet;
+import denominator.model.rdata.NAPTRData;
+import denominator.verisignmdns.VrsnContentConversionHelper;
+import denominator.verisignmdns.VrsnMdns.Record;
+
+/**
+ * @author sgavhane
+ *
+ */
+public class VrsnContentConversionHelperTest {
+
+	@Test
+	public void convertMDNSRecordToDenominator() throws IOException {
+		Record aMDNSRecord = VrsnMDNSTest.mockRecord();
+		ResourceRecordSet<?> rrSet = VrsnContentConversionHelper
+				.convertMDNSRecordToDenominator(aMDNSRecord);
+
+		assertNotNull(rrSet);
+		assertEquals(rrSet.ttl(), new Integer(Integer.parseInt(VALID_TTL1)));
+		assertEquals(rrSet.type(), VALID_RR_TYPE3);
+		assertEquals(rrSet.name(), VALID_OWNER1);
+		Object entry = rrSet.records().get(0);
+		assertTrue(entry instanceof NAPTRData);
+	}
+
+	@Test
+	public void getSortedSetForDenominator() {
+		List<Record> aMDNSRecordList = new ArrayList<Record>();
+		aMDNSRecordList.add(VrsnMDNSTest.mockRecord());
+
+		SortedSet<ResourceRecordSet<?>> actualResult = VrsnContentConversionHelper
+				.getSortedSetForDenominator(aMDNSRecordList);
+
+		assertNotNull(actualResult);
+		assertEquals(actualResult, actualResult);
+	}
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnDNSProviderTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnDNSProviderTest.java
@@ -1,0 +1,56 @@
+package denominator.verisignmdns;
+
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_URL;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import denominator.verisignmdns.VrsnDNSProvider;
+
+/**
+ * @author sgavhane
+ *
+ */
+public class VrsnDNSProviderTest {
+
+	@Test
+	public void credentialTypeToParameterNames() {
+		VrsnDNSProvider vrsnDNSProvider = new VrsnDNSProvider();
+		Map<String, Collection<String>> actualResult = vrsnDNSProvider
+				.credentialTypeToParameterNames();
+		assertNotNull(actualResult);
+
+		Map<String, Collection<String>> expectedResult = VrsnMDNSTest
+				.MockcredentialTypeToParameterNamesResponse();
+		assertNotNull(expectedResult);
+		assertEquals(actualResult.containsKey("password"),
+				expectedResult.containsKey("password"));
+	}
+
+	@Test
+	public void profileToRecordTypes() {
+		VrsnDNSProvider vrsnDNSProvider = new VrsnDNSProvider();
+		Map<String, Collection<String>> actualResult = vrsnDNSProvider
+				.profileToRecordTypes();
+		assertNotNull(actualResult);
+
+		Map<String, Collection<String>> expectedResult = VrsnMDNSTest
+				.mockProfileToRecordTypesResponse();
+		assertNotNull(actualResult);
+
+		assertEquals(actualResult, expectedResult);
+	}
+
+	@Test
+	public void url() {
+		VrsnDNSProvider vrsnDNSProvider = new VrsnDNSProvider();
+		String actualResult = vrsnDNSProvider.url();
+		assertNotNull(actualResult);
+
+		assertEquals(actualResult, VALID_URL);
+	}
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnMDNSTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnMDNSTest.java
@@ -1,0 +1,465 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import static denominator.CredentialsConfiguration.credentials;
+import static feign.Util.UTF_8;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import dagger.ObjectGraph;
+import denominator.Credentials;
+import denominator.Credentials.ListCredentials;
+import denominator.Denominator;
+import denominator.ResourceRecordSetApi;
+import denominator.ZoneApi;
+import denominator.verisignmdns.VrsnAllProfileResourceRecordSetApi;
+import denominator.verisignmdns.VrsnDNSProvider;
+import denominator.verisignmdns.VrsnDNSProvider.XMLCodec;
+import denominator.verisignmdns.VrsnMdns.Record;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+/**
+ * This class defines data required for tests
+ * 
+ * @author smahurpawar
+ *
+ */
+public class VrsnMDNSTest {
+	public static final String VALID_TTL1 = "86000";
+	public static final String VALID_RR_TYPE2 = "TXT";
+	public static final String VALID_RR_TYPE1 = "CNAME";
+	public static final String TEST_USER_NAME = "testUser";
+	public static final String TEST_PASSWORD = "testPass";
+	public static final String VALID_RR_TYPE3 = "NAPTR";
+	public static final String METHODKEY = "testMethodKey";
+	public static final String VALID_RDATA1 = "dummy_rdata1";
+	public static final String VALID_RDATA2 = "dummy_rdata2";
+	public static final String RESOURCE_RECORD_ID = "19049261";
+	public static final String VALID_QUALIFIER = "testqualifier";
+	public static final String VALID_ZONE_NAME1 = "dummyDomain1.com";
+	public static final String VALID_ZONE_NAME2 = "dummyDomain2.co.cc";
+	public static final String VALID_OWNER1 = "test1." + VALID_ZONE_NAME1;
+	public static final String VALID_OWNER2 = "test2." + VALID_ZONE_NAME2;
+	public static final String VALID_URL = "https://api.dns-tool.com/dnsa-ws/V2.0/dnsaapi";
+	public static final String VALID_RData_NAPTR = "100 50 \"a\" \"z3950+n2l+n2c\" \"\" cidserver.example.com.";
+ 
+	public static final String  createRequestARecordTemplete = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+		    + "<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+			+"<soap:Header>"
+			+"<urn1:authInfo>"
+			+"<urn1:userToken>"
+			+"<urn1:userName>"+TEST_USER_NAME+"</urn1:userName>"
+			+"<urn1:password>"+TEST_PASSWORD+"</urn1:password>"
+			+"</urn1:userToken>"
+			+"</urn1:authInfo>"
+			+"</soap:Header>"
+			+"<soap:Body>"
+			+"<urn2:createResourceRecords>"
+			+"<urn2:domainName>"+VALID_ZONE_NAME1+"</urn2:domainName>"
+			+"<urn2:resourceRecord allowanyIP='false'>"
+			+"<urn2:owner>"+VALID_OWNER1+"</urn2:owner>"
+			+"<urn2:type>"+VALID_RR_TYPE1+"</urn2:type>"
+			+"<urn2:ttl>"+VALID_TTL1+"</urn2:ttl>"
+			+"<urn2:rData>"+VALID_RDATA1+"</urn2:rData>"
+			+"</urn2:resourceRecord>"
+			+"</urn2:createResourceRecords>"
+			+"</soap:Body>"
+			+"</soap:Envelope>";
+	
+	public static final String createRequestARecordResponse = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+			+"<S:Envelope xmlns:S=\"http://www.w3.org/2003/05/soap-envelope\">"
+			+"<S:Body>"
+			+"<ns2:dnsaWSRes xmlns=\"urn:com:verisign:dnsa:api:schema:2\" xmlns:ns2=\"urn:com:verisign:dnsa:api:schema:1\" xmlns:ns3=\"urn:com:verisign:dnsa:auth:schema:1\" xmlns:ns4=\"urn:com:verisign:dnsa:messaging:schema:1\">"
+			+"<ns2:callSuccess>true</ns2:callSuccess>"
+			+"</ns2:dnsaWSRes>"
+			+"</S:Body>"
+			+"</S:Envelope>";
+	
+	public static final String rrDeleteTemplete = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+		    + "<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<soap:Header>"
+			+ "<urn1:authInfo>"
+			+ "<urn1:userToken>"
+			+ "<urn1:userName>"+ TEST_USER_NAME+ "</urn1:userName>"
+			+ "<urn1:password>"+ TEST_PASSWORD+ "</urn1:password>"
+			+ "</urn1:userToken>"
+			+ "</urn1:authInfo>"
+			+ "</soap:Header>"
+			+ "<soap:Body>"
+			+ "<urn2:deleteResourceRecords>"
+			+ "<urn2:domainName>"+ VALID_ZONE_NAME1+ "</urn2:domainName>"
+			+ "<urn2:resourceRecordId>"+ RESOURCE_RECORD_ID	+ "</urn2:resourceRecordId>"
+			+ "</urn2:deleteResourceRecords>"
+			+ "</soap:Body>" + "</soap:Envelope>";
+
+	public static final String rrDeleteResponse = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Body>"
+			+ "<ns2:dnsaWSRes xmlns='urn:com:verisign:dnsa:api:schema:2' xmlns:ns2='urn:com:verisign:dnsa:api:schema:1' xmlns:ns3='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns4='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:callSuccess>true</ns2:callSuccess>"
+			+ "</ns2:dnsaWSRes>"
+			+ "</S:Body>"
+			+ "</S:Envelope>";
+
+	public static final String rrListCNAMETypesResponse = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+			+ "<S:Envelope xmlns:S=\"http://www.w3.org/2003/05/soap-envelope\">"
+			+ "<S:Body>"
+			+ "<ns2:getResourceRecordListRes "
+			+ "xmlns=\"urn:com:verisign:dnsa:api:schema:2\" "
+			+ "xmlns:ns2=\"urn:com:verisign:dnsa:api:schema:1\" "
+			+ "xmlns:ns3=\"urn:com:verisign:dnsa:auth:schema:1\" xmlns:ns4=\"urn:com:verisign:dnsa:messaging:schema:1\">"
+			+ "<ns2:callSuccess>true</ns2:callSuccess>"
+			+ "<ns2:totalCount>2</ns2:totalCount>"
+			+ "<ns2:resourceRecord>"
+			+ "<ns2:resourceRecordId>"+ RESOURCE_RECORD_ID+ "</ns2:resourceRecordId>"
+			+ "<ns2:owner>mbvdemo.mbv-demo.cc.</ns2:owner>"
+			+ "<ns2:type>CNAME</ns2:type>"
+			+ "<ns2:ttl>86400</ns2:ttl>"
+			+ "<ns2:rData>myhost.mbv-demo.cc.</ns2:rData>"
+			+ "</ns2:resourceRecord>"
+			+ "</ns2:getResourceRecordListRes>"
+			+ "</S:Body>" + "</S:Envelope>";
+
+	public static final String rrListCNAMETypesTemplete = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' "
+			+ "xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<soap:Header>"
+			+ "<urn1:authInfo>"
+			+ "<urn1:userToken>"
+			+ "<urn1:userName>"+ TEST_USER_NAME+ "</urn1:userName>"
+			+ "<urn1:password>"+ TEST_PASSWORD+ "</urn1:password>"
+			+ "</urn1:userToken>"
+			+ "</urn1:authInfo>"
+			+ "</soap:Header>"
+			+ "<soap:Body>"
+			+ "<urn2:getResourceRecord>"
+			+ "<urn2:resourceRecordId>"+ RESOURCE_RECORD_ID+ "</urn2:resourceRecordId>"
+			+ "</urn2:getResourceRecord>"
+			+ "</soap:Body>" 
+			+ "</soap:Envelope>";
+
+	public static final String getrrListCNAMETypesTemplete =
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+"<S:Envelope xmlns:S=\"http://www.w3.org/2003/05/soap-envelope\">"
+			+"<S:Header>"
+			+"<ns2:authInfo xmlns=\"urn:com:verisign:dnsa:messaging:schema:1\" xmlns:ns2=\"urn:com:verisign:dnsa:auth:schema:1\" xmlns:ns3=\"urn:com:verisign:dnsa:api:schema:1\">"
+			+"<ns2:userToken>"
+			+"<ns2:userName>"+TEST_USER_NAME+"</ns2:userName>"
+			+"<ns2:password>"+TEST_PASSWORD+"</ns2:password>"
+			+"</ns2:userToken>"
+			+"</ns2:authInfo>"
+			+"</S:Header>"
+			+"<S:Body>"
+			+"<ns3:getResourceRecordList xmlns=\"urn:com:verisign:dnsa:auth:schema:1\" xmlns:ns2=\"urn:com:verisign:dnsa:messaging:schema:1\" xmlns:ns3=\"urn:com:verisign:dnsa:api:schema:1\">"
+			+"<ns3:domainName>"+VALID_ZONE_NAME1+"</ns3:domainName>"
+			+"<ns3:resourceRecordType>"+VALID_RR_TYPE1+"</ns3:resourceRecordType>"
+			+"</ns3:getResourceRecordList>"
+			+"</S:Body>"
+			+"</S:Envelope>";
+	
+	public static final String nAPTRDataResponse = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Body>"
+			+ "<ns2:getResourceRecordListRes xmlns='urn:com:verisign:dnsa:api:schema:2' xmlns:ns2='urn:com:verisign:dnsa:api:schema:1' xmlns:ns3='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns4='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:callSuccess>true</ns2:callSuccess>"
+			+ "<ns2:totalCount>2</ns2:totalCount>"
+			+ "<ns2:resourceRecord>"
+			+ "<ns2:resourceRecordId>19076156</ns2:resourceRecordId>"
+			+ "<ns2:owner>"+ VALID_OWNER1+ "</ns2:owner>"
+			+ "<ns2:type>"+ VALID_RR_TYPE3+ "</ns2:type>"
+			+ "<ns2:ttl>"+ VALID_TTL1+ "</ns2:ttl>"
+			+ "<ns2:rData>"+ VALID_RData_NAPTR+ "</ns2:rData>"
+			+ "</ns2:resourceRecord>"
+			+ "<ns2:resourceRecord>"
+			+ "<ns2:resourceRecordId>19049261</ns2:resourceRecordId>"
+			+ "<ns2:owner>"+ VALID_OWNER2+ "</ns2:owner>"
+			+ "<ns2:type>"+ VALID_RR_TYPE3+ "</ns2:type>"
+			+ "<ns2:ttl>"+ VALID_TTL1+ "</ns2:ttl>"
+			+ "<ns2:rData>"+ VALID_RData_NAPTR+ "</ns2:rData>"
+			+ "</ns2:resourceRecord>"
+			+ "</ns2:getResourceRecordListRes>"
+			+ "</S:Body>" + "</S:Envelope>";
+
+	public static final String zoneListRequestTemplate = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'><S:Header><ns2:authInfo xmlns='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns2='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<ns2:userToken>"
+			+ "<ns2:userName>"+ TEST_USER_NAME+ "</ns2:userName>"
+			+ "<ns2:password>"+ TEST_PASSWORD+ "</ns2:password>"
+			+ "</ns2:userToken>"
+			+ "</ns2:authInfo>"
+			+ "</S:Header>"
+			+ "<S:Body>"
+			+ "<ns3:getZoneList xmlns='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns2='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<ns3:listPagingInfo><ns3:pageNumber>1</ns3:pageNumber><ns3:pageSize>50</ns3:pageSize>"
+			+ "</ns3:listPagingInfo>"
+			+ "</ns3:getZoneList>"
+			+ "</S:Body>"
+			+ "</S:Envelope>";
+
+	public static final String zoneListResponse = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Header>"
+			+ "<ns2:reliableMessageRes xmlns:ns2='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:MessageId>1111011</ns2:MessageId>"
+			+ "</ns2:reliableMessageRes>"
+			+ "</S:Header>"
+			+ "<S:Body>"
+			+ "<ns2:getZoneListRes xmlns='urn:com:verisign:dnsa:api:schema:2' xmlns:ns2='urn:com:verisign:dnsa:api:schema:1' xmlns:ns3='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns4='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:callSuccess>true</ns2:callSuccess>"
+			+ "<ns2:totalCount>2</ns2:totalCount>"
+			+ "<ns2:zoneInfo>"
+			+ "<ns2:domainName>dummyDomain1.com</ns2:domainName>"
+			+ "<ns2:type>DNS Hosting</ns2:type>"
+			+ "<ns2:status>ACTIVE</ns2:status>"
+			+ "<ns2:createTimestamp>2014-05-15T16:21:33.000Z</ns2:createTimestamp>"
+			+ "<ns2:updateTimestamp>2014-08-07T20:57:49.000Z</ns2:updateTimestamp>"
+			+ "<ns2:geoLocationEnabled>No</ns2:geoLocationEnabled>"
+			+ "</ns2:zoneInfo>"
+			+ "<ns2:zoneInfo>"
+			+ "<ns2:domainName>dummyDomain2.co.cc</ns2:domainName>"
+			+ "<ns2:type>DNS Hosting</ns2:type>"
+			+ "<ns2:status>ACTIVE</ns2:status>"
+			+ "<ns2:createTimestamp>2010-04-05T06:29:33.000Z</ns2:createTimestamp>"
+			+ "<ns2:updateTimestamp>2014-07-01T08:29:20.000Z</ns2:updateTimestamp>"
+			+ "<ns2:geoLocationEnabled>No</ns2:geoLocationEnabled>"
+			+ "</ns2:zoneInfo>"
+			+ "</ns2:getZoneListRes>"
+			+ "</S:Body>"
+			+ "</S:Envelope>";
+
+	public static final String authFailureResponse = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Header>"
+			+ "<ns2:reliableMessageRes xmlns:ns2='urn:com:verisign:dnsa:messaging:schema:1'><ns2:MessageId>1111011</ns2:MessageId>"
+			+ "</ns2:reliableMessageRes>"
+			+ "</S:Header>"
+			+ "<S:Body>"
+			+ "<ns3:Fault xmlns:ns2='http://schemas.xmlsoap.org/soap/envelope/' xmlns:ns3='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<ns3:Code><ns3:Value>ns3:Receiver</ns3:Value></ns3:Code>"
+			+ "<ns3:Reason><ns3:Text xml:lang='en'>ERROR_OPERATION_FAILURE</ns3:Text></ns3:Reason>"
+			+ "<ns3:Detail>"
+			+ "<ns2:dnsaWSRes xmlns:ns2='urn:com:verisign:dnsa:api:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:2' xmlns:ns4='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns5='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:callSuccess>false</ns2:callSuccess>"
+			+ "<ns2:reason code='ERROR_OPERATION_FAILURE' description='Authentication Failed. Please verify your Username and Password.'/>"
+			+ "</ns2:dnsaWSRes>"
+			+ "</ns3:Detail>"
+			+ "</ns3:Fault>"
+			+ "</S:Body>" 
+			+ "</S:Envelope>";
+
+	public static final String rrListRequestTemplate = 
+		"<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:urn='urn:com:verisign:dnsa:messaging:schema:1' xmlns:urn1='urn:com:verisign:dnsa:auth:schema:1' xmlns:urn2='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<soap:Header>"
+			+ "<urn1:authInfo>"
+			+ "<urn1:userToken>"
+			+ "<urn1:userName>%s</urn1:userName>"
+			+ "<urn1:password>%s</urn1:password>"
+			+ "</urn1:userToken>"
+			+ "</urn1:authInfo>"
+			+ "</soap:Header>"
+			+ "<soap:Body>"
+			+ "<urn2:getResourceRecordList>"
+			+ "<urn2:domainName>%s</urn2:domainName>"
+			+ "</urn2:getResourceRecordList>"
+			+ "</soap:Body>"
+			+ "</soap:Envelope>";
+
+	public static final String rrByNameAndTypeTemplate = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Header>"
+			+ "<ns2:authInfo xmlns='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns2='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<ns2:userToken>"
+			+ "<ns2:userName>%s</ns2:userName>"
+			+ "<ns2:password>%s</ns2:password>"
+			+ "</ns2:userToken>"
+			+ "</ns2:authInfo>"
+			+ "</S:Header>"
+			+ "<S:Body>"
+			+ "<ns3:getResourceRecordList xmlns='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns2='urn:com:verisign:dnsa:messaging:schema:1' xmlns:ns3='urn:com:verisign:dnsa:api:schema:1'>"
+			+ "<ns3:domainName>%s</ns3:domainName>"
+			+ "<ns3:resourceRecordType>%s</ns3:resourceRecordType>"
+			+ "<ns3:owner>%s</ns3:owner>"
+			+ "</ns3:getResourceRecordList>"
+			+ "</S:Body>" + "</S:Envelope>";
+
+	public static final String rrListValildResponse = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Body>"
+			+ "<ns2:getResourceRecordListRes xmlns='urn:com:verisign:dnsa:api:schema:2' xmlns:ns2='urn:com:verisign:dnsa:api:schema:1' xmlns:ns3='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns4='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:callSuccess>true</ns2:callSuccess>"
+			+ "<ns2:totalCount>2</ns2:totalCount>"
+			+ "<ns2:resourceRecord>"
+			+ "<ns2:resourceRecordId>19076156</ns2:resourceRecordId>"
+			+ "<ns2:owner>"+ VALID_OWNER1+ "</ns2:owner>"
+			+ "<ns2:type>"+ VALID_RR_TYPE1+ "</ns2:type>"
+			+ "<ns2:ttl>"+ VALID_TTL1+ "</ns2:ttl>"
+			+ "<ns2:rData>"+ VALID_RDATA1+ "</ns2:rData>"
+			+ "</ns2:resourceRecord>"
+			+ "<ns2:resourceRecord>"
+			+ "<ns2:resourceRecordId>19049261</ns2:resourceRecordId>"
+			+ "<ns2:owner>"+ VALID_OWNER2+ "</ns2:owner>"
+			+ "<ns2:type>"+ VALID_RR_TYPE2+ "</ns2:type>"
+			+ "<ns2:ttl>"+ VALID_TTL1+ "</ns2:ttl>"
+			+ "<ns2:rData>"+ VALID_RDATA2+ "</ns2:rData>"
+			+ "</ns2:resourceRecord>"
+			+ "</ns2:getResourceRecordListRes>"
+			+ "</S:Body>" + "</S:Envelope>";
+
+	public static final String rrListValidResponseNoRecords = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Body>"
+			+ "<ns2:getResourceRecordListRes xmlns='urn:com:verisign:dnsa:api:schema:2' xmlns:ns2='urn:com:verisign:dnsa:api:schema:1' xmlns:ns3='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns4='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:callSuccess>true</ns2:callSuccess>"
+			+ "<ns2:totalCount>0</ns2:totalCount>"
+			+ "</ns2:getResourceRecordListRes>" 
+			+ "</S:Body>" 
+			+ "</S:Envelope>";
+
+	public static final String rrListInvalidZoneResponse = 
+		"<?xml version='1.0' encoding='UTF-8'?>"
+			+ "<S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'>"
+			+ "<S:Body>"
+			+ "<S:Fault xmlns:ns4='http://schemas.xmlsoap.org/soap/envelope/'>"
+			+ "<S:Code>"
+			+ "<S:Value>S:Receiver</S:Value>"
+			+ "</S:Code>"
+			+ "<S:Reason>"
+			+ "<S:Text xml:lang='en'>ERROR_OPERATION_FAILURE</S:Text>"
+			+ "</S:Reason>"
+			+ "<S:Detail>"
+			+ "<ns2:dnsaWSRes xmlns='urn:com:verisign:dnsa:api:schema:2' xmlns:ns2='urn:com:verisign:dnsa:api:schema:1' xmlns:ns3='urn:com:verisign:dnsa:auth:schema:1' xmlns:ns4='urn:com:verisign:dnsa:messaging:schema:1'>"
+			+ "<ns2:callSuccess>false</ns2:callSuccess>"
+			+ "<ns2:reason code='ERROR_OPERATION_FAILURE' description='The domain name could not be found.'/>"
+			+ "</ns2:dnsaWSRes>"
+			+ "</S:Detail>"
+			+ "</S:Fault>"
+			+ "</S:Body>"
+			+ "</S:Envelope>";
+
+	public static ZoneApi mockZoneApi(final int port) {
+		return Denominator.create(new VrsnDNSProvider() {
+			@Override
+			public String url() {
+				return "http://localhost:" + port + "/";
+			}
+		}, credentials(TEST_USER_NAME, TEST_PASSWORD)).api().zones();
+	}
+
+	public static ResourceRecordSetApi mockResourceRecordSetApi(final int port) {
+		return Denominator.create(new VrsnDNSProvider() {
+			@Override
+			public String url() {
+				return "http://localhost:" + port + "/";
+			}
+		}, credentials(TEST_USER_NAME, TEST_PASSWORD)).api()
+				.basicRecordSetsInZone(VALID_ZONE_NAME1);
+	}
+
+	public static VrsnAllProfileResourceRecordSetApi mockAllProfileResourceRecordSetApi(
+			final int port) {
+		return (VrsnAllProfileResourceRecordSetApi) Denominator
+				.create(new VrsnDNSProvider() {
+					@Override
+					public String url() {
+						return "http://localhost:" + port + "/";
+					}
+				}, credentials(TEST_USER_NAME, TEST_PASSWORD)).api()
+				.recordSetsInZone(VALID_ZONE_NAME1);
+	}
+
+	public static javax.inject.Provider<Credentials> mockProviderCredentials() {
+		return new javax.inject.Provider<Credentials>() {
+			@Override
+			public Credentials get() {
+				List<String> tempList = new ArrayList<String>();
+				tempList.add(TEST_USER_NAME);
+				tempList.add(TEST_PASSWORD);
+				return (ListCredentials) new TestListCredentials(tempList);
+			}
+		};
+	}
+
+	public static ErrorDecoder mockErrorDecoder() {
+		ErrorDecoder errorDecoder = ObjectGraph.create(new XMLCodec()).get(
+				ErrorDecoder.class);
+		return errorDecoder;
+	}
+
+	public static String[] mockArrayList() {
+		String[] result = { "testItem1", "testItem2", "testItem3" };
+		return result;
+	}
+
+	static Response mockResponse(String body) {
+		return Response.create(200, "OK",
+				ImmutableMap.<String, Collection<String>> of(), body, UTF_8);
+	}
+
+	public static Map<String, Collection<String>> MockcredentialTypeToParameterNamesResponse() {
+		Map<String, Collection<String>> options = new LinkedHashMap<String, Collection<String>>();
+		options.put("password", Arrays.asList(TEST_USER_NAME, TEST_PASSWORD));
+		return options;
+	}
+
+	public static Map<String, Collection<String>> mockProfileToRecordTypesResponse() {
+		Map<String, Collection<String>> profileToRecordTypes = new LinkedHashMap<String, Collection<String>>();
+		return profileToRecordTypes;
+	}
+
+	public static Record mockRecord() {
+		List<String> rData = new ArrayList<String>();
+		rData.add(VALID_RData_NAPTR);
+		Record record = new Record();
+		record.id = VALID_TTL1;
+		record.name = VALID_OWNER1;
+		record.type = VALID_RR_TYPE3;
+		record.ttl = Integer.parseInt(VALID_TTL1);
+		record.rdata = rData;
+
+		return record;
+	}
+	
+	public static Record mockCNameRecord() {
+		List<String> rData = new ArrayList<String>();
+		rData.add(VALID_RDATA1);
+		Record record = new Record();
+		record.id = VALID_TTL1;
+		record.name = VALID_OWNER1;
+		record.type = VALID_RR_TYPE1;
+		record.ttl = Integer.parseInt(VALID_TTL1);
+		record.rdata = rData;
+
+		return record;
+	}
+
+	@SuppressWarnings("serial")
+	public static class TestListCredentials extends
+			denominator.Credentials.ListCredentials {
+		protected TestListCredentials(Collection<?> args) {
+			super(args);
+		}
+	}
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnMdnsErrorDecoderTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnMdnsErrorDecoderTest.java
@@ -1,0 +1,29 @@
+package denominator.verisignmdns;
+
+import static denominator.verisignmdns.VrsnMDNSTest.METHODKEY;
+import static denominator.verisignmdns.VrsnMDNSTest.mockResponse;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListInvalidZoneResponse;
+import static org.testng.Assert.assertNotNull;
+
+import org.testng.annotations.Test;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+/**
+ * @author sgavhane
+ *
+ */
+public class VrsnMdnsErrorDecoderTest {
+
+	@Test
+	public void decode() {
+		Response response = mockResponse(rrListInvalidZoneResponse);
+		ErrorDecoder errorDecoder = VrsnMDNSTest.mockErrorDecoder();
+
+		Exception actualResult = errorDecoder.decode(METHODKEY, response);
+
+		assertNotNull(actualResult);
+	}
+
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnMdnsRequestHelperTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnMdnsRequestHelperTest.java
@@ -1,0 +1,51 @@
+package denominator.verisignmdns;
+
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_OWNER1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_RR_TYPE1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_RR_TYPE3;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_TTL1;
+import static denominator.verisignmdns.VrsnMDNSTest.mockResourceRecordSetApi;
+import static denominator.verisignmdns.VrsnMDNSTest.nAPTRDataResponse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+
+import denominator.ResourceRecordSetApi;
+import denominator.model.ResourceRecordSet;
+import denominator.verisignmdns.VrsnMdnsRequestHelper;
+
+/**
+ * @author sgavhane
+ *
+ */
+public class VrsnMdnsRequestHelperTest {
+
+	@Test
+	public void getNAPTRData() throws IOException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(nAPTRDataResponse));
+		server.play();
+
+		try {
+			ResourceRecordSetApi api = mockResourceRecordSetApi(server
+					.getPort());
+			ResourceRecordSet<?> rrSet = api.getByNameAndType(VALID_OWNER1,
+					VALID_RR_TYPE1);
+			String actualNAPTRData = VrsnMdnsRequestHelper.getNAPTRData(rrSet);
+			assertNotNull(actualNAPTRData);
+			assertNotNull(rrSet);
+			assertEquals(rrSet.ttl(), new Integer(Integer.parseInt(VALID_TTL1)));
+			assertEquals(rrSet.type(), VALID_RR_TYPE3);
+			assertEquals(rrSet.name(), VALID_OWNER1);
+			assertNotNull(rrSet.records());
+		} finally {
+			server.shutdown();
+		}
+	}
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnResourceRecordSetApiTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnResourceRecordSetApiTest.java
@@ -1,0 +1,242 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+import static denominator.verisignmdns.VrsnMDNSTest.TEST_PASSWORD;
+import static denominator.verisignmdns.VrsnMDNSTest.TEST_USER_NAME;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_OWNER1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_RDATA1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_RR_TYPE1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_TTL1;
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_ZONE_NAME1;
+import static denominator.verisignmdns.VrsnMDNSTest.createRequestARecordResponse;
+import static denominator.verisignmdns.VrsnMDNSTest.createRequestARecordTemplete;
+import static denominator.verisignmdns.VrsnMDNSTest.mockResourceRecordSetApi;
+import static denominator.verisignmdns.VrsnMDNSTest.rrByNameAndTypeTemplate;
+import static denominator.verisignmdns.VrsnMDNSTest.rrDeleteResponse;
+import static denominator.verisignmdns.VrsnMDNSTest.rrDeleteTemplete;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListCNAMETypesResponse;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListInvalidZoneResponse;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListRequestTemplate;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListValidResponseNoRecords;
+import static denominator.verisignmdns.VrsnMDNSTest.rrListValildResponse;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.testng.annotations.Test;
+
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+
+import denominator.ResourceRecordSetApi;
+import denominator.model.ResourceRecordSet;
+import denominator.model.rdata.CNAMEData;
+import denominator.verisignmdns.VrsnContentConversionHelper;
+import denominator.verisignmdns.VrsnMdns.Record;
+
+/**
+ * @author smahurpawar
+ *
+ */
+public class VrsnResourceRecordSetApiTest {
+
+	@Test
+	public void rrListInvalidZone() throws IOException, InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListInvalidZoneResponse));
+		server.play();
+
+		try {
+			ResourceRecordSetApi api = mockResourceRecordSetApi(server
+					.getPort());
+			assertFalse(api.iterator().hasNext());
+
+			assertEquals(server.getRequestCount(), 1);
+			String expectedRequest = format(rrListRequestTemplate,
+					TEST_USER_NAME, TEST_PASSWORD, VALID_ZONE_NAME1);
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	@Test
+	public void rrListvalidZoneNoRRs() throws IOException, InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListValidResponseNoRecords));
+		server.play();
+
+		try {
+			ResourceRecordSetApi api = mockResourceRecordSetApi(server
+					.getPort());
+			assertFalse(api.iterator().hasNext());
+
+			assertEquals(server.getRequestCount(), 1);
+			String expectedRequest = format(rrListRequestTemplate,
+					TEST_USER_NAME, TEST_PASSWORD, VALID_ZONE_NAME1);
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	@Test
+	public void rrListvalidResponse() throws IOException, InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListValildResponse));
+		server.play();
+
+		try {
+			ResourceRecordSetApi api = mockResourceRecordSetApi(server
+					.getPort());
+			Iterator<ResourceRecordSet<?>> iter = api.iterator();
+			ResourceRecordSet<?> rrSet = iter.next();
+			assertNotNull(rrSet);
+			assertEquals(rrSet.ttl(), new Integer(Integer.parseInt(VALID_TTL1)));
+			assertEquals(rrSet.type(), VALID_RR_TYPE1);
+			assertEquals(rrSet.name(), VALID_OWNER1);
+			Object entry = rrSet.records().get(0);
+
+			assertTrue(entry instanceof CNAMEData);
+			CNAMEData cnameData = (CNAMEData) entry;
+			assertEquals(cnameData.values().iterator().next(), VALID_RDATA1);
+
+			// verify we have 2 records as expected.
+			assertTrue(iter.hasNext());
+
+			String expectedRequest = format(rrListRequestTemplate,
+					TEST_USER_NAME, TEST_PASSWORD, VALID_ZONE_NAME1);
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	@Test
+	public void rrListByNameAndTypeValidResponse() throws IOException,
+			InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListValildResponse));
+		server.play();
+
+		try {
+			ResourceRecordSetApi api = mockResourceRecordSetApi(server
+					.getPort());
+			ResourceRecordSet<?> rrSet = api.getByNameAndType(VALID_OWNER1,
+					VALID_RR_TYPE1);
+			assertNotNull(rrSet);
+			assertEquals(rrSet.ttl(), new Integer(Integer.parseInt(VALID_TTL1)));
+			assertEquals(rrSet.type(), VALID_RR_TYPE1);
+			assertEquals(rrSet.name(), VALID_OWNER1);
+			Object entry = rrSet.records().get(0);
+
+			assertTrue(entry instanceof CNAMEData);
+			CNAMEData cnameData = (CNAMEData) entry;
+			assertEquals(cnameData.values().iterator().next(), VALID_RDATA1);
+
+			String expectedRequest = format(rrByNameAndTypeTemplate,
+					TEST_USER_NAME, TEST_PASSWORD, VALID_ZONE_NAME1,
+					VALID_RR_TYPE1, VALID_OWNER1);
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	@Test
+	public void testGetByNameAndType() throws IOException, InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListValildResponse));
+		server.play();
+		try {
+			ResourceRecordSetApi api = mockResourceRecordSetApi(server
+					.getPort());
+			ResourceRecordSet<?> actualResult = api.getByNameAndType(
+					VALID_OWNER1, VALID_RR_TYPE1);
+
+			assertNotNull(actualResult);
+			assertEquals(actualResult.ttl(),
+					new Integer(Integer.parseInt(VALID_TTL1)));
+			assertEquals(actualResult.type(), VALID_RR_TYPE1);
+			assertEquals(actualResult.name(), VALID_OWNER1);
+			Object entry = actualResult.records().get(0);
+
+			assertTrue(entry instanceof CNAMEData);
+			CNAMEData cnameData = (CNAMEData) entry;
+			assertEquals(cnameData.values().iterator().next(), VALID_RDATA1);
+			String expectedRequest = format(rrByNameAndTypeTemplate,
+					TEST_USER_NAME, TEST_PASSWORD, VALID_ZONE_NAME1,
+					VALID_RR_TYPE1, VALID_OWNER1);
+
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest);
+		} finally {
+			server.shutdown();
+		}
+	}
+	 	
+	@Test
+	public void TestDeleteByNameAndType() throws IOException,
+			InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(rrListCNAMETypesResponse));
+		server.enqueue(new MockResponse().setBody(rrDeleteResponse));
+		server.play();
+
+		try {
+			ResourceRecordSetApi apiforDelete = mockResourceRecordSetApi(server
+					.getPort());
+			apiforDelete.deleteByNameAndType(VALID_OWNER1, VALID_RR_TYPE1);
+			String expectedRequest1 = format(rrByNameAndTypeTemplate,
+					TEST_USER_NAME, TEST_PASSWORD, VALID_ZONE_NAME1,
+					VALID_RR_TYPE1, VALID_OWNER1);
+			String expectedRequest2 = format(rrDeleteTemplete, TEST_USER_NAME,
+					TEST_PASSWORD, VALID_ZONE_NAME1, VALID_RR_TYPE1,
+					VALID_OWNER1);
+
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest1);
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest2);
+
+		} finally {
+			server.shutdown();
+		}
+	}
+	
+	@Test
+	public void testPut() throws IOException, InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(createRequestARecordResponse));
+		server.play();
+
+		try {
+			ResourceRecordSetApi api = mockResourceRecordSetApi(server
+					.getPort());
+			Record aMDNSRecord = VrsnMDNSTest.mockCNameRecord();
+			ResourceRecordSet<?> inputRecordSet = VrsnContentConversionHelper
+					.convertMDNSRecordToDenominator(aMDNSRecord);
+			api.put(inputRecordSet);
+
+			String expectedRequest = format(createRequestARecordTemplete,
+					TEST_USER_NAME, TEST_PASSWORD, VALID_ZONE_NAME1,
+					VALID_RR_TYPE1, VALID_OWNER1);
+
+			assertEquals(new String(server.takeRequest().getBody()),
+					expectedRequest);
+		} finally {
+			server.shutdown();
+		}
+	}
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnUtilsTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnUtilsTest.java
@@ -1,0 +1,41 @@
+package denominator.verisignmdns;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Map;
+
+import javax.inject.Provider;
+
+import org.testng.annotations.Test;
+
+import denominator.Credentials;
+import denominator.verisignmdns.VrsnConstants;
+import denominator.verisignmdns.VrsnUtils;
+
+/**
+ * @author sgavhane
+ *
+ */
+
+public class VrsnUtilsTest {
+
+	@Test
+	public void TestGetMapOfCredentials() {
+		Provider<Credentials> aCredentials = (Provider<Credentials>) VrsnMDNSTest
+				.mockProviderCredentials();
+		Map<String, String> actualResult = VrsnUtils
+				.getMapOfCredentials(aCredentials);
+
+		assertNotNull(actualResult);
+		assertTrue(actualResult
+				.containsKey(VrsnConstants.CREDENITAL_USERNAME_KEY));
+		assertTrue(actualResult
+				.containsKey(VrsnConstants.CREDENTIAL_PASSWORD_KEY));
+		assertEquals(actualResult.get(VrsnConstants.CREDENITAL_USERNAME_KEY),
+				VrsnMDNSTest.TEST_USER_NAME);
+		assertEquals(actualResult.get(VrsnConstants.CREDENTIAL_PASSWORD_KEY),
+				VrsnMDNSTest.TEST_PASSWORD);
+	}
+}

--- a/verisignmdns/src/test/java/denominator/verisignmdns/VrsnZoneApiTest.java
+++ b/verisignmdns/src/test/java/denominator/verisignmdns/VrsnZoneApiTest.java
@@ -1,0 +1,71 @@
+/**
+ * 
+ */
+package denominator.verisignmdns;
+
+/**
+ * @author smahurpawar
+ *
+ */
+import static denominator.verisignmdns.VrsnMDNSTest.VALID_ZONE_NAME1;
+import static denominator.verisignmdns.VrsnMDNSTest.authFailureResponse;
+import static denominator.verisignmdns.VrsnMDNSTest.mockZoneApi;
+import static denominator.verisignmdns.VrsnMDNSTest.zoneListRequestTemplate;
+import static denominator.verisignmdns.VrsnMDNSTest.zoneListResponse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.testng.annotations.Test;
+
+import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.MockWebServer;
+
+import denominator.ZoneApi;
+import denominator.model.Zone;
+
+@Test(singleThreaded = true)
+public class VrsnZoneApiTest {
+	@Test
+	public void validResponseWithZoneList() throws IOException,
+			InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(zoneListResponse));
+		server.play();
+
+		try {
+			ZoneApi api = mockZoneApi(server.getPort());
+			Zone zone = api.iterator().next();
+			assertEquals(zone.name(), VALID_ZONE_NAME1);
+			assertNull(zone.id());
+
+			assertEquals(server.getRequestCount(), 1);
+
+			assertEquals(new String(server.takeRequest().getBody()),
+					zoneListRequestTemplate);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	@Test
+	public void authenticationFailResponse() throws IOException,
+			InterruptedException {
+		MockWebServer server = new MockWebServer();
+		server.enqueue(new MockResponse().setBody(authFailureResponse));
+		server.play();
+
+		try {
+			ZoneApi api = mockZoneApi(server.getPort());
+			Iterator<Zone> iter = api.iterator();
+			assertEquals(server.getRequestCount(), 1);
+			assertFalse(iter.hasNext());
+
+		} finally {
+			server.shutdown();
+		}
+	}
+}


### PR DESCRIPTION
Hi,

Please review this pull request as per our earlier discussion (mail) regarding Verisign MDNS plugin for Netflix Denominator,  I tried to create feature branch however but settle down for a fork as I do not have permission for it.  We are supporting basic Resource Record   operations (list, add, delete) and zone list in this phase of development.

We have tested  zone list  and  add, create, delete operation of  Resource Records supported in this release. 
(Unfortunately Github does not allow to add test execution files as attachment)
Please let us know your questions and concerns.

-Thanks



