### PR TITLE
Dynect Provider does not returns type-safe rdata

### DIFF
--- a/dynect/src/main/java/denominator/dynect/DynECTGeoResourceRecordSetApi.java
+++ b/dynect/src/main/java/denominator/dynect/DynECTGeoResourceRecordSetApi.java
@@ -175,7 +175,7 @@ public final class DynECTGeoResourceRecordSetApi implements GeoResourceRecordSet
         }
 
         for (int i = 0; i < entry.getValue().size(); i++) {
-          rrset.add(ToRecord.toRData(entry.getValue().get(i).getAsJsonObject()));
+          rrset.add(ToRecord.toRData(type, entry.getValue().get(i).getAsJsonObject()));
         }
         rrsets.add(rrset);
       }

--- a/dynect/src/main/java/denominator/dynect/ToRecord.java
+++ b/dynect/src/main/java/denominator/dynect/ToRecord.java
@@ -9,22 +9,69 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import denominator.dynect.DynECT.Record;
+import denominator.model.rdata.AAAAData;
+import denominator.model.rdata.AData;
+import denominator.model.rdata.CNAMEData;
+import denominator.model.rdata.MXData;
+import denominator.model.rdata.NSData;
+import denominator.model.rdata.PTRData;
+import denominator.model.rdata.SOAData;
+import denominator.model.rdata.SPFData;
+import denominator.model.rdata.SRVData;
+import denominator.model.rdata.TXTData;
 
 enum ToRecord {
   INSTANCE;
 
-  static Map<String, Object> toRData(JsonObject rdata) {
-    Map<String, Object> builder = new LinkedHashMap<String, Object>();
-    for (Entry<String, JsonElement> entry : rdata.entrySet()) {
-      // values are never nested
-      JsonPrimitive value = entry.getValue().getAsJsonPrimitive();
-      if (value.isNumber()) {
-        builder.put(entry.getKey(), value.getAsInt());
-      } else {
-        builder.put(entry.getKey(), value.getAsString());
+  static Map<String, Object> toRData(String type, JsonObject rdata) {
+    if ("A".equals(type)) {
+      return AData.create(rdata.get("address").getAsString());
+    } else if ("AAAA".equals(type)) {
+      return AAAAData.create(rdata.get("address").getAsString());
+    } else if ("CNAME".equals(type)) {
+      return CNAMEData.create(rdata.get("cname").getAsString());
+    } else if ("MX".equals(type)) {
+      int preference = rdata.get("preference").getAsInt();
+      String exchange = rdata.get("exchange").getAsString();
+      return MXData.create(preference, exchange);
+    } else if ("NS".equals(type)) {
+      return NSData.create(rdata.get("nsdname").getAsString());
+    } else if ("PTR".equals(type)) {
+      return PTRData.create(rdata.get("ptrdname").getAsString());
+    } else if ("SOA".equals(type)) {
+      return SOAData.builder()
+                 .rname(rdata.get("rname").getAsString())
+                 .retry(rdata.get("retry").getAsInt())
+                 .mname(rdata.get("mname").getAsString())
+                 .minimum(rdata.get("minimum").getAsInt())
+                 .refresh(rdata.get("refresh").getAsInt())
+                 .expire(rdata.get("expire").getAsInt())
+                 .serial(rdata.get("serial").getAsInt())
+                 .build();
+    } else if ("SPF".equals(type)) {
+      return SPFData.create(rdata.get("txtdata").getAsString());
+    } else if ("SRV".equals(type)) {
+      return SRVData.builder()
+                 .priority(rdata.get("priority").getAsInt())
+                 .weight(rdata.get("weight").getAsInt())
+                 .port(rdata.get("port").getAsInt())
+                 .target(rdata.get("target").getAsString())
+                 .build();
+    } else if ("TXT".equals(type)) {
+      return TXTData.create(rdata.get("txtdata").getAsString());
+    } else {
+      Map<String, Object> builder = new LinkedHashMap<String, Object>();
+      for (Entry<String, JsonElement> entry : rdata.entrySet()) {
+        // values are never nested
+        JsonPrimitive value = entry.getValue().getAsJsonPrimitive();
+        if (value.isNumber()) {
+          builder.put(entry.getKey(), value.getAsInt());
+        } else {
+          builder.put(entry.getKey(), value.getAsString());
+        }
       }
+      return builder;
     }
-    return builder;
   }
 
   public Record apply(JsonElement element) {
@@ -34,7 +81,7 @@ enum ToRecord {
     record.name = current.get("fqdn").getAsString();
     record.type = current.get("record_type").getAsString();
     record.ttl = current.get("ttl").getAsInt();
-    record.rdata = toRData(current.get("rdata").getAsJsonObject());
+    record.rdata = toRData(record.type, current.get("rdata").getAsJsonObject());
     return record;
   }
 }

--- a/dynect/src/test/java/denominator/dynect/DynECTFunctionsTest.java
+++ b/dynect/src/test/java/denominator/dynect/DynECTFunctionsTest.java
@@ -1,0 +1,132 @@
+package denominator.dynect;
+
+import com.google.gson.JsonParser;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import denominator.model.rdata.AAAAData;
+import denominator.model.rdata.AData;
+import denominator.model.rdata.CNAMEData;
+import denominator.model.rdata.MXData;
+import denominator.model.rdata.NSData;
+import denominator.model.rdata.PTRData;
+import denominator.model.rdata.SOAData;
+import denominator.model.rdata.SPFData;
+import denominator.model.rdata.SRVData;
+import denominator.model.rdata.TXTData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DynECTFunctionsTest{
+
+  @DataProvider(name = "rdata")
+  public Object[][] rdata() throws IOException {
+    return new Object[][] {
+        {
+            "SOA",
+            "{\n"
+            + "  \"rname\": \"admin.denominator.io.\",\n"
+            + "  \"retry\": 600,\n"
+            + "  \"mname\": \"ns1.p28.dynect.net.\",\n"
+            + "  \"minimum\": 60,\n"
+            + "  \"refresh\": 3600,\n"
+            + "  \"expire\": 604800,\n"
+            + "  \"serial\": 43\n"
+            + "}",
+            SOAData.builder()
+                .rname("admin.denominator.io.")
+                .retry(600)
+                .mname("ns1.p28.dynect.net.")
+                .minimum(60)
+                .refresh(3600)
+                .expire(604800)
+                .serial(43)
+                .build()
+        },
+        {
+            "NS",
+            "{\n"
+            + "  \"nsdname\": \"ns1.p28.dynect.net.\"\n"
+            + "}",
+            NSData.create("ns1.p28.dynect.net.")
+        },
+        {
+            "A",
+            "{\n"
+            + "  \"address\": \"192.0.2.1\"\n"
+            + "}",
+            AData.create("192.0.2.1")
+        },
+        {
+            "AAAA",
+            "{\n"
+            + "  \"address\": \"2001:db8::3\"\n"
+            + "}",
+            AAAAData.create("2001:db8::3")
+        },
+        {
+            "CNAME",
+            "{\n"
+            + "  \"cname\": \"denominator.github.com\"\n"
+            + "}",
+            CNAMEData.create("denominator.github.com")
+        },
+        {
+            "SPF",
+            "{\n"
+            + "  \"txtdata\": \"sample SPF text data\"\n"
+            + "}",
+            SPFData.create("sample SPF text data")
+        },
+        {
+            "TXT",
+            "{\n"
+            + "  \"txtdata\": \"sample TXT text data\"\n"
+            + "}",
+            TXTData.create("sample TXT text data")
+        },
+        {
+            "MX",
+            "{\n"
+            + "  \"preference\": 5,\n"
+            + "  \"exchange\": \"helloExchange\"\n"
+            + "}",
+            MXData.create(5, "helloExchange")
+        },
+        {
+            "PTR",
+            "{\n"
+            + "  \"ptrdname\": \"hello.ptrdname\"\n"
+            + "}",
+            PTRData.create("hello.ptrdname")
+        },
+        {
+            "SRV",
+            "{\n"
+            + "  \"priority\": 1,\n"
+            + "  \"weight\": 2,\n"
+            + "  \"port\": 80,\n"
+            + "  \"target\": \"helloTarget\"\n"
+            + "}",
+            SRVData.builder()
+                .priority(1)
+                .weight(2)
+                .port(80)
+                .target("helloTarget")
+                .build()
+        }
+    };
+  }
+
+  @Test(dataProvider = "rdata")
+  public void toRecord(String type, String inputJson, Map<String, Object> expectedResult) throws Exception {
+    assertThat(ToRecord.toRData(type, new JsonParser().parse(inputJson).getAsJsonObject()))
+        .isInstanceOf(expectedResult.getClass())
+        .isEqualTo(expectedResult);
+  }
+}
+


### PR DESCRIPTION
in Dynect Provider, the ResourceRecordSet returned by api, always
contains records of type LinkedHashMap. It should contain records of
type-safe subclasses like AData, AAAAData etc. All other providers
return type-safe rdata.

closes #296