### PR TITLE
Converts model tests to JUnit and AssertJ

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -2,12 +2,7 @@ apply plugin: 'java'
 
 sourceCompatibility = 1.6
 
-test {
-  useTestNG()
-}
-
 dependencies {
-  testCompile 'com.google.guava:guava:14.0.1'
-  testCompile 'org.testng:testng:6.8.5'
-  testCompile 'com.google.code.gson:gson:2.2.4'
+  testCompile 'junit:junit:4.12'
+  testCompile 'org.assertj:assertj-core:1.7.1'
 }

--- a/model/src/main/java/denominator/model/ResourceRecordSet.java
+++ b/model/src/main/java/denominator/model/ResourceRecordSet.java
@@ -37,10 +37,8 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
 
   @ConstructorProperties({"name", "type", "qualifier", "ttl", "records", "geo", "weighted"})
   ResourceRecordSet(String name, String type, String qualifier, Integer ttl, List<D> records,
-                    Geo geo,
-                    Weighted weighted) {
-    checkArgument(checkNotNull(name, "name").length() <= 255,
-                  "Name must be limited to 255 characters");
+                    Geo geo, Weighted weighted) {
+    checkArgument(checkNotNull(name, "name").length() <= 255, "Name must be <= 255 characters");
     this.name = name;
     this.type = checkNotNull(type, "type of %s", name);
     this.qualifier = qualifier;

--- a/model/src/main/java/denominator/model/profile/Geos.java
+++ b/model/src/main/java/denominator/model/profile/Geos.java
@@ -1,11 +1,11 @@
 package denominator.model.profile;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import denominator.model.ResourceRecordSet;
 
@@ -39,7 +39,7 @@ public class Geos {
       regionsToApply.put(entry.getKey(), entry.getValue());
     }
     for (Entry<String, Collection<String>> entry : regionsToAdd.entrySet()) {
-      Set<String> updates = new LinkedHashSet<String>();
+      List<String> updates = new ArrayList<String>();
       if (regionsToApply.containsKey(entry.getKey())) {
         updates.addAll(regionsToApply.get(entry.getKey()));
       }

--- a/model/src/test/java/denominator/common/PeekingIteratorTest.java
+++ b/model/src/test/java/denominator/common/PeekingIteratorTest.java
@@ -1,40 +1,43 @@
 package denominator.common;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.NoSuchElementException;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Test
 public class PeekingIteratorTest {
 
-  @Test(expectedExceptions = UnsupportedOperationException.class)
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void unmodifiable() {
+    thrown.expect(UnsupportedOperationException.class);
+
     PeekingIterator<Boolean> it = TrueThenDone.INSTANCE.iterator();
-    assertTrue(it.next());
+    assertThat(it).containsExactly(true);
     it.remove();
   }
 
-  ;
-
-  @Test(expectedExceptions = NoSuchElementException.class)
+  @Test
   public void next() {
+    thrown.expect(NoSuchElementException.class);
+
     PeekingIterator<Boolean> it = TrueThenDone.INSTANCE.iterator();
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertFalse(it.hasNext());
+    assertThat(it).containsExactly(true);
     it.next();
   }
 
-  @Test(expectedExceptions = NoSuchElementException.class)
+  @Test
   public void peek() {
+    thrown.expect(NoSuchElementException.class);
+
     PeekingIterator<Boolean> it = TrueThenDone.INSTANCE.iterator();
-    assertTrue(it.hasNext());
-    assertTrue(it.peek());
-    assertTrue(it.next());
-    assertFalse(it.hasNext());
+    assertThat(it.peek()).isTrue();
+    assertThat(it).containsExactly(true);
     it.peek();
   }
 
@@ -56,6 +59,5 @@ public class PeekingIteratorTest {
         }
       };
     }
-
   }
 }

--- a/model/src/test/java/denominator/common/PreconditionsTest.java
+++ b/model/src/test/java/denominator/common/PreconditionsTest.java
@@ -1,17 +1,24 @@
 package denominator.common;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Preconditions.checkNotNull;
 import static denominator.common.Preconditions.checkState;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Test
 public class PreconditionsTest {
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "should be foo")
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void checkArgumentFormatted() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("should be foo");
+
     checkArgument(false, "should be %s", "foo");
   }
 
@@ -20,8 +27,11 @@ public class PreconditionsTest {
     checkArgument(true, "should be %s", "foo");
   }
 
-  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "should be foo")
+  @Test
   public void checkStateFormatted() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("should be foo");
+
     checkState(false, "should be %s", "foo");
   }
 
@@ -30,13 +40,16 @@ public class PreconditionsTest {
     checkState(true, "should be %s", "foo");
   }
 
-  @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "should be foo")
+  @Test
   public void checkNotNullFormatted() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("should be foo");
+
     checkNotNull(null, "should be %s", "foo");
   }
 
   @Test
   public void checkNotNullPass() {
-    assertEquals(checkNotNull("foo", "should be %s", "foo"), "foo");
+    assertThat(checkNotNull("foo", "should be %s", "foo")).isEqualTo("foo");
   }
 }

--- a/model/src/test/java/denominator/common/UtilTest.java
+++ b/model/src/test/java/denominator/common/UtilTest.java
@@ -1,8 +1,8 @@
 package denominator.common;
 
-import com.google.common.collect.ImmutableList;
-
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -20,17 +20,16 @@ import static denominator.common.Util.nextOrNull;
 import static denominator.common.Util.peekingIterator;
 import static denominator.common.Util.slurp;
 import static denominator.common.Util.split;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Test
 public class UtilTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void slurpDoesntScrewWithWhitespance() throws IOException {
-    assertEquals(slurp(new StringReader(" foo\n")), " foo\n");
+    assertThat(slurp(new StringReader(" foo\n"))).isEqualTo(" foo\n");
   }
 
   @Test
@@ -40,71 +39,71 @@ public class UtilTest {
       builder.append('a');
     }
     String twoK1 = builder.toString();
-    assertEquals(slurp(new StringReader(twoK1)), twoK1);
+    assertThat(slurp(new StringReader(twoK1))).isEqualTo(twoK1);
   }
 
   @Test
   public void joinNadaReturnsEmpty() {
-    assertEquals(join(';', (Object[]) null), "");
-    assertEquals(join(';', new Object[]{}), "");
+    assertThat(join(';', (Object[]) null)).isEmpty();
+    assertThat(join(';', new Object[]{})).isEmpty();
   }
 
   @Test
   public void equalTest() {
-    assertTrue(equal(null, null));
-    assertTrue(equal("1", "1"));
-    assertFalse(equal(null, "1"));
-    assertFalse(equal("1", null));
-    assertFalse(equal("1", "2"));
+    assertThat(equal(null, null)).isTrue();
+    assertThat(equal("1", "1")).isTrue();
+    assertThat(equal(null, "1")).isFalse();
+    assertThat(equal("1", null)).isFalse();
+    assertThat(equal("1", "2")).isFalse();
   }
 
   @Test
   public void joinMultiple() {
-    assertEquals(join(';', "one", 2), "one;2");
+    assertThat(join(';', "one", 2)).isEqualTo("one;2");
   }
 
-  @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "toSplit")
+  @Test
   public void splitNull() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("toSplit");
+
     split(';', null);
   }
 
   @Test
   public void splitMiss() {
-    assertEquals(split(';', "one,2"), Arrays.asList("one,2"));
+    assertThat(split(';', "one,2")).containsOnly("one,2");
   }
 
   @Test
   public void splitWin() {
-    assertEquals(split(';', "one;2;2"), Arrays.asList("one", "2", "2"));
+    assertThat(split(';', "one;2;2")).containsOnly("one", "2", "2");
   }
 
   @Test
   public void splitEmpty() {
-    assertEquals(split(';', "one;;2"), Arrays.asList("one", null, "2"));
-    assertEquals(split(';', ";;"), Arrays.asList(null, null, null));
+    assertThat(split(';', "one;;2")).containsOnly("one", null, "2");
+    assertThat(split(';', ";;")).containsOnly(null, null, null);
   }
 
   @Test
   public void testNextOrNull() {
     PeekingIterator<Boolean> it = TrueThenDone.INSTANCE.iterator();
-    assertTrue(it.next());
-    assertNull(nextOrNull(it));
+    assertThat(it.next()).isTrue();
+    assertThat(nextOrNull(it)).isNull();
   }
 
   @Test
   public void peekingIteratorWhenPresent() {
-    PeekingIterator<Boolean> it = peekingIterator(ImmutableList.of(true).iterator());
-    assertTrue(it.hasNext());
-    assertTrue(it.peek());
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertFalse(it.hasNext());
+    PeekingIterator<Boolean> it = peekingIterator(Arrays.asList(true).iterator());
+    assertThat(it.peek()).isTrue();
+    assertThat(it).containsExactly(true);
   }
 
   @Test
   public void peekingIteratorWhenAbsent() {
-    PeekingIterator<Object> it = peekingIterator(ImmutableList.of().iterator());
-    assertFalse(it.hasNext());
+    PeekingIterator<Object> it = peekingIterator(Arrays.asList().iterator());
+    assertThat(it).isEmpty();
   }
 
   @Test
@@ -112,11 +111,7 @@ public class UtilTest {
     Iterator<Boolean>
         it =
         concat(TrueThenDone.INSTANCE.iterator(), TrueThenDone.INSTANCE.iterator());
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertFalse(it.hasNext());
+    assertThat(it).containsExactly(true, true);
   }
 
   @Test
@@ -126,7 +121,7 @@ public class UtilTest {
     Iterator<Boolean> second = TrueThenDone.INSTANCE.iterator();
     second.next();
     Iterator<Boolean> it = concat(first, second);
-    assertFalse(it.hasNext());
+    assertThat(it).isEmpty();
   }
 
   @Test
@@ -134,40 +129,32 @@ public class UtilTest {
     Iterator<Boolean> first = TrueThenDone.INSTANCE.iterator();
     first.next();
     Iterator<Boolean> it = concat(first, TrueThenDone.INSTANCE.iterator());
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertFalse(it.hasNext());
+    assertThat(it).containsExactly(true);
   }
 
   @Test
   public void concatIterablesWhenPresent() {
-    Iterator<Boolean> it = concat(ImmutableList.of(ImmutableList.of(true), ImmutableList.of(true)));
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertFalse(it.hasNext());
+    Iterator<Boolean> it = concat(Arrays.asList(Arrays.asList(true), Arrays.asList(true)));
+    assertThat(it).containsExactly(true, true);
   }
 
   @Test
   public void concatIterablesWhenAbsent() {
-    Iterator<Object> it = concat(ImmutableList.of(ImmutableList.of(), ImmutableList.of()));
-    assertFalse(it.hasNext());
+    Iterator<Object> it = concat(Arrays.asList(Arrays.asList(), Arrays.asList()));
+    assertThat(it).isEmpty();
   }
 
   @Test
   public void concatIterablesWhenFirstIsEmpty() {
     Iterator<Boolean>
         it =
-        concat(ImmutableList.of(ImmutableList.<Boolean>of(), ImmutableList.of(true)));
-    assertTrue(it.hasNext());
-    assertTrue(it.next());
-    assertFalse(it.hasNext());
+        concat(Arrays.asList(Arrays.<Boolean>asList(), Arrays.asList(true)));
+    assertThat(it).containsExactly(true);
   }
 
   @Test
   public void filterRetains() {
-    Iterator<String> it = filter(ImmutableList.of("waffles", "poo", "pancakes", "eggs").iterator(),
+    Iterator<String> it = filter(Arrays.asList("waffles", "poo", "pancakes", "eggs").iterator(),
                                  new Filter<String>() {
 
                                    @Override
@@ -176,9 +163,7 @@ public class UtilTest {
                                    }
 
                                  });
-    assertTrue(it.hasNext());
-    assertEquals(it.next(), "pancakes");
-    assertFalse(it.hasNext());
+    assertThat(it).containsExactly("pancakes");
   }
 
   @Test
@@ -200,7 +185,7 @@ public class UtilTest {
       }
 
     };
-    assertTrue(and(startsWithP, notPoo).apply("pancakes"));
-    assertFalse(and(startsWithP, notPoo).apply("poo"));
+    assertThat(and(startsWithP, notPoo).apply("pancakes")).isTrue();
+    assertThat(and(startsWithP, notPoo).apply("poo")).isFalse();
   }
 }

--- a/model/src/test/java/denominator/model/ResourceRecordSetTest.java
+++ b/model/src/test/java/denominator/model/ResourceRecordSetTest.java
@@ -1,15 +1,17 @@
 package denominator.model;
 
-import org.testng.annotations.Test;
-
-import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import denominator.model.rdata.AData;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Test
 public class ResourceRecordSetTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
 
   ResourceRecordSet<AData> record = ResourceRecordSet.<AData>builder()
       .name("www.denominator.io.")
@@ -17,32 +19,28 @@ public class ResourceRecordSetTest {
       .ttl(3600)
       .add(AData.create("192.0.2.1")).build();
 
-  String
-      asJson =
-      "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"ttl\":3600,\"records\":[{\"address\":\"192.0.2.1\"}]}";
-
+  @Test
   public void canBuildARecordSetInLongForm() {
-    assertEquals(record.name(), "www.denominator.io.");
-    assertEquals(record.type(), "A");
-    assertEquals(record.ttl(), Integer.valueOf(3600));
-    assertEquals(record.records().get(0), AData.create("192.0.2.1"));
+    assertThat(record.name()).isEqualTo("www.denominator.io.");
+    assertThat(record.type()).isEqualTo("A");
+    assertThat(record.ttl()).isEqualTo(3600);
+    assertThat(record.records().get(0)).isEqualTo(AData.create("192.0.2.1"));
   }
 
-  public void serializeNaturallyAsJson() {
-    assertEquals(ResourceRecordSetsTest.gson.toJson(record), asJson);
-  }
-
-  public void deserializesNaturallyFromJson() throws IOException {
-    assertEquals(ResourceRecordSetsTest.gson.fromJson(asJson, ResourceRecordSet.class), record);
-  }
-
-  @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "record")
+  @Test
   public void testNullRdataNPE() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("record");
+
     ResourceRecordSet.<AData>builder().add(null);
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid ttl.*")
+  @Test
+
   public void testInvalidTTL() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid ttl");
+
     ResourceRecordSet.<AData>builder()//
         .name("www.denominator.io.")//
         .type("A")//

--- a/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -1,27 +1,15 @@
 package denominator.model;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.InstanceCreator;
-import com.google.gson.TypeAdapter;
-import com.google.gson.internal.ConstructorConstructor;
-import com.google.gson.internal.bind.MapTypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import denominator.model.profile.Geo;
 import denominator.model.rdata.AAAAData;
@@ -58,57 +46,21 @@ import static denominator.model.ResourceRecordSets.srv;
 import static denominator.model.ResourceRecordSets.sshfp;
 import static denominator.model.ResourceRecordSets.tlsa;
 import static denominator.model.ResourceRecordSets.txt;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Test
+@RunWith(Enclosed.class)
 public class ResourceRecordSetsTest {
 
-  private static final TypeToken<Map<String, Object>>
-      MAP_STRING_OBJECT =
-      new TypeToken<Map<String, Object>>() {
-      };
-  private static final TypeToken<ResourceRecordSet<Map<String, Object>>>
-      RRSET_STRING_OBJECT =
-      new TypeToken<ResourceRecordSet<Map<String, Object>>>() {
-      };
-  private static final TypeAdapter<Map<String, Object>>
-      doubleToInt =
-      new TypeAdapter<Map<String, Object>>() {
-        TypeAdapter<Map<String, Object>>
-            delegate =
-            new MapTypeAdapterFactory(new ConstructorConstructor(
-                Collections.<Type, InstanceCreator<?>>emptyMap()), false)
-                .create(new Gson(), MAP_STRING_OBJECT);
-
-        @Override
-        public void write(JsonWriter out, Map<String, Object> value) throws IOException {
-          delegate.write(out, value);
-        }
-
-        @Override
-        public Map<String, Object> read(JsonReader in) throws IOException {
-          Map<String, Object> map = delegate.read(in);
-          for (Entry<String, Object> entry : map.entrySet()) {
-            if (entry.getValue() instanceof Double) {
-              entry.setValue(Double.class.cast(entry.getValue()).intValue());
-            }
-          }
-          return map;
-        }
-      }.nullSafe();
-  // deals with scenario where gson Object type treats all numbers as doubles.
-  public final static Gson gson = new GsonBuilder()//
-      .disableHtmlEscaping()//
-      .registerTypeAdapter(Map.class, doubleToInt)//
-      .registerTypeAdapter(MAP_STRING_OBJECT.getType(), doubleToInt).create();
   ResourceRecordSet<AData> aRRS = ResourceRecordSet.<AData>builder()
       .name("www.denominator.io.")
       .type("A")
       .ttl(3600)
       .add(AData.create("192.0.2.1")).build();
-  Geo geo = Geo.create(ImmutableMultimap.of("US", "US-VA").asMap());
+  Geo geo = Geo.create(new LinkedHashMap<String, Collection<String>>() {
+    {
+      put("US", Arrays.asList("US-VA"));
+    }
+  });
   ResourceRecordSet<AData> geoRRS = ResourceRecordSet.<AData>builder()
       .name("www.denominator.io.")
       .type("A")
@@ -118,317 +70,270 @@ public class ResourceRecordSetsTest {
       .geo(geo).build();
 
   public void nameEqualToReturnsFalseOnNull() {
-    assertFalse(nameEqualTo(aRRS.name()).apply(null));
+    assertThat(nameEqualTo(aRRS.name()).apply(null)).isFalse();
   }
 
   public void nameEqualToReturnsFalseOnDifferentName() {
-    assertFalse(nameEqualTo("www.foo.com").apply(aRRS));
+    assertThat(nameEqualTo("www.foo.com").apply(aRRS)).isFalse();
   }
 
   public void nameEqualToReturnsTrueOnSameName() {
-    assertTrue(nameEqualTo(aRRS.name()).apply(aRRS));
+    assertThat(nameEqualTo(aRRS.name()).apply(aRRS)).isTrue();
   }
 
   public void typeEqualToReturnsFalseOnNull() {
-    assertFalse(nameAndTypeEqualTo(aRRS.name(), aRRS.type()).apply(null));
+    assertThat(nameAndTypeEqualTo(aRRS.name(), aRRS.type()).apply(null)).isFalse();
   }
 
   public void typeEqualToReturnsFalseOnDifferentType() {
-    assertFalse(nameAndTypeEqualTo(aRRS.name(), "TXT").apply(aRRS));
+    assertThat(nameAndTypeEqualTo(aRRS.name(), "TXT").apply(aRRS)).isFalse();
   }
 
   public void typeEqualToReturnsTrueOnSameType() {
-    assertTrue(nameAndTypeEqualTo(aRRS.name(), aRRS.type()).apply(aRRS));
+    assertThat(nameAndTypeEqualTo(aRRS.name(), aRRS.type()).apply(aRRS)).isTrue();
   }
 
   public void containsRecordReturnsFalseOnNull() {
-    assertFalse(ResourceRecordSets.containsRecord(aRRS.records().get(0)).apply(null));
+    assertThat(ResourceRecordSets.containsRecord(aRRS.records().get(0)).apply(null)).isFalse();
   }
 
   public void containsRecordReturnsFalseWhenRDataDifferent() {
-    assertFalse(ResourceRecordSets.containsRecord(AData.create("198.51.100.1")).apply(aRRS));
+    assertThat(ResourceRecordSets.containsRecord(AData.create("198.51.100.1")).apply(aRRS))
+        .isFalse();
   }
 
   public void containsRecordReturnsTrueWhenRDataEqual() {
-    assertTrue(ResourceRecordSets.containsRecord(AData.create("192.0.2.1")).apply(aRRS));
+    assertThat(ResourceRecordSets.containsRecord(AData.create("192.0.2.1")).apply(aRRS)).isTrue();
   }
 
   public void containsRecordReturnsTrueWhenRDataEqualButDifferentType() {
-    assertTrue(
-        ResourceRecordSets.containsRecord(ImmutableMap.of("address", "192.0.2.1")).apply(aRRS));
+    Map<String, String> record = new LinkedHashMap<String, String>();
+    record.put("address", "192.0.2.1");
+    assertThat(ResourceRecordSets.containsRecord(record).apply(aRRS)).isTrue();
   }
 
   public void qualifierEqualToReturnsFalseOnNull() {
-    assertFalse(
-        nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), geoRRS.qualifier()).apply(null));
+    assertThat(
+        nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), geoRRS.qualifier()).apply(null))
+        .isFalse();
   }
 
   public void qualifierEqualToReturnsFalseOnDifferentQualifier() {
-    assertFalse(nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), "TXT").apply(geoRRS));
+    assertThat(nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), "TXT").apply(geoRRS))
+        .isFalse();
   }
 
   public void qualifierEqualToReturnsFalseOnAbsentQualifier() {
-    assertFalse(nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), "TXT").apply(aRRS));
+    assertThat(nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), "TXT").apply(aRRS))
+        .isFalse();
   }
 
   public void qualifierEqualToReturnsTrueOnSameQualifier() {
-    assertTrue(nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), geoRRS.qualifier())
-                   .apply(geoRRS));
+    assertThat(nameTypeAndQualifierEqualTo(geoRRS.name(), geoRRS.type(), geoRRS.qualifier())
+                   .apply(geoRRS)).isTrue();
   }
 
-  @DataProvider(name = "a")
-  public Object[][] createData() {
-    Object[][] data = new Object[37][3];
-    data[0][0] = a("www.denominator.io.", "192.0.2.1");
-    data[0][1] = ResourceRecordSet.<AData>builder()
-        .name("www.denominator.io.")
-        .type("A")
-        .add(AData.create("192.0.2.1")).build();
-    data[0][2] =
-        "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"records\":[{\"address\":\"192.0.2.1\"}]}";
-    data[1][0] = a("www.denominator.io.", 3600, "192.0.2.1");
-    data[1][1] = ResourceRecordSet.<AData>builder()
-        .name("www.denominator.io.")
-        .type("A")
-        .ttl(3600)
-        .add(AData.create("192.0.2.1")).build();
-    data[1][2] =
-        "{\"name\":\"www.denominator.io.\",\"type\":\"A\",\"ttl\":3600,\"records\":[{\"address\":\"192.0.2.1\"}]}";
-    data[2][0] = a("www.denominator.io.", ImmutableSet.of("192.0.2.1"));
-    data[2][1] = data[0][1];
-    data[2][2] = data[0][2];
-    data[3][0] = a("www.denominator.io.", 3600, ImmutableSet.of("192.0.2.1"));
-    data[3][1] = data[1][1];
-    data[3][2] = data[1][2];
-    data[4][0] = aaaa("www.denominator.io.", "1234:ab00:ff00::6b14:abcd");
-    data[4][1] = ResourceRecordSet.<AAAAData>builder()
-        .name("www.denominator.io.")
-        .type("AAAA")
-        .add(AAAAData.create("1234:ab00:ff00::6b14:abcd")).build();
-    data[4][2] =
-        "{\"name\":\"www.denominator.io.\",\"type\":\"AAAA\",\"records\":[{\"address\":\"1234:ab00:ff00::6b14:abcd\"}]}";
-    data[5][0] = aaaa("www.denominator.io.", 3600, "1234:ab00:ff00::6b14:abcd");
-    data[5][1] = ResourceRecordSet.<AAAAData>builder()
-        .name("www.denominator.io.")
-        .type("AAAA")
-        .ttl(3600)
-        .add(AAAAData.create("1234:ab00:ff00::6b14:abcd")).build();
-    data[5][2] =
-        "{\"name\":\"www.denominator.io.\",\"type\":\"AAAA\",\"ttl\":3600,\"records\":[{\"address\":\"1234:ab00:ff00::6b14:abcd\"}]}";
-    data[6][0] = aaaa("www.denominator.io.", ImmutableSet.of("1234:ab00:ff00::6b14:abcd"));
-    data[6][1] = data[4][1];
-    data[6][2] = data[4][2];
-    data[7][0] = aaaa("www.denominator.io.", 3600, ImmutableSet.of("1234:ab00:ff00::6b14:abcd"));
-    data[7][1] = data[5][1];
-    data[7][2] = data[5][2];
-    data[8][0] = cname("www.denominator.io.", "www1.denominator.io.");
-    data[8][1] = ResourceRecordSet.<CNAMEData>builder()
-        .name("www.denominator.io.")
-        .type("CNAME")
-        .add(CNAMEData.create("www1.denominator.io.")).build();
-    data[8][2] =
-        "{\"name\":\"www.denominator.io.\",\"type\":\"CNAME\",\"records\":[{\"cname\":\"www1.denominator.io.\"}]}";
-    data[9][0] = cname("www.denominator.io.", 3600, "www1.denominator.io.");
-    data[9][1] = ResourceRecordSet.<CNAMEData>builder()
-        .name("www.denominator.io.")
-        .type("CNAME")
-        .ttl(3600)
-        .add(CNAMEData.create("www1.denominator.io.")).build();
-    data[9][2] =
-        "{\"name\":\"www.denominator.io.\",\"type\":\"CNAME\",\"ttl\":3600,\"records\":[{\"cname\":\"www1.denominator.io.\"}]}";
-    data[10][0] = cname("www.denominator.io.", ImmutableSet.of("www1.denominator.io."));
-    data[10][1] = data[8][1];
-    data[10][2] = data[8][2];
-    data[11][0] = cname("www.denominator.io.", 3600, ImmutableSet.of("www1.denominator.io."));
-    data[11][1] = data[9][1];
-    data[11][2] = data[9][2];
-    data[12][0] = ns("denominator.io.", "ns.denominator.io.");
-    data[12][1] = ResourceRecordSet.<NSData>builder()
-        .name("denominator.io.")
-        .type("NS")
-        .add(NSData.create("ns.denominator.io.")).build();
-    data[12][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"NS\",\"records\":[{\"nsdname\":\"ns.denominator.io.\"}]}";
-    data[13][0] = ns("denominator.io.", 3600, "ns.denominator.io.");
-    data[13][1] = ResourceRecordSet.<NSData>builder()
-        .name("denominator.io.")
-        .type("NS")
-        .ttl(3600)
-        .add(NSData.create("ns.denominator.io.")).build();
-    data[13][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"NS\",\"ttl\":3600,\"records\":[{\"nsdname\":\"ns.denominator.io.\"}]}";
-    data[14][0] = ns("denominator.io.", ImmutableSet.of("ns.denominator.io."));
-    data[14][1] = data[12][1];
-    data[14][2] = data[12][2];
-    data[15][0] = ns("denominator.io.", 3600, ImmutableSet.of("ns.denominator.io."));
-    data[15][1] = data[13][1];
-    data[15][2] = data[13][2];
-    data[16][0] = ptr("denominator.io.", "ptr.denominator.io.");
-    data[16][1] = ResourceRecordSet.<PTRData>builder()
-        .name("denominator.io.")
-        .type("PTR")
-        .add(PTRData.create("ptr.denominator.io.")).build();
-    data[16][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"PTR\",\"records\":[{\"ptrdname\":\"ptr.denominator.io.\"}]}";
-    data[17][0] = ptr("denominator.io.", 3600, "ptr.denominator.io.");
-    data[17][1] = ResourceRecordSet.<PTRData>builder()
-        .name("denominator.io.")
-        .type("PTR")
-        .ttl(3600)
-        .add(PTRData.create("ptr.denominator.io.")).build();
-    data[17][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"PTR\",\"ttl\":3600,\"records\":[{\"ptrdname\":\"ptr.denominator.io.\"}]}";
-    data[18][0] = ptr("denominator.io.", ImmutableSet.of("ptr.denominator.io."));
-    data[18][1] = data[16][1];
-    data[18][2] = data[16][2];
-    data[19][0] = ptr("denominator.io.", 3600, ImmutableSet.of("ptr.denominator.io."));
-    data[19][1] = data[17][1];
-    data[19][2] = data[17][2];
-    data[20][0] = txt("denominator.io.", "\"made in sweden\"");
-    data[20][1] = ResourceRecordSet.<TXTData>builder()
-        .name("denominator.io.")
-        .type("TXT")
-        .add(TXTData.create("\"made in sweden\"")).build();
-    data[20][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"TXT\",\"records\":[{\"txtdata\":\"\\\"made in sweden\\\"\"}]}";
-    data[21][0] = txt("denominator.io.", 3600, "\"made in sweden\"");
-    data[21][1] = ResourceRecordSet.<TXTData>builder()
-        .name("denominator.io.")
-        .type("TXT")
-        .ttl(3600)
-        .add(TXTData.create("\"made in sweden\"")).build();
-    data[21][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"TXT\",\"ttl\":3600,\"records\":[{\"txtdata\":\"\\\"made in sweden\\\"\"}]}";
-    data[22][0] = txt("denominator.io.", ImmutableSet.of("\"made in sweden\""));
-    data[22][1] = data[20][1];
-    data[22][2] = data[20][2];
-    data[23][0] = txt("denominator.io.", 3600, ImmutableSet.of("\"made in sweden\""));
-    data[23][1] = data[21][1];
-    data[23][2] = data[21][2];
-    data[24][0] = spf("denominator.io.", "\"v=spf1 a mx -all\"");
-    data[24][1] = ResourceRecordSet.<SPFData>builder()
-        .name("denominator.io.")
-        .type("SPF")
-        .add(SPFData.create("\"v=spf1 a mx -all\"")).build();
-    data[24][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"SPF\",\"records\":[{\"txtdata\":\"\\\"v=spf1 a mx -all\\\"\"}]}";
-    data[25][0] = spf("denominator.io.", 3600, "\"v=spf1 a mx -all\"");
-    data[25][1] = ResourceRecordSet.<SPFData>builder()
-        .name("denominator.io.")
-        .type("SPF")
-        .ttl(3600)
-        .add(SPFData.create("\"v=spf1 a mx -all\"")).build();
-    data[25][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"SPF\",\"ttl\":3600,\"records\":[{\"txtdata\":\"\\\"v=spf1 a mx -all\\\"\"}]}";
-    data[26][0] = spf("denominator.io.", ImmutableSet.of("\"v=spf1 a mx -all\""));
-    data[26][1] = data[24][1];
-    data[26][2] = data[24][2];
-    data[27][0] = spf("denominator.io.", 3600, ImmutableSet.of("\"v=spf1 a mx -all\""));
-    data[27][1] = data[25][1];
-    data[27][2] = data[25][2];
-    data[28][0] = mx("denominator.io.", 3600, ImmutableSet.of("1 mx1.denominator.io."));
-    data[28][1] = ResourceRecordSet.<MXData>builder()
-        .name("denominator.io.")
-        .type("MX")
-        .ttl(3600)
-        .add(MXData.create(1, "mx1.denominator.io.")).build();
-    data[28][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"MX\",\"ttl\":3600,\"records\":[{\"preference\":1,\"exchange\":\"mx1.denominator.io.\"}]}";
-    data[29][0] = srv("denominator.io.", 3600, ImmutableSet.of("0 1 80 srv.denominator.io."));
-    data[29][1] = ResourceRecordSet.<SRVData>builder()
-        .name("denominator.io.")
-        .type("SRV")
-        .ttl(3600)
-        .add(SRVData.builder().priority(0).weight(1).port(80).target("srv.denominator.io.").build())
-        .build();
-    data[29][2] =
-        "{\"name\":\"denominator.io.\",\"type\":\"SRV\",\"ttl\":3600,\"records\":[{\"priority\":0,\"weight\":1,\"port\":80,\"target\":\"srv.denominator.io.\"}]}";
-    data[30][0] = ds("ds.denominator.io.", 3600, ImmutableSet.of("12345 1 1 B33F"));
-    data[30][1] = ResourceRecordSet.<DSData>builder()
-        .name("ds.denominator.io.")
-        .type("DS")
-        .ttl(3600)
-        .add(DSData.builder().keyTag(12345).algorithmId(1).digestId(1).digest("B33F").build())
-        .build();
-    data[30][2] =
-        "{\"name\":\"ds.denominator.io.\",\"type\":\"DS\",\"ttl\":3600,\"records\":[{\"keyTag\":12345,\"algorithmId\":1,\"digestId\":1,\"digest\":\"B33F\"}]}";
-    data[31][0] = cert("www.denominator.io.", 3600, ImmutableSet.of("12345 1 1 B33F"));
-    data[31][1] = ResourceRecordSet.<CERTData>builder()
-        .name("www.denominator.io.")
-        .type("CERT")
-        .ttl(3600)
-        .add(CERTData.builder().certType(12345).keyTag(1).algorithm(1).cert("B33F").build())
-        .build();
-    data[31][2] =
-        "{\"name\":\"www.denominator.io.\",\"type\":\"CERT\",\"ttl\":3600,\"records\":[{\"certType\":12345,\"keyTag\":1,\"algorithm\":1,\"cert\":\"B33F\"}]}";
-    data[32][0] =
-        naptr("phone.denominator.io.", 3600,
-              ImmutableSet.of("1 1 U E2U+sip !^.*$!sip:customer-service@example.com! ."));
-    data[32][1] = ResourceRecordSet.<NAPTRData>builder()
-        .name("phone.denominator.io.")
-        .type("NAPTR")
-        .ttl(3600)
-        .add(NAPTRData.builder().order(1).preference(1).flags("U").services("E2U+sip")
-                 .regexp("!^.*$!sip:customer-service@example.com!").replacement(".").build())
-        .build();
-    data[32][2] =
-        "{\"name\":\"phone.denominator.io.\",\"type\":\"NAPTR\",\"ttl\":3600,\"records\":[{\"order\":1,\"preference\":1,\"flags\":\"U\",\"services\":\"E2U+sip\",\"regexp\":\"!^.*$!sip:customer-service@example.com!\",\"replacement\":\".\"}]}";
-    data[33][0] =
-        sshfp("server1.denominator.io.", 3600,
-              ImmutableSet.of("2 1 123456789abcdef67890123456789abcdef67890"));
-    data[33][1] = ResourceRecordSet.<SSHFPData>builder()
-        .name("server1.denominator.io.")
-        .type("SSHFP")
-        .ttl(3600)
-        .add(SSHFPData.createDSA("123456789abcdef67890123456789abcdef67890")).build();
-    data[33][2] =
-        "{\"name\":\"server1.denominator.io.\",\"type\":\"SSHFP\",\"ttl\":3600,\"records\":[{\"algorithm\":2,\"fptype\":1,\"fingerprint\":\"123456789abcdef67890123456789abcdef67890\"}]}";
-    data[34][0] =
-        loc("server1.denominator.io.", 3600,
-            ImmutableSet.of("37 48 48.892 S 144 57 57.502 E 26m 10m 100m 10m"));
-    data[34][1] = ResourceRecordSet.<LOCData>builder()
-        .name("server1.denominator.io.")
-        .type("LOC")
-        .ttl(3600)
-        .add(LOCData.builder().latitude("37 48 48.892 S").longitude("144 57 57.502 E")
-                 .altitude("26m").diameter("10m").hprecision("100m").vprecision("10m").build())
-        .build();
-    data[34][2] =
-        "{\"name\":\"server1.denominator.io.\",\"type\":\"LOC\",\"ttl\":3600,\"records\":[{\"latitude\":\"37 48 48.892 S\",\"longitude\":\"144 57 57.502 E\",\"altitude\":\"26m\",\"diameter\":\"10m\",\"hprecision\":\"100m\",\"vprecision\":\"10m\"}]}";
-    data[35][0] = tlsa("server1.denominator.io.", 3600, ImmutableSet.of("1 1 1 B33F"));
-    data[35][1] = ResourceRecordSet.<TLSAData>builder()
-        .name("server1.denominator.io.")
-        .type("TLSA")
-        .ttl(3600)
-        .add(TLSAData.builder().usage(1).selector(1).matchingType(1)
-                 .certificateAssociationData("B33F").build()).build();
-    data[35][2] =
-        "{\"name\":\"server1.denominator.io.\",\"type\":\"TLSA\",\"ttl\":3600,\"records\":[{\"usage\":1,\"selector\":1,\"matchingType\":1,\"certificateAssociationData\":\"B33F\"}]}";
-    data[36][0] =
-        loc("server1.denominator.io.", 3600, ImmutableSet.of("37 48 48.892 S 144 57 57.502 E"));
-    data[36][1] = ResourceRecordSet.<LOCData>builder()
-        .name("server1.denominator.io.")
-        .type("LOC")
-        .ttl(3600)
-        .add(LOCData.builder().latitude("37 48 48.892 S").longitude("144 57 57.502 E").build())
-        .build();
-    data[36][2] =
-        "{\"name\":\"server1.denominator.io.\",\"type\":\"LOC\",\"ttl\":3600,\"records\":[{\"latitude\":\"37 48 48.892 S\",\"longitude\":\"144 57 57.502 E\"}]}";
-    return data;
-  }
+  @RunWith(Parameterized.class)
+  public static class ShortFormEqualsLongFormTest {
 
-  @Test(dataProvider = "a")
-  public void shortFormEqualsLongForm(ResourceRecordSet<?> shortForm, ResourceRecordSet<?> longForm,
-                                      String json)
-      throws IOException {
-    assertEquals(shortForm, longForm);
-    assertEquals(shortForm.name(), longForm.name());
-    assertEquals(shortForm.type(), longForm.type());
-    assertEquals(shortForm.ttl(), longForm.ttl());
-    assertEquals(ImmutableList.copyOf(shortForm.records()),
-                 ImmutableList.copyOf(longForm.records()));
-    assertEquals(gson.toJson(shortForm), json);
-    assertEquals(gson.fromJson(json, RRSET_STRING_OBJECT.getType()), shortForm);
-    assertEquals(gson.fromJson(json, ResourceRecordSet.class), shortForm);
+    private final ResourceRecordSet<?> shortForm;
+    private final ResourceRecordSet<?> longForm;
+
+    public ShortFormEqualsLongFormTest(ResourceRecordSet<?> shortForm,
+                                       ResourceRecordSet<?> longForm) {
+      this.shortForm = shortForm;
+      this.longForm = longForm;
+    }
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> data() {
+      Object[][] data = new Object[37][2];
+      data[0][0] = a("www.denominator.io.", "192.0.2.1");
+      data[0][1] = ResourceRecordSet.<AData>builder()
+          .name("www.denominator.io.")
+          .type("A")
+          .add(AData.create("192.0.2.1")).build();
+      data[1][0] = a("www.denominator.io.", 3600, "192.0.2.1");
+      data[1][1] = ResourceRecordSet.<AData>builder()
+          .name("www.denominator.io.")
+          .type("A")
+          .ttl(3600)
+          .add(AData.create("192.0.2.1")).build();
+      data[2][0] = a("www.denominator.io.", Arrays.asList("192.0.2.1"));
+      data[2][1] = data[0][1];
+      data[3][0] = a("www.denominator.io.", 3600, Arrays.asList("192.0.2.1"));
+      data[3][1] = data[1][1];
+      data[4][0] = aaaa("www.denominator.io.", "1234:ab00:ff00::6b14:abcd");
+      data[4][1] = ResourceRecordSet.<AAAAData>builder()
+          .name("www.denominator.io.")
+          .type("AAAA")
+          .add(AAAAData.create("1234:ab00:ff00::6b14:abcd")).build();
+      data[5][0] = aaaa("www.denominator.io.", 3600, "1234:ab00:ff00::6b14:abcd");
+      data[5][1] = ResourceRecordSet.<AAAAData>builder()
+          .name("www.denominator.io.")
+          .type("AAAA")
+          .ttl(3600)
+          .add(AAAAData.create("1234:ab00:ff00::6b14:abcd")).build();
+      data[6][0] = aaaa("www.denominator.io.", Arrays.asList("1234:ab00:ff00::6b14:abcd"));
+      data[6][1] = data[4][1];
+      data[7][0] = aaaa("www.denominator.io.", 3600, Arrays.asList("1234:ab00:ff00::6b14:abcd"));
+      data[7][1] = data[5][1];
+      data[8][0] = cname("www.denominator.io.", "www1.denominator.io.");
+      data[8][1] = ResourceRecordSet.<CNAMEData>builder()
+          .name("www.denominator.io.")
+          .type("CNAME")
+          .add(CNAMEData.create("www1.denominator.io.")).build();
+      data[9][0] = cname("www.denominator.io.", 3600, "www1.denominator.io.");
+      data[9][1] = ResourceRecordSet.<CNAMEData>builder()
+          .name("www.denominator.io.")
+          .type("CNAME")
+          .ttl(3600)
+          .add(CNAMEData.create("www1.denominator.io.")).build();
+      data[10][0] = cname("www.denominator.io.", Arrays.asList("www1.denominator.io."));
+      data[10][1] = data[8][1];
+      data[11][0] = cname("www.denominator.io.", 3600, Arrays.asList("www1.denominator.io."));
+      data[11][1] = data[9][1];
+      data[12][0] = ns("denominator.io.", "ns.denominator.io.");
+      data[12][1] = ResourceRecordSet.<NSData>builder()
+          .name("denominator.io.")
+          .type("NS")
+          .add(NSData.create("ns.denominator.io.")).build();
+      data[13][0] = ns("denominator.io.", 3600, "ns.denominator.io.");
+      data[13][1] = ResourceRecordSet.<NSData>builder()
+          .name("denominator.io.")
+          .type("NS")
+          .ttl(3600)
+          .add(NSData.create("ns.denominator.io.")).build();
+      data[14][0] = ns("denominator.io.", Arrays.asList("ns.denominator.io."));
+      data[14][1] = data[12][1];
+      data[15][0] = ns("denominator.io.", 3600, Arrays.asList("ns.denominator.io."));
+      data[15][1] = data[13][1];
+      data[16][0] = ptr("denominator.io.", "ptr.denominator.io.");
+      data[16][1] = ResourceRecordSet.<PTRData>builder()
+          .name("denominator.io.")
+          .type("PTR")
+          .add(PTRData.create("ptr.denominator.io.")).build();
+      data[17][0] = ptr("denominator.io.", 3600, "ptr.denominator.io.");
+      data[17][1] = ResourceRecordSet.<PTRData>builder()
+          .name("denominator.io.")
+          .type("PTR")
+          .ttl(3600)
+          .add(PTRData.create("ptr.denominator.io.")).build();
+      data[18][0] = ptr("denominator.io.", Arrays.asList("ptr.denominator.io."));
+      data[18][1] = data[16][1];
+      data[19][0] = ptr("denominator.io.", 3600, Arrays.asList("ptr.denominator.io."));
+      data[19][1] = data[17][1];
+      data[20][0] = txt("denominator.io.", "\"made in sweden\"");
+      data[20][1] = ResourceRecordSet.<TXTData>builder()
+          .name("denominator.io.")
+          .type("TXT")
+          .add(TXTData.create("\"made in sweden\"")).build();
+      data[21][0] = txt("denominator.io.", 3600, "\"made in sweden\"");
+      data[21][1] = ResourceRecordSet.<TXTData>builder()
+          .name("denominator.io.")
+          .type("TXT")
+          .ttl(3600)
+          .add(TXTData.create("\"made in sweden\"")).build();
+      data[22][0] = txt("denominator.io.", Arrays.asList("\"made in sweden\""));
+      data[22][1] = data[20][1];
+      data[23][0] = txt("denominator.io.", 3600, Arrays.asList("\"made in sweden\""));
+      data[23][1] = data[21][1];
+      data[24][0] = spf("denominator.io.", "\"v=spf1 a mx -all\"");
+      data[24][1] = ResourceRecordSet.<SPFData>builder()
+          .name("denominator.io.")
+          .type("SPF")
+          .add(SPFData.create("\"v=spf1 a mx -all\"")).build();
+      data[25][0] = spf("denominator.io.", 3600, "\"v=spf1 a mx -all\"");
+      data[25][1] = ResourceRecordSet.<SPFData>builder()
+          .name("denominator.io.")
+          .type("SPF")
+          .ttl(3600)
+          .add(SPFData.create("\"v=spf1 a mx -all\"")).build();
+      data[26][0] = spf("denominator.io.", Arrays.asList("\"v=spf1 a mx -all\""));
+      data[26][1] = data[24][1];
+      data[27][0] = spf("denominator.io.", 3600, Arrays.asList("\"v=spf1 a mx -all\""));
+      data[27][1] = data[25][1];
+      data[28][0] = mx("denominator.io.", 3600, Arrays.asList("1 mx1.denominator.io."));
+      data[28][1] = ResourceRecordSet.<MXData>builder()
+          .name("denominator.io.")
+          .type("MX")
+          .ttl(3600)
+          .add(MXData.create(1, "mx1.denominator.io.")).build();
+      data[29][0] = srv("denominator.io.", 3600, Arrays.asList("0 1 80 srv.denominator.io."));
+      data[29][1] = ResourceRecordSet.<SRVData>builder()
+          .name("denominator.io.")
+          .type("SRV")
+          .ttl(3600)
+          .add(SRVData.builder().priority(0).weight(1).port(80).target("srv.denominator.io.")
+                   .build())
+          .build();
+      data[30][0] = ds("ds.denominator.io.", 3600, Arrays.asList("12345 1 1 B33F"));
+      data[30][1] = ResourceRecordSet.<DSData>builder()
+          .name("ds.denominator.io.")
+          .type("DS")
+          .ttl(3600)
+          .add(DSData.builder().keyTag(12345).algorithmId(1).digestId(1).digest("B33F").build())
+          .build();
+      data[31][0] = cert("www.denominator.io.", 3600, Arrays.asList("12345 1 1 B33F"));
+      data[31][1] = ResourceRecordSet.<CERTData>builder()
+          .name("www.denominator.io.")
+          .type("CERT")
+          .ttl(3600)
+          .add(CERTData.builder().certType(12345).keyTag(1).algorithm(1).cert("B33F").build())
+          .build();
+      data[32][0] =
+          naptr("phone.denominator.io.", 3600,
+                Arrays.asList("1 1 U E2U+sip !^.*$!sip:customer-service@example.com! ."));
+      data[32][1] = ResourceRecordSet.<NAPTRData>builder()
+          .name("phone.denominator.io.")
+          .type("NAPTR")
+          .ttl(3600)
+          .add(NAPTRData.builder().order(1).preference(1).flags("U").services("E2U+sip")
+                   .regexp("!^.*$!sip:customer-service@example.com!").replacement(".").build())
+          .build();
+      data[33][0] =
+          sshfp("server1.denominator.io.", 3600,
+                Arrays.asList("2 1 123456789abcdef67890123456789abcdef67890"));
+      data[33][1] = ResourceRecordSet.<SSHFPData>builder()
+          .name("server1.denominator.io.")
+          .type("SSHFP")
+          .ttl(3600)
+          .add(SSHFPData.createDSA("123456789abcdef67890123456789abcdef67890")).build();
+      data[34][0] =
+          loc("server1.denominator.io.", 3600,
+              Arrays.asList("37 48 48.892 S 144 57 57.502 E 26m 10m 100m 10m"));
+      data[34][1] = ResourceRecordSet.<LOCData>builder()
+          .name("server1.denominator.io.")
+          .type("LOC")
+          .ttl(3600)
+          .add(LOCData.builder().latitude("37 48 48.892 S").longitude("144 57 57.502 E")
+                   .altitude("26m").diameter("10m").hprecision("100m").vprecision("10m").build())
+          .build();
+      data[35][0] = tlsa("server1.denominator.io.", 3600, Arrays.asList("1 1 1 B33F"));
+      data[35][1] = ResourceRecordSet.<TLSAData>builder()
+          .name("server1.denominator.io.")
+          .type("TLSA")
+          .ttl(3600)
+          .add(TLSAData.builder().usage(1).selector(1).matchingType(1)
+                   .certificateAssociationData("B33F").build()).build();
+      data[36][0] =
+          loc("server1.denominator.io.", 3600, Arrays.asList("37 48 48.892 S 144 57 57.502 E 0m"));
+      data[36][1] = ResourceRecordSet.<LOCData>builder()
+          .name("server1.denominator.io.")
+          .type("LOC")
+          .ttl(3600)
+          .add(LOCData.builder().latitude("37 48 48.892 S").longitude("144 57 57.502 E").altitude("0m").build())
+          .build();
+      return Arrays.asList(data);
+    }
+
+    @Test
+    public void shortFormEqualsLongForm() throws IOException {
+      assertThat(shortForm).isEqualTo(longForm);
+      assertThat(shortForm.name()).isEqualTo(longForm.name());
+      assertThat(shortForm.type()).isEqualTo(longForm.type());
+      assertThat(shortForm.ttl()).isEqualTo(longForm.ttl());
+      assertThat(shortForm.records()).containsExactlyElementsOf(longForm.records());
+    }
   }
 }

--- a/model/src/test/java/denominator/model/ZoneTest.java
+++ b/model/src/test/java/denominator/model/ZoneTest.java
@@ -1,54 +1,43 @@
 package denominator.model;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNull;
-
-@Test
 public class ZoneTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void factoryMethodsWork() {
     Zone name = Zone.create("denominator.io.");
 
-    assertEquals(name.name(), "denominator.io.");
-    assertNull(name.id());
-    assertEquals(name, new Zone("denominator.io.", null));
-    assertEquals(name.hashCode(), new Zone("denominator.io.", null).hashCode());
-    assertEquals(name.toString(), "Zone [name=denominator.io.]");
+    assertThat(name.name()).isEqualTo("denominator.io.");
+    assertThat(name.id()).isNull();
+    assertThat(name).isEqualTo(new Zone("denominator.io.", null));
+    assertThat(name.hashCode()).isEqualTo(new Zone("denominator.io.", null).hashCode());
+    assertThat(name.toString()).isEqualTo("Zone [name=denominator.io.]");
 
     Zone id = Zone.create("denominator.io.", "ABCD");
 
-    assertEquals(id.name(), "denominator.io.");
-    assertEquals(id.id(), "ABCD");
-    assertEquals(id, new Zone("denominator.io.", "ABCD"));
-    assertEquals(id.hashCode(), new Zone("denominator.io.", "ABCD").hashCode());
-    assertEquals(id.toString(), "Zone [name=denominator.io., id=ABCD]");
+    assertThat(id.name()).isEqualTo("denominator.io.");
+    assertThat(id.id()).isEqualTo("ABCD");
+    assertThat(id).isEqualTo(new Zone("denominator.io.", "ABCD"));
+    assertThat(id.hashCode()).isEqualTo(new Zone("denominator.io.", "ABCD").hashCode());
+    assertThat(id.toString()).isEqualTo("Zone [name=denominator.io., id=ABCD]");
 
-    assertNotEquals(name, id);
-    assertNotEquals(name.hashCode(), id.hashCode());
+    assertThat(name).isNotEqualTo(id);
+    assertThat(name.hashCode()).isNotEqualTo(id.hashCode());
   }
 
-  public void serializeNaturallyAsJson() {
-    assertEquals(ResourceRecordSetsTest.gson.toJson(Zone.create("denominator.io.")),
-                 "{\"name\":\"denominator.io.\"}");
-    assertEquals(ResourceRecordSetsTest.gson.toJson(Zone.create("denominator.io.", "ABCD")),
-                 "{\"name\":\"denominator.io.\",\"id\":\"ABCD\"}");
-  }
-
-  public void deserializesNaturallyFromJson() throws IOException {
-    assertEquals(ResourceRecordSetsTest.gson.fromJson("{\"name\":\"denominator.io.\"}", Zone.class),
-                 Zone.create("denominator.io."));
-    assertEquals(ResourceRecordSetsTest.gson
-                     .fromJson("{\"name\":\"denominator.io.\",\"id\":\"ABCD\"}", Zone.class),
-                 Zone.create("denominator.io.", "ABCD"));
-  }
-
-  @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "name")
+  @Test
   public void nullNameNPEMessage() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+
     new Zone(null, "id");
   }
 }

--- a/model/src/test/java/denominator/model/profile/GeoTest.java
+++ b/model/src/test/java/denominator/model/profile/GeoTest.java
@@ -1,30 +1,28 @@
 package denominator.model.profile;
 
-import com.google.common.collect.ImmutableMultimap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import org.testng.annotations.Test;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-import java.io.IOException;
-
-import denominator.model.ResourceRecordSetsTest;
-
-import static org.testng.Assert.assertEquals;
-
-@Test
 public class GeoTest {
 
-  static Geo geo = Geo.create(ImmutableMultimap.<String, String>builder()//
-                                  .put("US", "US-VA")//
-                                  .put("US", "US-CA")//
-                                  .put("IM", "IM").build().asMap());
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
 
-  String asJson = "{\"regions\":{\"US\":[\"US-VA\",\"US-CA\"],\"IM\":[\"IM\"]}}";
+  @Test
+  public void immutableRegions() {
+    thrown.expect(UnsupportedOperationException.class);
 
-  public void serializeNaturallyAsJson() {
-    assertEquals(ResourceRecordSetsTest.gson.toJson(geo), asJson);
-  }
+    Map<String, Collection<String>> regions = new LinkedHashMap<String, Collection<String>>();
+    regions.put("US", Arrays.asList("US-VA", "US-CA"));
 
-  public void deserializesNaturallyFromJson() throws IOException {
-    assertEquals(ResourceRecordSetsTest.gson.fromJson(asJson, Geo.class), geo);
+    Geo geo = Geo.create(regions);
+
+    geo.regions().remove("US");
   }
 }

--- a/model/src/test/java/denominator/model/profile/WeightedTest.java
+++ b/model/src/test/java/denominator/model/profile/WeightedTest.java
@@ -1,38 +1,19 @@
 package denominator.model.profile;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
-
-import denominator.model.ResourceRecordSet;
-import denominator.model.ResourceRecordSetsTest;
-import denominator.model.rdata.AData;
-
-import static org.testng.Assert.assertEquals;
-
-@Test
 public class WeightedTest {
 
-  static Weighted weighted = Weighted.create(2);
-  static ResourceRecordSet<AData> weightedRRS = ResourceRecordSet.<AData>builder()//
-      .name("www.denominator.io.")//
-      .type("A")//
-      .qualifier("US-East")//
-      .ttl(3600)//
-      .add(AData.create("1.1.1.1"))//
-      .weighted(Weighted.create(2)).build();
-  String asJson = "{\"weight\":2}";
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "weight must be positive")
+  @Test
   public void testInvalidWeight() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("weight must be positive");
+
     Weighted.create(-1);
-  }
-
-  public void serializeNaturallyAsJson() {
-    assertEquals(ResourceRecordSetsTest.gson.toJson(weighted), asJson);
-  }
-
-  public void deserializesNaturallyFromJson() throws IOException {
-    assertEquals(ResourceRecordSetsTest.gson.fromJson(asJson, Weighted.class), weighted);
   }
 }

--- a/model/src/test/java/denominator/model/rdata/AAAADataTest.java
+++ b/model/src/test/java/denominator/model/rdata/AAAADataTest.java
@@ -1,22 +1,33 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.aaaa;
 
-@Test
 public class AAAADataTest {
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*should be a ipv6 address.*")
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testBadIPv4() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("should be a ipv6 address");
+
     aaaa("www.denominator.io.", "192.0.2.1");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*should be a ipv6 address.*")
+  @Test
   public void testNoIP() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("should be a ipv6 address");
+
     aaaa("www.denominator.io.", "");
   }
 
+  @Test
   public void testGoodIPv6() {
     aaaa("www.denominator.io.", "2001:db8:1cfe:face:b00c::3");
   }

--- a/model/src/test/java/denominator/model/rdata/ADataTest.java
+++ b/model/src/test/java/denominator/model/rdata/ADataTest.java
@@ -1,22 +1,34 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.a;
 
-@Test
 public class ADataTest {
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*should be a ipv4 address.*")
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testBadIPv6() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("should be a ipv4 address");
+
     a("www.denominator.io.", "2001:db8:1cfe:face:b00c::3");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*should be a ipv4 address.*")
+  @Test
   public void testNoIP() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("should be a ipv4 address");
+
     a("www.denominator.io.", "");
   }
 
+  @Test
   public void testGoodIPv4() {
     a("www.denominator.io.", "192.0.2.1");
   }

--- a/model/src/test/java/denominator/model/rdata/CERTDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/CERTDataTest.java
@@ -1,19 +1,26 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.cert;
 
-@Test
 public class CERTDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     cert("www.denominator.io.", "12345 1 1 B33F");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*record must have exactly four parts.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("record must have exactly four parts");
+
     cert("www.denominator.io.", "12345 1 1");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/CNAMEDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/CNAMEDataTest.java
@@ -1,15 +1,21 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.cname;
 
-@Test
 public class CNAMEDataTest {
 
-  @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "record")
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testNullTarget() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("record");
+
     cname("www.denominator.io.", (String) null);
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/DSDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/DSDataTest.java
@@ -1,19 +1,26 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.ds;
 
-@Test
 public class DSDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     ds("www.denominator.io.", "12345 1 1 B33F");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*record must have exactly four parts.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("record must have exactly four parts");
+
     ds("www.denominator.io.", "12345 1 1");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/LOCDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/LOCDataTest.java
@@ -1,55 +1,59 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.loc;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Test
 public class LOCDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     loc("www.denominator.io.", "37 48 48.892 S 144 57 57.502 E 26m 10m 100m 10m");
   }
 
+  @Test
   public void testSimpleRecord() {
     loc("www.denominator.io.", "37 48 48.892 S 144 57 57.502 E 0m");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*could not find longitude.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("could not find longitude");
+
     loc("www.denominator.io.", "37 48 48.892 S");
   }
 
+  @Test
   public void testSimple() {
     LOCData data = LOCData.create("37 48 48.892 S 144 57 57.502 E 0m");
-    assertEquals(data.latitude(), "37 48 48.892 S");
-    assertEquals(data.longitude(), "144 57 57.502 E");
-    assertEquals(data.altitude(), "0m");
-    assertNull(data.diameter());
-    assertNull(data.hprecision());
-    assertNull(data.vprecision());
+    assertThat(data.latitude()).isEqualTo("37 48 48.892 S");
+    assertThat(data.longitude()).isEqualTo("144 57 57.502 E");
+    assertThat(data.altitude()).isEqualTo("0m");
   }
 
+  @Test
   public void testMinimal() {
     LOCData data = LOCData.create("37 S 144 E 0m");
-    assertEquals(data.latitude(), "37 S");
-    assertEquals(data.longitude(), "144 E");
-    assertEquals(data.altitude(), "0m");
-    assertNull(data.diameter());
-    assertNull(data.hprecision());
-    assertNull(data.vprecision());
+    assertThat(data.latitude()).isEqualTo("37 S");
+    assertThat(data.longitude()).isEqualTo("144 E");
+    assertThat(data.altitude()).isEqualTo("0m");
   }
 
+  @Test
   public void testFull() {
     LOCData data = LOCData.create("37 48 48.892 S 144 57 57.502 E 26m 1m 2m 3m");
-    assertEquals(data.latitude(), "37 48 48.892 S");
-    assertEquals(data.longitude(), "144 57 57.502 E");
-    assertEquals(data.altitude(), "26m");
-    assertEquals(data.diameter(), "1m");
-    assertEquals(data.hprecision(), "2m");
-    assertEquals(data.vprecision(), "3m");
+    assertThat(data.latitude()).isEqualTo("37 48 48.892 S");
+    assertThat(data.longitude()).isEqualTo("144 57 57.502 E");
+    assertThat(data.altitude()).isEqualTo("26m");
+    assertThat(data.diameter()).isEqualTo("1m");
+    assertThat(data.hprecision()).isEqualTo("2m");
+    assertThat(data.vprecision()).isEqualTo("3m");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/MXDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/MXDataTest.java
@@ -1,19 +1,26 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.mx;
 
-@Test
 public class MXDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     mx("www.denominator.io.", "1 mx1.denominator.io.");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*record must have exactly two parts.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("record must have exactly two parts");
+
     mx("www.denominator.io.", "1");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/NAPTRDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/NAPTRDataTest.java
@@ -1,19 +1,26 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.naptr;
 
-@Test
 public class NAPTRDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     naptr("www.denominator.io.", "1 1 U E2U+sip !^.*$!sip:customer-service@example.com! .");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*record must have exactly six parts.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("record must have exactly six parts");
+
     naptr("www.denominator.io.", "1 1 U E2U+sip");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/NSDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/NSDataTest.java
@@ -1,15 +1,21 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.ns;
 
-@Test
 public class NSDataTest {
 
-  @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "record")
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testNullTargetNS() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("record");
+
     ns("www.denominator.io.", (String) null);
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/SPFDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/SPFDataTest.java
@@ -1,18 +1,23 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.spf;
 
-@Test
 public class SPFDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testSinglePart() {
     spf("www.denominator.io.", "v=spf1 a mx -all");
   }
 
+  @Test
   public void testMultiPart() {
     spf("www.denominator.io.", "\"v=spf1 a mx -all\" \"v=spf1 aaaa mx -all\"");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/SRVDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/SRVDataTest.java
@@ -1,19 +1,26 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.srv;
 
-@Test
 public class SRVDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     srv("www.denominator.io.", "0 1 80 www.foo.com.");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*record must have exactly four parts.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("record must have exactly four parts");
+
     srv("www.denominator.io.", "0 1 80");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/SSHFPDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/SSHFPDataTest.java
@@ -1,19 +1,26 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.sshfp;
 
-@Test
 public class SSHFPDataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     sshfp("www.denominator.io.", "1 1 B33F");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*record must have exactly three parts.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("record must have exactly three parts");
+
     sshfp("www.denominator.io.", "1");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/TLSADataTest.java
+++ b/model/src/test/java/denominator/model/rdata/TLSADataTest.java
@@ -1,19 +1,26 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static denominator.model.ResourceRecordSets.tlsa;
 
-@Test
 public class TLSADataTest {
 
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
   public void testGoodRecord() {
     tlsa("www.denominator.io.", "1 1 1 B33F");
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*record must have exactly four parts.*")
+  @Test
   public void testMissingParts() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("record must have exactly four parts");
+
     tlsa("www.denominator.io.", "1 1 1");
   }
-
 }

--- a/model/src/test/java/denominator/model/rdata/TXTDataTest.java
+++ b/model/src/test/java/denominator/model/rdata/TXTDataTest.java
@@ -1,18 +1,18 @@
 package denominator.model.rdata;
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 import static denominator.model.ResourceRecordSets.txt;
 
-@Test
 public class TXTDataTest {
 
+  @Test
   public void testSinglePart() {
     txt("www.denominator.io.", "foo");
   }
 
+  @Test
   public void testMultiPart() {
     txt("www.denominator.io.", "\"foo bar\"");
   }
-
 }


### PR DESCRIPTION
Also removes json dependency from tests. We don't have
means to enforce all json mappers act correctly. This
removes the distraction of doing so only in Gson.