### PR TITLE
Accommodates UltraDNS accounts without directional support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Version 4.4
 * Adds support for DiscoveryDNS (http://www.discoverydns.com)
+* Accommodates UltraDNS accounts without directional support
 * Allows map credentials to be used without regard to iteration order
 * Changes DynECT to return type-safe rdata
 * Updates to feign 7.2.1 and dagger 1.2.2

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSException.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSException.java
@@ -39,6 +39,10 @@ class UltraDNSException extends FeignException {
    */
   static final int GROUP_NOT_FOUND = 4003;
   /**
+   * Directional feature not Enabled or Directional migration is not done.
+   */
+  static final int DIRECTIONAL_NOT_ENABLED = 4006;
+  /**
    * Resource Record already exists.
    */
   static final int POOL_RECORD_ALREADY_EXISTS = 4009;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
@@ -303,6 +303,15 @@ final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordSetApi {
     @Override
     public GeoResourceRecordSetApi create(String idOrName) {
       checkNotNull(idOrName, "idOrName was null");
+      // Eager fetch of regions to determine if directional records are supported or not.
+      try {
+        regions.get();
+      } catch (UltraDNSException e) {
+        if (e.code() == UltraDNSException.DIRECTIONAL_NOT_ENABLED) {
+          return null;
+        }
+        throw e;
+      }
       return new UltraDNSGeoResourceRecordSetApi(supportedTypes, regions, api, iteratorFactory,
                                                  idOrName);
     }

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSErrorDecoderTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSErrorDecoderTest.java
@@ -14,6 +14,7 @@ import feign.codec.ErrorDecoder;
 
 import static denominator.ultradns.UltraDNSTest.dirPoolNotFound;
 import static denominator.ultradns.UltraDNSTest.dirRecordNotFound;
+import static denominator.ultradns.UltraDNSTest.directionalNotEnabled;
 import static denominator.ultradns.UltraDNSTest.groupNotFound;
 import static denominator.ultradns.UltraDNSTest.invalidUser;
 import static denominator.ultradns.UltraDNSTest.poolAlreadyExists;
@@ -116,6 +117,17 @@ public class UltraDNSErrorDecoderTest {
     throw errors.decode(
         "UltraDNS#directionalRecordsInZoneAndGroupByNameAndType(String,String,String,int)",
         errorResponse(groupNotFound));
+  }
+
+  @Test
+  public void code4006() throws Exception {
+    thrown.expect(UltraDNSException.class);
+    thrown.expectMessage(
+        "UltraDNS#directionalRecordsInZoneAndGroupByNameAndType(String,String,String,int) failed with error 4006: Directional feature not Enabled or Directional migration is not done.");
+
+    throw errors.decode(
+        "UltraDNS#directionalRecordsInZoneAndGroupByNameAndType(String,String,String,int)",
+        errorResponse(directionalNotEnabled));
   }
 
   @Test

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApiMockTest.java
@@ -16,6 +16,7 @@ import denominator.model.rdata.CNAMEData;
 import denominator.profile.GeoResourceRecordSetApi;
 
 import static denominator.assertj.ModelAssertions.assertThat;
+import static denominator.ultradns.UltraDNSTest.directionalNotEnabled;
 import static denominator.ultradns.UltraDNSTest.getAvailableRegions;
 import static denominator.ultradns.UltraDNSTest.getAvailableRegionsResponse;
 import static denominator.ultradns.UltraDNSTest.getDirectionalDNSGroupDetails;
@@ -41,48 +42,18 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
   @Rule
   public final MockUltraDNSServer server = new MockUltraDNSServer();
 
-  String getDirectionalDNSGroupDetailsResponseEverywhereElse =
-      "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
-      + "        <soap:Body>\n"
-      + "                <ns1:getDirectionalDNSGroupDetailsResponse xmlns:ns1=\"http://webservice.api.ultra.neustar.com/v01/\">\n"
-      + "                        <DirectionalDNSGroupDetail xmlns:ns2=\"http://schema.ultraservice.neustar.com/v01/\" GroupName=\"Everywhere Else\">\n"
-      + "                                <ns2:DirectionalDNSRegion>\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Anonymous Proxy (A1)\" TerritoryName=\"Anonymous Proxy\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Mexico\" TerritoryName=\"Mexico\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Satellite Provider (A2)\" TerritoryName=\"Satellite Provider\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Unknown / Uncategorized IPs\" TerritoryName=\"Unknown / Uncategorized IPs\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Canada (CA)\" TerritoryName=\"Alberta;British Columbia;Greenland;Manitoba;New Brunswick;Newfoundland and Labrador;Northwest Territories;Nova Scotia;Nunavut;Ontario;Prince Edward Island;Quebec;Saint Pierre and Miquelon;Saskatchewan;Undefined Canada;Yukon\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"The Caribbean\" TerritoryName=\"Anguilla;Antigua and Barbuda;Aruba;Bahamas;Barbados;Bermuda;British Virgin Islands;Cayman Islands;Cuba;Dominica;Dominican Republic;Grenada;Guadeloupe;Haiti;Jamaica;Martinique;Montserrat;Netherlands Antilles;Puerto Rico;Saint Barthelemy;Saint Martin;Saint Vincent and the Grenadines;St. Kitts and Nevis;St. Lucia;Trinidad and Tobago;Turks and Caicos Islands;U.S. Virgin Islands\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Central America\" TerritoryName=\"Belize;Costa Rica;El Salvador;Guatemala;Honduras;Nicaragua;Panama;Undefined Central America\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"South America\" TerritoryName=\"Argentina;Bolivia;Brazil;Chile;Colombia;Ecuador;Falkland Islands;French Guiana;Guyana;Paraguay;Peru;South Georgia and the South Sandwich Islands;Suriname;Undefined South America;Uruguay;Venezuela, Bolivarian Republic of\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Russian Federation\" TerritoryName=\"Russian Federation\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Middle East\" TerritoryName=\"Afghanistan;Bahrain;Cyprus;Iran;Iraq;Israel;Jordan;Kuwait;Lebanon;Oman;Palestinian Territory, Occupied;Qatar;Saudi Arabia;Syrian Arab Republic;Turkey, Republic of;Undefined Middle East;United Arab Emirates;Yemen\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Africa\" TerritoryName=\"Algeria;Angola;Benin;Botswana;Burkina Faso;Burundi;Cameroon;Cape Verde;Central African Republic;Chad;Comoros;Congo;Cote d'Ivoire;Democratic Republic of the Congo;Djibouti;Egypt;Equatorial Guinea;Eritrea;Ethiopia;Gabon;Gambia;Ghana;Guinea;Guinea-Bissau;Kenya;Lesotho;Liberia;Libyan Arab Jamahiriya;Madagascar;Malawi;Mali;Mauritania;Mauritius;Mayotte;Morocco;Mozambique;Namibia;Niger;Nigeria;Reunion;Rwanda;Sao Tome and Principe;Senegal;Seychelles;Sierra Leone;Somalia;South Africa;St. Helena;Sudan;Swaziland;Tanzania, United Republic of;Togo;Tunisia;Uganda;Undefined Africa;Western Sahara;Zambia;Zimbabwe\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Asia\" TerritoryName=\"Bangladesh;Bhutan;British Indian Ocean Territory - Chagos Islands;Brunei Darussalam;Cambodia;China;Hong Kong;India;Indonesia;Japan;Kazakhstan;Korea, Democratic People's Republic of;Korea, Republic of;Kyrgyzstan;Lao People's Democratic Republic;Macao;Malaysia;Maldives;Mongolia;Myanmar;Nepal;Pakistan;Philippines;Singapore;Sri Lanka;Taiwan;Tajikistan;Thailand;Timor-Leste, Democratic Republic of;Turkmenistan;Undefined Asia;Uzbekistan;Vietnam\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Australia / Oceania\" TerritoryName=\"American Samoa;Australia;Christmas Island;Cocos (Keeling) Islands;Cook Islands;Fiji;French Polynesia;Guam;Heard Island and McDonald Islands;Kiribati;Marshall Islands;Micronesia , Federated States of;Nauru;New Caledonia;New Zealand;Niue;Norfolk Island;Northern Mariana Islands, Commonwealth of;Palau;Papua New Guinea;Pitcairn;Samoa;Solomon Islands;Tokelau;Tonga;Tuvalu;Undefined Australia / Oceania;Vanuatu;Wallis and Futuna\" />\n"
-      + "                                        <ns2:RegionForNewGroups RegionName=\"Antarctica\" TerritoryName=\"Antarctica;Bouvet Island;French Southern Territories\" />\n"
-      + "                                </ns2:DirectionalDNSRegion>\n"
-      + "                        </DirectionalDNSGroupDetail>\n"
-      + "                </ns1:getDirectionalDNSGroupDetailsResponse>\n"
-      + "        </soap:Body>\n"
-      + "</soap:Envelope>";
+  @Test
+  public void apiWhenUnsupported() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500).setBody(directionalNotEnabled));
 
-  String getDirectionalDNSGroupDetailsResponseUS =
-      "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
-      + " <soap:Body>\n"
-      + "         <ns1:getDirectionalDNSGroupDetailsResponse xmlns:ns1=\"http://webservice.api.ultra.neustar.com/v01/\">\n"
-      + "                 <DirectionalDNSGroupDetail\n"
-      + "                         xmlns:ns2=\"http://schema.ultraservice.neustar.com/v01/\" GroupName=\"US\">\n"
-      + "                         <ns2:DirectionalDNSRegion>\n"
-      + "                                 <ns2:RegionForNewGroups RegionName=\"United States (US)\" TerritoryName=\"Alabama;Alaska;Arizona;Arkansas;Armed Forces Americas;Armed Forces Europe, Middle East, and Canada;Armed Forces Pacific;California;Colorado;Connecticut;Delaware;District of Columbia;Florida;Georgia;Hawaii;Idaho;Illinois;Indiana;Iowa;Kansas;Kentucky;Louisiana;Maine;Maryland;Massachusetts;Michigan;Minnesota;Mississippi;Missouri;Montana;Nebraska;Nevada;New Hampshire;New Jersey;New Mexico;New York;North Carolina;North Dakota;Ohio;Oklahoma;Oregon;Pennsylvania;Rhode Island;South Carolina;South Dakota;Tennessee;Texas;Undefined United States;United States Minor Outlying Islands;Utah;Vermont;Virginia;Washington;West Virginia;Wisconsin;Wyoming\" />\n"
-      + "                         </ns2:DirectionalDNSRegion>\n"
-      + "                 </DirectionalDNSGroupDetail>\n"
-      + "         </ns1:getDirectionalDNSGroupDetailsResponse>\n"
-      + " </soap:Body>\n"
-      + "</soap:Envelope>";
+    assertThat(server.connect().api().geoRecordSetsInZone("denominator.io.")).isNull();
+
+    server.assertRequestHasBody(getAvailableRegions);
+  }
 
   @Test
   public void listWhenPresent() throws Exception {
+    server.enqueue(new MockResponse().setBody(getAvailableRegionsResponse));
     server.enqueue(new MockResponse().setBody(getDirectionalPoolsOfZoneResponsePresent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForHostResponsePresent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSGroupDetailsResponseEurope));
@@ -97,6 +68,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
     assertUS(iterator.next());
     assertThat(iterator).isEmpty();
 
+    server.assertRequestHasBody(getAvailableRegions);
     server.assertRequestHasBody(getDirectionalPoolsOfZone);
     server.assertRequestHasBody(getDirectionalDNSRecordsForHost);
     server.assertRequestHasBody(
@@ -109,6 +81,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
 
   @Test
   public void iterateByNameWhenPresent() throws Exception {
+    server.enqueue(new MockResponse().setBody(getAvailableRegionsResponse));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForHostResponsePresent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSGroupDetailsResponseEurope));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSGroupDetailsResponseEverywhereElse));
@@ -122,6 +95,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
     assertUS(iterator.next());
     assertThat(iterator).isEmpty();
 
+    server.assertRequestHasBody(getAvailableRegions);
     server.assertRequestHasBody(getDirectionalDNSRecordsForHost);
     server.assertRequestHasBody(
         getDirectionalDNSGroupDetails.replace("AAAAAAAAAAAAAAAA", "C000000000000001"));
@@ -133,6 +107,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
 
   @Test
   public void iterateByNameAndTypeWhenPresent() throws Exception {
+    server.enqueue(new MockResponse().setBody(getAvailableRegionsResponse));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForHostResponsePresent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForHostResponseAbsent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSGroupDetailsResponseEurope));
@@ -149,6 +124,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
     assertUS(iterator.next());
     assertThat(iterator).isEmpty();
 
+    server.assertRequestHasBody(getAvailableRegions);
     server.assertRequestHasBody(getDirectionalDNSRecordsForHostIPV4);
     server.assertRequestHasBody(getDirectionalDNSRecordsForHostIPV6);
     server.assertRequestHasBody(
@@ -173,6 +149,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
 
   @Test
   public void putWhenMatches() throws Exception {
+    server.enqueue(new MockResponse().setBody(getAvailableRegionsResponse));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForGroupResponsePresent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForGroupResponseAbsent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSGroupDetailsResponseEurope));
@@ -181,6 +158,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
 
     api.put(europe);
 
+    server.assertRequestHasBody(getAvailableRegions);
     server.assertRequestHasBody(getDirectionalDNSRecordsForGroup);
     server.assertRequestHasBody(getDirectionalDNSRecordsForGroupEuropeIPV6);
     server.assertRequestHasBody(
@@ -189,6 +167,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
 
   @Test
   public void putWhenRegionsDiffer() throws Exception {
+    server.enqueue(new MockResponse().setBody(getAvailableRegionsResponse));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForGroupResponsePresent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForGroupResponseAbsent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSGroupDetailsResponseEurope));
@@ -209,6 +188,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
         })).build();
     api.put(lessOfEurope);
 
+    server.assertRequestHasBody(getAvailableRegions);
     server.assertRequestHasBody(getDirectionalDNSRecordsForGroup);
     server.assertRequestHasBody(getDirectionalDNSRecordsForGroupEuropeIPV6);
     server.assertRequestHasBody(
@@ -218,6 +198,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
 
   @Test
   public void putWhenTTLDiffers() throws Exception {
+    server.enqueue(new MockResponse().setBody(getAvailableRegionsResponse));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForGroupResponsePresent));
     server.enqueue(new MockResponse().setBody(getDirectionalDNSRecordsForGroupResponseAbsent));
     server.enqueue(new MockResponse().setBody(updateDirectionalPoolRecordResponse));
@@ -232,6 +213,7 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
         .geo(europe.geo()).build();
     api.put(lessTTL);
 
+    server.assertRequestHasBody(getAvailableRegions);
     server.assertRequestHasBody(getDirectionalDNSRecordsForGroup);
     server.assertRequestHasBody(getDirectionalDNSRecordsForGroupEuropeIPV6);
     server.assertRequestHasBody(format(
@@ -356,4 +338,44 @@ public class UltraDNSGeoResourceRecordSetApiMockTest {
                       "Vatican City"));
         }
       })).build();
+
+  String getDirectionalDNSGroupDetailsResponseEverywhereElse =
+      "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+      + "        <soap:Body>\n"
+      + "                <ns1:getDirectionalDNSGroupDetailsResponse xmlns:ns1=\"http://webservice.api.ultra.neustar.com/v01/\">\n"
+      + "                        <DirectionalDNSGroupDetail xmlns:ns2=\"http://schema.ultraservice.neustar.com/v01/\" GroupName=\"Everywhere Else\">\n"
+      + "                                <ns2:DirectionalDNSRegion>\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Anonymous Proxy (A1)\" TerritoryName=\"Anonymous Proxy\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Mexico\" TerritoryName=\"Mexico\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Satellite Provider (A2)\" TerritoryName=\"Satellite Provider\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Unknown / Uncategorized IPs\" TerritoryName=\"Unknown / Uncategorized IPs\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Canada (CA)\" TerritoryName=\"Alberta;British Columbia;Greenland;Manitoba;New Brunswick;Newfoundland and Labrador;Northwest Territories;Nova Scotia;Nunavut;Ontario;Prince Edward Island;Quebec;Saint Pierre and Miquelon;Saskatchewan;Undefined Canada;Yukon\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"The Caribbean\" TerritoryName=\"Anguilla;Antigua and Barbuda;Aruba;Bahamas;Barbados;Bermuda;British Virgin Islands;Cayman Islands;Cuba;Dominica;Dominican Republic;Grenada;Guadeloupe;Haiti;Jamaica;Martinique;Montserrat;Netherlands Antilles;Puerto Rico;Saint Barthelemy;Saint Martin;Saint Vincent and the Grenadines;St. Kitts and Nevis;St. Lucia;Trinidad and Tobago;Turks and Caicos Islands;U.S. Virgin Islands\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Central America\" TerritoryName=\"Belize;Costa Rica;El Salvador;Guatemala;Honduras;Nicaragua;Panama;Undefined Central America\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"South America\" TerritoryName=\"Argentina;Bolivia;Brazil;Chile;Colombia;Ecuador;Falkland Islands;French Guiana;Guyana;Paraguay;Peru;South Georgia and the South Sandwich Islands;Suriname;Undefined South America;Uruguay;Venezuela, Bolivarian Republic of\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Russian Federation\" TerritoryName=\"Russian Federation\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Middle East\" TerritoryName=\"Afghanistan;Bahrain;Cyprus;Iran;Iraq;Israel;Jordan;Kuwait;Lebanon;Oman;Palestinian Territory, Occupied;Qatar;Saudi Arabia;Syrian Arab Republic;Turkey, Republic of;Undefined Middle East;United Arab Emirates;Yemen\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Africa\" TerritoryName=\"Algeria;Angola;Benin;Botswana;Burkina Faso;Burundi;Cameroon;Cape Verde;Central African Republic;Chad;Comoros;Congo;Cote d'Ivoire;Democratic Republic of the Congo;Djibouti;Egypt;Equatorial Guinea;Eritrea;Ethiopia;Gabon;Gambia;Ghana;Guinea;Guinea-Bissau;Kenya;Lesotho;Liberia;Libyan Arab Jamahiriya;Madagascar;Malawi;Mali;Mauritania;Mauritius;Mayotte;Morocco;Mozambique;Namibia;Niger;Nigeria;Reunion;Rwanda;Sao Tome and Principe;Senegal;Seychelles;Sierra Leone;Somalia;South Africa;St. Helena;Sudan;Swaziland;Tanzania, United Republic of;Togo;Tunisia;Uganda;Undefined Africa;Western Sahara;Zambia;Zimbabwe\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Asia\" TerritoryName=\"Bangladesh;Bhutan;British Indian Ocean Territory - Chagos Islands;Brunei Darussalam;Cambodia;China;Hong Kong;India;Indonesia;Japan;Kazakhstan;Korea, Democratic People's Republic of;Korea, Republic of;Kyrgyzstan;Lao People's Democratic Republic;Macao;Malaysia;Maldives;Mongolia;Myanmar;Nepal;Pakistan;Philippines;Singapore;Sri Lanka;Taiwan;Tajikistan;Thailand;Timor-Leste, Democratic Republic of;Turkmenistan;Undefined Asia;Uzbekistan;Vietnam\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Australia / Oceania\" TerritoryName=\"American Samoa;Australia;Christmas Island;Cocos (Keeling) Islands;Cook Islands;Fiji;French Polynesia;Guam;Heard Island and McDonald Islands;Kiribati;Marshall Islands;Micronesia , Federated States of;Nauru;New Caledonia;New Zealand;Niue;Norfolk Island;Northern Mariana Islands, Commonwealth of;Palau;Papua New Guinea;Pitcairn;Samoa;Solomon Islands;Tokelau;Tonga;Tuvalu;Undefined Australia / Oceania;Vanuatu;Wallis and Futuna\" />\n"
+      + "                                        <ns2:RegionForNewGroups RegionName=\"Antarctica\" TerritoryName=\"Antarctica;Bouvet Island;French Southern Territories\" />\n"
+      + "                                </ns2:DirectionalDNSRegion>\n"
+      + "                        </DirectionalDNSGroupDetail>\n"
+      + "                </ns1:getDirectionalDNSGroupDetailsResponse>\n"
+      + "        </soap:Body>\n"
+      + "</soap:Envelope>";
+
+  String getDirectionalDNSGroupDetailsResponseUS =
+      "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+      + " <soap:Body>\n"
+      + "         <ns1:getDirectionalDNSGroupDetailsResponse xmlns:ns1=\"http://webservice.api.ultra.neustar.com/v01/\">\n"
+      + "                 <DirectionalDNSGroupDetail\n"
+      + "                         xmlns:ns2=\"http://schema.ultraservice.neustar.com/v01/\" GroupName=\"US\">\n"
+      + "                         <ns2:DirectionalDNSRegion>\n"
+      + "                                 <ns2:RegionForNewGroups RegionName=\"United States (US)\" TerritoryName=\"Alabama;Alaska;Arizona;Arkansas;Armed Forces Americas;Armed Forces Europe, Middle East, and Canada;Armed Forces Pacific;California;Colorado;Connecticut;Delaware;District of Columbia;Florida;Georgia;Hawaii;Idaho;Illinois;Indiana;Iowa;Kansas;Kentucky;Louisiana;Maine;Maryland;Massachusetts;Michigan;Minnesota;Mississippi;Missouri;Montana;Nebraska;Nevada;New Hampshire;New Jersey;New Mexico;New York;North Carolina;North Dakota;Ohio;Oklahoma;Oregon;Pennsylvania;Rhode Island;South Carolina;South Dakota;Tennessee;Texas;Undefined United States;United States Minor Outlying Islands;Utah;Vermont;Virginia;Washington;West Virginia;Wisconsin;Wyoming\" />\n"
+      + "                         </ns2:DirectionalDNSRegion>\n"
+      + "                 </DirectionalDNSGroupDetail>\n"
+      + "         </ns1:getDirectionalDNSGroupDetailsResponse>\n"
+      + " </soap:Body>\n"
+      + "</soap:Envelope>";
 }

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSTest.java
@@ -23,6 +23,7 @@ import feign.codec.DecodeException;
 import static denominator.assertj.ModelAssertions.assertThat;
 import static denominator.ultradns.UltraDNSException.DIRECTIONALPOOL_NOT_FOUND;
 import static denominator.ultradns.UltraDNSException.DIRECTIONALPOOL_RECORD_NOT_FOUND;
+import static denominator.ultradns.UltraDNSException.DIRECTIONAL_NOT_ENABLED;
 import static denominator.ultradns.UltraDNSException.GROUP_NOT_FOUND;
 import static denominator.ultradns.UltraDNSException.POOL_ALREADY_EXISTS;
 import static denominator.ultradns.UltraDNSException.POOL_NOT_FOUND;
@@ -1161,4 +1162,8 @@ public class UltraDNSTest {
       + "      </ns2:DirectionalDNSRecordDetail>\n"
       + "    </DirectionalDNSRecordDetailList>\n"
       + getDirectionalDNSRecordsForHostResponseFooter;
+  static String
+      directionalNotEnabled =
+      format(FAULT_TEMPLATE, DIRECTIONAL_NOT_ENABLED,
+             "Directional feature not Enabled or Directional migration is not done.");
 }


### PR DESCRIPTION
At the cost of a request to getAvailableRegions, this guards calls to
DNSApi.geoRecordSetsInZone, returning null when directional records are
not enabled in the UltraDNS account.

closes #259