### PR TITLE
Map Credentials does not work some times

### DIFF
--- a/clouddns/src/main/java/denominator/clouddns/InvalidatableAuthProvider.java
+++ b/clouddns/src/main/java/denominator/clouddns/InvalidatableAuthProvider.java
@@ -81,7 +81,7 @@ class InvalidatableAuthProvider implements Provider<TokenIdAndPublicURL> {
       }
       return identityService.passwordAuth(url, username, mapCreds.get("password"));
     }
-    List<Object> listCreds = ListCredentials.asList(currentCreds);
+    List<Object> listCreds = ListCredentials.asList(currentCreds, provider);
     return identityService
         .apiKeyAuth(url, listCreds.get(0).toString(), listCreds.get(1).toString());
   }

--- a/designate/src/main/java/denominator/designate/InvalidatableAuthProvider.java
+++ b/designate/src/main/java/denominator/designate/InvalidatableAuthProvider.java
@@ -70,7 +70,7 @@ class InvalidatableAuthProvider implements Provider<TokenIdAndPublicURL> {
 
   private TokenIdAndPublicURL auth(Credentials currentCreds) {
     URI url = URI.create(lastKeystoneUrl);
-    List<Object> listCreds = ListCredentials.asList(currentCreds);
+    List<Object> listCreds = ListCredentials.asList(currentCreds, provider);
     return identityService
         .passwordAuth(url, listCreds.get(0).toString(), listCreds.get(1).toString(), listCreds
             .get(2).toString());

--- a/discoverydns/src/main/java/denominator/discoverydns/DiscoveryDNSProvider.java
+++ b/discoverydns/src/main/java/denominator/discoverydns/DiscoveryDNSProvider.java
@@ -138,7 +138,7 @@ public class DiscoveryDNSProvider extends BasicProvider {
     // TODO: this doesn't allow for dynamic credential changes.
     @Provides
     SSLSocketFactory sslSocketFactory(Provider<Credentials> credentials) {
-      List<Object> creds = ListCredentials.asList(credentials.get());
+      List<Object> creds = ListCredentials.asList(credentials.get(), new DiscoveryDNSProvider());
       String cert = creds.get(0).toString();
       String key = creds.get(1).toString();
 

--- a/dynect/src/main/java/denominator/dynect/InvalidatableTokenProvider.java
+++ b/dynect/src/main/java/denominator/dynect/InvalidatableTokenProvider.java
@@ -83,7 +83,7 @@ class InvalidatableTokenProvider implements Provider<String>, CheckConnection {
   }
 
   private String auth(Credentials currentCreds) {
-    List<Object> listCreds = ListCredentials.asList(currentCreds);
+    List<Object> listCreds = ListCredentials.asList(currentCreds, provider);
     return session.login(listCreds.get(0).toString(), listCreds.get(1).toString(),
                          listCreds.get(2).toString()).data;
   }

--- a/route53/src/main/java/denominator/route53/InvalidatableAuthenticationHeadersProvider.java
+++ b/route53/src/main/java/denominator/route53/InvalidatableAuthenticationHeadersProvider.java
@@ -66,7 +66,7 @@ public class InvalidatableAuthenticationHeadersProvider {
     }
 
     Map<String, String> auth(Credentials currentCreds) {
-        List<Object> creds = ListCredentials.asList(currentCreds);
+        List<Object> creds = ListCredentials.asList(currentCreds, new Route53Provider());
         String accessKey = creds.get(0).toString();
         String secretKey = creds.get(1).toString();
         String token = null;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSTarget.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSTarget.java
@@ -59,7 +59,7 @@ class UltraDNSTarget implements Target<UltraDNS> {
   @Override
   public Request apply(RequestTemplate in) {
     in.insert(0, url());
-    List<Object> creds = ListCredentials.asList(credentials.get());
+    List<Object> creds = ListCredentials.asList(credentials.get(), provider);
     in.body(format(SOAP_TEMPLATE, creds.get(0).toString(), creds.get(1).toString(),
                    new String(in.body(), UTF_8)));
     in.header("Host", URI.create(in.url()).getHost());


### PR DESCRIPTION
`MapCredenitals` are converted to `List<Object>` by providers using:

````java
ListCredentials.asList(credentials)
````
current implementation of this method, simply takes returns `new ArrayList<Object>(map.values())`

note that, in map order of entries is not defined. so credential parameters might be in wrong order;

you can verify the same by following test:
````java
        Map<String, String> map = new LinkedHashMap<String, String>();
        map.put("secretKey", "ZZZZZZZZZZZZZZ");
        map.put("accessKey", "AAAAAA");

        System.out.println(map.values());
        Credentials credentials = Credentials.MapCredentials.from(map);
        DNSApiManager manager = Denominator.create("route53", CredentialsConfiguration.credentials(credentials));
        ZoneApi zones = manager.api().zones();
        for(Zone zone: zones)
            System.out.println(zone);
````
the above code fails to list zones. but if `accessKey` is inserted before `secretKey`, then it works

I fixed the issue in my fork branch `map-credentials`:
https://github.com/santhosh-tekuri/denominator/tree/map-credentials

please evaluate the fix and merge