### PR TITLE
Removes java.beans.ConstructorProperties from value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add support for DiscoveryDNS (http://www.discoverydns.com)
 * Updates to feign 7.2.1 and dagger 1.2.2
 * Reformats code according to [Google Java Style](https://google-styleguide.googlecode.com/svn/trunk/javaguide.html)
+* Removes java.beans.ConstructorProperties from value types
 
 ### Version 4.3.5
 * Support for more exotic RRtypes added

--- a/core/src/main/java/denominator/Provider.java
+++ b/core/src/main/java/denominator/Provider.java
@@ -55,14 +55,17 @@ public interface Provider {
   Set<String> basicRecordTypes();
 
   /**
-   * Maps a {@link ResourceRecordSet#profiles() profile} {@code type} value to a collection of
-   * supported record types. If empty, the provider does not support advanced records. <br> For
-   * example:
+   * Maps a profile value to a collection of supported record types. If empty, the provider does not
+   * support advanced records.
+   *
+   * <p/> For example:
    *
    * <pre>
    * { "geo" : ["A", "AAAA", "CNAME", "HINFO", "MX", "PTR", "RP", "SRV", "TXT", "NAPTR"],
    *   "weighted" : ["A", "AAAA", "CNAME"] }
    * </pre>
+   * 
+   * @see denominator.model.profile 
    */
   Map<String, Collection<String>> profileToRecordTypes();
 

--- a/core/src/main/java/denominator/Providers.java
+++ b/core/src/main/java/denominator/Providers.java
@@ -37,7 +37,7 @@ public final class Providers {
    *
    * @param providerName corresponds to {@link Provider#name()}. ex {@code ultradns}
    * @throws IllegalArgumentException if the providerName is not configured
-   * @see {@link #list()}
+   * @see #list()
    */
   public static Provider getByName(String providerName) {
     checkNotNull(providerName, "providerName");

--- a/core/src/main/java/denominator/ResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/ResourceRecordSetApi.java
@@ -7,8 +7,8 @@ import denominator.model.ResourceRecordSet;
 public interface ResourceRecordSetApi extends Iterable<ResourceRecordSet<?>> {
 
   /**
-   * Iterates across all basic record sets in the zone (those with no {@link
-   * ResourceRecordSet#profiles() profile}). Implementations are lazy when possible.
+   * Iterates across all basic record sets in the zone (those with no profile). Implementations are
+   * lazy when possible.
    *
    * @return iterator which is lazy where possible
    * @throws IllegalArgumentException if the zone {@code idOrName} is not found.

--- a/model/src/main/java/denominator/model/ResourceRecordSet.java
+++ b/model/src/main/java/denominator/model/ResourceRecordSet.java
@@ -1,6 +1,5 @@
 package denominator.model;
 
-import java.beans.ConstructorProperties;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,7 +34,6 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
   private final Geo geo;
   private final Weighted weighted;
 
-  @ConstructorProperties({"name", "type", "qualifier", "ttl", "records", "geo", "weighted"})
   ResourceRecordSet(String name, String type, String qualifier, Integer ttl, List<D> records,
                     Geo geo, Weighted weighted) {
     checkArgument(checkNotNull(name, "name").length() <= 255, "Name must be <= 255 characters");

--- a/model/src/main/java/denominator/model/Zone.java
+++ b/model/src/main/java/denominator/model/Zone.java
@@ -1,7 +1,5 @@
 package denominator.model;
 
-import java.beans.ConstructorProperties;
-
 import static denominator.common.Preconditions.checkNotNull;
 import static denominator.common.Util.equal;
 
@@ -16,7 +14,6 @@ public class Zone {
   private final String name;
   private final String id;
 
-  @ConstructorProperties({"name", "id"})
   Zone(String name, String id) {
     this.name = checkNotNull(name, "name");
     this.id = id;

--- a/model/src/main/java/denominator/model/profile/Geo.java
+++ b/model/src/main/java/denominator/model/profile/Geo.java
@@ -1,6 +1,5 @@
 package denominator.model.profile;
 
-import java.beans.ConstructorProperties;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -20,7 +19,6 @@ public class Geo {
 
   private final Map<String, Collection<String>> regions;
 
-  @ConstructorProperties({"regions"})
   private Geo(Map<String, Collection<String>> regions) {
     this.regions = Collections.unmodifiableMap(checkNotNull(regions, "regions"));
   }

--- a/model/src/main/java/denominator/model/profile/Weighted.java
+++ b/model/src/main/java/denominator/model/profile/Weighted.java
@@ -1,7 +1,5 @@
 package denominator.model.profile;
 
-import java.beans.ConstructorProperties;
-
 import static denominator.common.Preconditions.checkArgument;
 
 /**
@@ -19,7 +17,6 @@ public class Weighted {
 
   private final int weight;
 
-  @ConstructorProperties({"weight"})
   private Weighted(int weight) {
     checkArgument(weight >= 0, "weight must be positive");
     this.weight = weight;

--- a/model/src/main/java/denominator/model/rdata/AAAAData.java
+++ b/model/src/main/java/denominator/model/rdata/AAAAData.java
@@ -1,6 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -17,11 +16,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc3596.txt">RFC 3596</a>
  */
-public class AAAAData extends LinkedHashMap<String, Object> {
+public final class AAAAData extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties("address")
   AAAAData(String address) {
     checkNotNull(address, "address");
     checkArgument(address.indexOf(':') != -1, "%s should be a ipv6 address", address);

--- a/model/src/main/java/denominator/model/rdata/AData.java
+++ b/model/src/main/java/denominator/model/rdata/AData.java
@@ -1,6 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -17,11 +16,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class AData extends LinkedHashMap<String, Object> {
+public final class AData extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties("address")
   AData(String address) {
     checkNotNull(address, "address");
     checkArgument(address.indexOf('.') != -1, "%s should be a ipv4 address", address);

--- a/model/src/main/java/denominator/model/rdata/CERTData.java
+++ b/model/src/main/java/denominator/model/rdata/CERTData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -22,11 +20,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc4398.txt">RFC 4398</a>
  */
-public class CERTData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class CERTData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"certType", "keyTag", "algorithm", "cert"})
   CERTData(int certType, int keyTag, int algorithm, String cert) {
     checkArgument(certType <= 0xFFFF, "certType must be 0-65535");
     checkArgument(keyTag <= 0xFFFF, "keyTag must be 0-65535");

--- a/model/src/main/java/denominator/model/rdata/CNAMEData.java
+++ b/model/src/main/java/denominator/model/rdata/CNAMEData.java
@@ -1,6 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import static denominator.common.Preconditions.checkNotNull;
@@ -16,11 +15,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class CNAMEData extends LinkedHashMap<String, Object> {
+public final class CNAMEData extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties("cname")
   CNAMEData(String cname) {
     put("cname", checkNotNull(cname, "cname"));
   }

--- a/model/src/main/java/denominator/model/rdata/DSData.java
+++ b/model/src/main/java/denominator/model/rdata/DSData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -22,11 +20,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc3658.txt">RFC 3658</a>
  */
-public class DSData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class DSData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"keyTag", "algorithmId", "digestId", "digest"})
   DSData(int keyTag, int algorithmId, int digestId, String digest) {
     checkArgument(keyTag <= 0xFFFF, "keyTag must be 0-65535");
     checkArgument(algorithmId <= 0xFF, "algorithmId must be 0-255");

--- a/model/src/main/java/denominator/model/rdata/LOCData.java
+++ b/model/src/main/java/denominator/model/rdata/LOCData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -24,12 +22,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1876.txt">RFC 1876</a>
  */
-public class LOCData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class LOCData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"latitude", "longitude", "altitude", "diameter", "hprecision",
-                          "vprecision"})
   LOCData(String latitude, String longitude, String altitude, String diameter, String hprecision,
           String vprecision) {
     checkNotNull(latitude, "latitude");

--- a/model/src/main/java/denominator/model/rdata/MXData.java
+++ b/model/src/main/java/denominator/model/rdata/MXData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -18,11 +16,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class MXData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class MXData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"preference", "exchange"})
   MXData(int preference, String exchange) {
     checkArgument(preference <= 0xFFFF, "preference must be 65535 or less");
     checkNotNull(exchange, "exchange");

--- a/model/src/main/java/denominator/model/rdata/NAPTRData.java
+++ b/model/src/main/java/denominator/model/rdata/NAPTRData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -24,11 +22,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc3403.txt">RFC 3403</a>
  */
-public class NAPTRData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class NAPTRData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"order", "preference", "flags", "services", "regexp", "replacement"})
   NAPTRData(int order, int preference, String flags, String services, String regexp,
             String replacement) {
     checkArgument(order <= 0xFFFF, "order must be 0-65535");

--- a/model/src/main/java/denominator/model/rdata/NSData.java
+++ b/model/src/main/java/denominator/model/rdata/NSData.java
@@ -1,6 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import static denominator.common.Preconditions.checkNotNull;
@@ -16,11 +15,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class NSData extends LinkedHashMap<String, Object> {
+public final class NSData extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties("nsdname")
   NSData(String nsdname) {
     put("nsdname", checkNotNull(nsdname, "nsdname"));
   }

--- a/model/src/main/java/denominator/model/rdata/PTRData.java
+++ b/model/src/main/java/denominator/model/rdata/PTRData.java
@@ -1,6 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import static denominator.common.Preconditions.checkNotNull;
@@ -16,11 +15,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class PTRData extends LinkedHashMap<String, Object> {
+public final class PTRData extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties("ptrdname")
   PTRData(String ptrdname) {
     put("ptrdname", checkNotNull(ptrdname, "ptrdname"));
   }

--- a/model/src/main/java/denominator/model/rdata/SOAData.java
+++ b/model/src/main/java/denominator/model/rdata/SOAData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -25,11 +23,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class SOAData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class SOAData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"mname", "rname", "serial", "refresh", "retry", "expire", "minimum"})
   SOAData(String mname, String rname, int serial, int refresh, int retry, int expire, int minimum) {
     checkNotNull(mname, "mname");
     checkNotNull(rname, "rname of %s", mname);

--- a/model/src/main/java/denominator/model/rdata/SPFData.java
+++ b/model/src/main/java/denominator/model/rdata/SPFData.java
@@ -1,6 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -19,11 +18,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://tools.ietf.org/html/rfc4408#section-3.1.1">RFC 4408</a>
  */
-public class SPFData extends LinkedHashMap<String, Object> {
+public final class SPFData extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties("txtdata")
   SPFData(String txtdata) {
     checkArgument(checkNotNull(txtdata, "txtdata").length() <= 65535,
                   "txt data is limited to 65535");

--- a/model/src/main/java/denominator/model/rdata/SRVData.java
+++ b/model/src/main/java/denominator/model/rdata/SRVData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -22,11 +20,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc2782.txt">RFC 2782</a>
  */
-public class SRVData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class SRVData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"priority", "weight", "port", "target"})
   SRVData(int priority, int weight, int port, String target) {
     checkArgument(priority <= 0xFFFF, "priority must be 0-65535");
     checkArgument(weight <= 0xFFFF, "weight must be 0-65535");

--- a/model/src/main/java/denominator/model/rdata/SSHFPData.java
+++ b/model/src/main/java/denominator/model/rdata/SSHFPData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -21,11 +19,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.rfc-editor.org/rfc/rfc4255.txt">RFC 4255</a>
  */
-public class SSHFPData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class SSHFPData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"algorithm", "fptype", "fingerprint"})
   SSHFPData(int algorithm, int fptype, String fingerprint) {
     checkArgument(algorithm >= 0, "algorithm of %s must be unsigned", fingerprint);
     checkArgument(fptype >= 0, "fptype of %s must be unsigned", fingerprint);

--- a/model/src/main/java/denominator/model/rdata/TLSAData.java
+++ b/model/src/main/java/denominator/model/rdata/TLSAData.java
@@ -1,7 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
-
 import denominator.model.NumbersAreUnsignedIntsLinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -23,11 +21,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc6698.txt">RFC 6698</a>
  */
-public class TLSAData extends NumbersAreUnsignedIntsLinkedHashMap {
+public final class TLSAData extends NumbersAreUnsignedIntsLinkedHashMap {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"usage", "selector", "matchingType", "certificateAssociationData"})
   TLSAData(int usage, int selector, int matchingType, String certificateAssociationData) {
     checkArgument(usage <= 0xFF, "usage must be 0-255");
     checkArgument(selector <= 0xFF, "selector must be 0-255");

--- a/model/src/main/java/denominator/model/rdata/TXTData.java
+++ b/model/src/main/java/denominator/model/rdata/TXTData.java
@@ -1,6 +1,5 @@
 package denominator.model.rdata;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import static denominator.common.Preconditions.checkArgument;
@@ -17,11 +16,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
-public class TXTData extends LinkedHashMap<String, Object> {
+public final class TXTData extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties("txtdata")
   TXTData(String txtdata) {
     checkArgument(checkNotNull(txtdata, "txtdata").length() <= 65535,
                   "txt data is limited to 65535");

--- a/model/src/main/java/denominator/model/rdata/package-info.java
+++ b/model/src/main/java/denominator/model/rdata/package-info.java
@@ -1,7 +1,4 @@
 /**
  * DNS record data ({@code rdata}) in <a href="http://tools.ietf.org/html/rfc1035">Master File Format</a> are represented as {@code Map<String, Object>}, preferring values to be unsigned integers or {@code String}.
- *
- * <br><br><b>Implementation Notes</b><br>
- * {@link java.beans.ConstructorProperties} are assigned to constructors to help deserializing from json or otherwise where parameter names are required.  This approach avoids skipping constructor validation.
  */
 package denominator.model.rdata;

--- a/route53/src/main/java/denominator/route53/AliasTarget.java
+++ b/route53/src/main/java/denominator/route53/AliasTarget.java
@@ -1,6 +1,5 @@
 package denominator.route53;
 
-import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 
 import denominator.model.ResourceRecordSet;
@@ -24,11 +23,10 @@ import static denominator.common.Preconditions.checkNotNull;
  *
  * @since 4.2
  */
-public class AliasTarget extends LinkedHashMap<String, Object> {
+public final class AliasTarget extends LinkedHashMap<String, Object> {
 
   private static final long serialVersionUID = 1L;
 
-  @ConstructorProperties({"HostedZoneId", "DNSName"})
   AliasTarget(String hostedZoneId, String dnsName) {
     put("HostedZoneId", checkNotNull(hostedZoneId, "HostedZoneId"));
     put("DNSName", checkNotNull(dnsName, "DNSName"));


### PR DESCRIPTION
java.beans.ConstructorProperties adds maintenance to the project with
questionable value and no tests.