### PR TITLE
Ensures record type codes exist

### DIFF
--- a/model/src/main/java/denominator/ResourceTypeToValue.java
+++ b/model/src/main/java/denominator/ResourceTypeToValue.java
@@ -56,7 +56,7 @@ public class ResourceTypeToValue {
    * >iana types</a>.
    */
   // enum only to look and format prettier than fluent bimap builder calls
-  private static enum ResourceTypes {
+  static enum ResourceTypes {
     /**
      * a host address
      */
@@ -98,9 +98,34 @@ public class ResourceTypeToValue {
     AAAA(28),
 
     /**
+     * Location record
+     */
+    LOC(29),
+
+    /**
+     * Naming Authority Pointer
+     */
+    NAPTR(35),
+    
+    /**
+     * Certificate record
+     */
+    CERT(37),
+
+    /**
+     * Delegation signer
+     */
+    DS(43),
+
+    /**
      * SSH Public Key Fingerprint
      */
     SSHFP(44),
+
+    /**
+     * TLSA certificate association
+     */
+    TLSA(52),
 
     /**
      * Sender Policy Framework

--- a/model/src/test/java/denominator/ResourceTypeToValueTest.java
+++ b/model/src/test/java/denominator/ResourceTypeToValueTest.java
@@ -4,6 +4,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
+
+import denominator.ResourceTypeToValue.ResourceTypes;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResourceTypeToValueTest {
@@ -15,7 +19,7 @@ public class ResourceTypeToValueTest {
   public void testNiceExceptionOnNotFound() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(
-        "ResourceTypes do not include RRRR; types: [A, NS, CNAME, SOA, PTR, MX, TXT, AAAA, SSHFP, SPF, SRV]");
+        "ResourceTypes do not include RRRR; types: " + Arrays.asList(ResourceTypes.values()));
 
     ResourceTypeToValue.lookup("RRRR");
   }

--- a/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
+++ b/model/src/test/java/denominator/model/ResourceRecordSetsTest.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import denominator.ResourceTypeToValue;
 import denominator.model.profile.Geo;
 import denominator.model.rdata.AAAAData;
 import denominator.model.rdata.AData;
@@ -333,6 +334,7 @@ public class ResourceRecordSetsTest {
           .hasType(longForm.type())
           .hasTtl(longForm.ttl())
           .containsExactlyRecords(longForm.records());
+      ResourceTypeToValue.lookup(longForm.type());
     }
   }
 }


### PR DESCRIPTION
Formerly, the record code lookup was in a different module than where
new RData were created. This made a gap where it is easy to forget to
update the lookup table. Failed lookups can cause providers that use
numeric codes to crash.

See ab99c8149522db160a3b991848d695416f2f28b5