### PR TITLE
Removes dependency on sun.misc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Updates to feign 7.2.1 and dagger 1.2.2
 * Reformats code according to [Google Java Style](https://google-styleguide.googlecode.com/svn/trunk/javaguide.html)
 * Removes java.beans.ConstructorProperties from value types
+* Removes dependency on sun.misc
 
 ### Version 4.3.5
 * Support for more exotic RRtypes added

--- a/discoverydns/src/main/java/denominator/discoverydns/Pems.java
+++ b/discoverydns/src/main/java/denominator/discoverydns/Pems.java
@@ -1,7 +1,5 @@
 package denominator.discoverydns;
 
-import sun.misc.BASE64Decoder;
-
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -95,7 +93,7 @@ final class Pems {
           throw new IOException(END + " not found");
         }
 
-        return new BASE64Decoder().decodeBuffer(buf.toString());
+        return base64(buf.toString());
       }
 
       return null;
@@ -323,5 +321,93 @@ final class Pems {
 
       return new BigInteger(value);
     }
+  }
+
+  /**
+   * copied from <a href="https://github.com/square/okio/blob/master/okio/src/main/java/okio/Base64.java">okio</a>
+   *
+   * @author Alexander Y. Kleymenov
+   */
+  public static byte[] base64(String in) {
+    // Ignore trailing '=' padding and whitespace from the input.
+    int limit = in.length();
+    for (; limit > 0; limit--) {
+      char c = in.charAt(limit - 1);
+      if (c != '=' && c != '\n' && c != '\r' && c != ' ' && c != '\t') {
+        break;
+      }
+    }
+
+    // If the input includes whitespace, this output array will be longer than necessary.
+    byte[] out = new byte[(int) (limit * 6L / 8L)];
+    int outCount = 0;
+    int inCount = 0;
+
+    int word = 0;
+    for (int pos = 0; pos < limit; pos++) {
+      char c = in.charAt(pos);
+
+      int bits;
+      if (c >= 'A' && c <= 'Z') {
+        // char ASCII value
+        //  A    65    0
+        //  Z    90    25 (ASCII - 65)
+        bits = c - 65;
+      } else if (c >= 'a' && c <= 'z') {
+        // char ASCII value
+        //  a    97    26
+        //  z    122   51 (ASCII - 71)
+        bits = c - 71;
+      } else if (c >= '0' && c <= '9') {
+        // char ASCII value
+        //  0    48    52
+        //  9    57    61 (ASCII + 4)
+        bits = c + 4;
+      } else if (c == '+') {
+        bits = 62;
+      } else if (c == '/') {
+        bits = 63;
+      } else if (c == '\n' || c == '\r' || c == ' ' || c == '\t') {
+        continue;
+      } else {
+        return null;
+      }
+
+      // Append this char's 6 bits to the word.
+      word = (word << 6) | (byte) bits;
+
+      // For every 4 chars of input, we accumulate 24 bits of output. Emit 3 bytes.
+      inCount++;
+      if (inCount % 4 == 0) {
+        out[outCount++] = (byte) (word >> 16);
+        out[outCount++] = (byte) (word >> 8);
+        out[outCount++] = (byte) word;
+      }
+    }
+
+    int lastWordChars = inCount % 4;
+    if (lastWordChars == 1) {
+      // We read 1 char followed by "===". But 6 bits is a truncated byte! Fail.
+      return null;
+    } else if (lastWordChars == 2) {
+      // We read 2 chars followed by "==". Emit 1 byte with 8 of those 12 bits.
+      word = word << 12;
+      out[outCount++] = (byte) (word >> 16);
+    } else if (lastWordChars == 3) {
+      // We read 3 chars, followed by "=". Emit 2 bytes for 16 of those 18 bits.
+      word = word << 6;
+      out[outCount++] = (byte) (word >> 16);
+      out[outCount++] = (byte) (word >> 8);
+    }
+
+    // If we sized our out array perfectly, we're done.
+    if (outCount == out.length) {
+      return out;
+    }
+
+    // Copy the decoded bytes to a new, right-sized array.
+    byte[] prefix = new byte[outCount];
+    System.arraycopy(out, 0, prefix, 0, outCount);
+    return prefix;
   }
 }


### PR DESCRIPTION
Before, we were using sun.misc for Base64 codec. This is not a good
practice, and also interferes with Android support. This change employs
a local copy of Base64 from okio, which is known to work in both Java
and Android platforms.

closes #292