### PR TITLE
Unhooks from Feign Dagger modules

### DIFF
--- a/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
+++ b/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
@@ -20,7 +20,6 @@ import denominator.clouddns.RackspaceAdapters.JobIdAndStatusAdapter;
 import denominator.clouddns.RackspaceAdapters.RecordListAdapter;
 import denominator.clouddns.RackspaceApis.CloudDNS;
 import denominator.clouddns.RackspaceApis.CloudIdentity;
-import denominator.clouddns.RackspaceApis.TokenIdAndPublicURL;
 import denominator.config.GeoUnsupported;
 import denominator.config.NothingToClose;
 import denominator.config.OnlyBasicResourceRecordSets;
@@ -108,11 +107,9 @@ public class CloudDNSProvider extends BasicProvider {
     }
   }
 
-  @dagger.Module(//
-      injects = CloudDNSResourceRecordSetApi.Factory.class, //
-      complete = false, // doesn't bind Provider used by CloudDNSTarget
-      overrides = true, // builds Feign directly
-      includes = Feign.Defaults.class)
+  @dagger.Module(injects = CloudDNSResourceRecordSetApi.Factory.class,
+      complete = false // doesn't bind Provider used by DesignateTarget
+  )
   public static final class FeignModule {
 
     @Provides
@@ -128,14 +125,9 @@ public class CloudDNSProvider extends BasicProvider {
     }
 
     @Provides
-    public TokenIdAndPublicURL urlAndToken(InvalidatableAuthProvider provider) {
-      return provider.get();
-    }
-
-    @Provides
     @Singleton
-    Feign feign(Feign.Builder feignBuilder) {
-      return feignBuilder
+    Feign feign() {
+      return Feign.builder()
           .encoder(new GsonEncoder())
           .decoder(new GsonDecoder(Arrays.asList(
                        new KeystoneAccessAdapter("rax:dns"),

--- a/clouddns/src/main/java/denominator/clouddns/CloudDNSTarget.java
+++ b/clouddns/src/main/java/denominator/clouddns/CloudDNSTarget.java
@@ -12,10 +12,10 @@ import feign.Target;
 class CloudDNSTarget implements Target<CloudDNS> {
 
   private final Provider provider;
-  private final javax.inject.Provider<TokenIdAndPublicURL> lazyUrlAndToken;
+  private final InvalidatableAuthProvider lazyUrlAndToken;
 
   @Inject
-  CloudDNSTarget(Provider provider, javax.inject.Provider<TokenIdAndPublicURL> lazyUrlAndToken) {
+  CloudDNSTarget(Provider provider, InvalidatableAuthProvider lazyUrlAndToken) {
     this.provider = provider;
     this.lazyUrlAndToken = lazyUrlAndToken;
   }

--- a/core/src/test/java/denominator/DNSApiManagerFactory.java
+++ b/core/src/test/java/denominator/DNSApiManagerFactory.java
@@ -47,7 +47,7 @@ public final class DNSApiManagerFactory {
   }
 
   @Module(overrides = true, library = true)
-  static final class HttpLog {
+  public static final class HttpLog {
 
     @Provides
     @Singleton

--- a/core/src/test/java/denominator/Live.java
+++ b/core/src/test/java/denominator/Live.java
@@ -38,7 +38,7 @@ public class Live extends Suite {
   public Live(Class<?> klass) throws InitializationError {
     super(klass, Collections.<Runner>emptyList());
     graph = testGraph(klass);
-    if (graph.manager().checkConnection()) {
+    if (graph.manager() != null && graph.manager().checkConnection()) {
       runners = createRunners(klass);
     } else {
       runners = Collections.emptyList();

--- a/designate/src/main/java/denominator/designate/DesignateTarget.java
+++ b/designate/src/main/java/denominator/designate/DesignateTarget.java
@@ -11,10 +11,10 @@ import feign.Target;
 class DesignateTarget implements Target<Designate> {
 
   private final Provider provider;
-  private final javax.inject.Provider<TokenIdAndPublicURL> lazyUrlAndToken;
+  private final InvalidatableAuthProvider lazyUrlAndToken;
 
   @Inject
-  DesignateTarget(Provider provider, javax.inject.Provider<TokenIdAndPublicURL> lazyUrlAndToken) {
+  DesignateTarget(Provider provider, InvalidatableAuthProvider lazyUrlAndToken) {
     this.provider = provider;
     this.lazyUrlAndToken = lazyUrlAndToken;
   }

--- a/designate/src/main/java/denominator/designate/KeystoneV2AccessAdapter.java
+++ b/designate/src/main/java/denominator/designate/KeystoneV2AccessAdapter.java
@@ -10,21 +10,11 @@ import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import denominator.designate.KeystoneV2.TokenIdAndPublicURL;
-
-import static denominator.common.Preconditions.checkNotNull;
 
 class KeystoneV2AccessAdapter extends TypeAdapter<TokenIdAndPublicURL> {
 
-  private final String serviceTypeSuffix;
-
-  @Inject
-  KeystoneV2AccessAdapter(@Named("serviceTypeSuffix") String serviceTypeSuffix) {
-    this.serviceTypeSuffix = checkNotNull(serviceTypeSuffix, "serviceTypeSuffix was null");
-  }
+  private final String serviceTypeSuffix = ":dns";
 
   static boolean isNull(JsonElement element) {
     return element == null || element.isJsonNull();

--- a/designate/src/test/java/denominator/designate/KeystoneV2AccessAdapterTest.java
+++ b/designate/src/test/java/denominator/designate/KeystoneV2AccessAdapterTest.java
@@ -25,7 +25,7 @@ public class KeystoneV2AccessAdapterTest {
 
   KeystoneV2 client = Feign.builder()
       .decoder(
-          new GsonDecoder(Arrays.<TypeAdapter<?>>asList(new KeystoneV2AccessAdapter("hpext:dns"))))
+          new GsonDecoder(Arrays.<TypeAdapter<?>>asList(new KeystoneV2AccessAdapter())))
       .target(Target.EmptyTarget.create(KeystoneV2.class, "keystone"));
   
   @Test

--- a/dynect/src/main/java/denominator/dynect/DynECTProvider.java
+++ b/dynect/src/main/java/denominator/dynect/DynECTProvider.java
@@ -134,23 +134,15 @@ public class DynECTProvider extends BasicProvider {
     }
   }
 
-  @dagger.Module(
-      injects = DynECTResourceRecordSetApi.Factory.class,
-      complete = false, // doesn't bind Provider used by SessionTarget
-      overrides = true, // builds Feign directly
-      includes = Feign.Defaults.class)
+  @dagger.Module(injects = DynECTResourceRecordSetApi.Factory.class,
+      complete = false // doesn't bind Provider used by SessionTarget
+  )
   public static final class FeignModule {
 
     @Provides
     @Singleton
     Session session(Feign feign, SessionTarget target) {
       return feign.newInstance(target);
-    }
-
-    @Provides
-    @Named("Auth-Token")
-    public String authToken(InvalidatableTokenProvider supplier) {
-      return supplier.get();
     }
 
     @Provides
@@ -167,8 +159,8 @@ public class DynECTProvider extends BasicProvider {
 
     @Provides
     @Singleton
-    Feign feign(Feign.Builder feignBuilder, DynECTErrorDecoder errorDecoder) {
-      return feignBuilder
+    Feign feign(DynECTErrorDecoder errorDecoder) {
+      return Feign.builder()
           .encoder(new GsonEncoder())
           .decoder(new GsonDecoder(Arrays.<TypeAdapter<?>>asList(
                        new TokenAdapter(),

--- a/dynect/src/main/java/denominator/dynect/DynECTTarget.java
+++ b/dynect/src/main/java/denominator/dynect/DynECTTarget.java
@@ -1,7 +1,6 @@
 package denominator.dynect;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import denominator.Provider;
 import feign.Request;
@@ -11,10 +10,10 @@ import feign.Target;
 class DynECTTarget implements Target<DynECT> {
 
   private final Provider provider;
-  private final javax.inject.Provider<String> lazyToken;
+  private final InvalidatableTokenProvider lazyToken;
 
   @Inject
-  DynECTTarget(Provider provider, @Named("Auth-Token") javax.inject.Provider<String> lazyToken) {
+  DynECTTarget(Provider provider, InvalidatableTokenProvider lazyToken) {
     this.provider = provider;
     this.lazyToken = lazyToken;
   }

--- a/route53/src/main/java/denominator/route53/InvalidatableAuthenticationHeadersProvider.java
+++ b/route53/src/main/java/denominator/route53/InvalidatableAuthenticationHeadersProvider.java
@@ -20,7 +20,7 @@ import static java.util.Locale.US;
 import static denominator.common.Preconditions.checkNotNull;
 
 // http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/RESTAuthentication.html
-public class InvalidatableAuthenticationHeadersProvider {
+final class InvalidatableAuthenticationHeadersProvider {
 
   private static final String
       AUTH_FORMAT =

--- a/route53/src/main/java/denominator/route53/Route53Target.java
+++ b/route53/src/main/java/denominator/route53/Route53Target.java
@@ -1,6 +1,5 @@
 package denominator.route53;
 
-import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.inject.Inject;
@@ -13,10 +12,10 @@ import feign.Target;
 class Route53Target implements Target<Route53> {
 
   private final Provider provider;
-  private final javax.inject.Provider<Map<String, String>> lazyAuthHeaders;
+  private final InvalidatableAuthenticationHeadersProvider lazyAuthHeaders;
 
   @Inject
-  Route53Target(Provider provider, javax.inject.Provider<Map<String, String>> lazyAuthHeaders) {
+  Route53Target(Provider provider, InvalidatableAuthenticationHeadersProvider lazyAuthHeaders) {
     this.provider = provider;
     this.lazyAuthHeaders = lazyAuthHeaders;
   }

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSErrorDecoderTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSErrorDecoderTest.java
@@ -29,7 +29,7 @@ public class UltraDNSErrorDecoderTest {
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
-  ErrorDecoder errors = new UltraDNSErrorDecoder(new UltraDNSProvider.FeignModule().decoder());
+  ErrorDecoder errors = new UltraDNSErrorDecoder(UltraDNSProvider.FeignModule.decoder());
 
   static Response errorResponse(String body) {
     return Response.create(500, "Server Error", Collections.<String, Collection<String>>emptyMap(),

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSTest.java
@@ -654,7 +654,8 @@ public class UltraDNSTest {
   }
 
   UltraDNS mockApi() {
-    return Feign.create(new UltraDNSTarget(new UltraDNSProvider() {
+    Feign feign = new UltraDNSProvider.FeignModule().feign();
+    return feign.newInstance(new UltraDNSTarget(new UltraDNSProvider() {
       @Override
       public String url() {
         return server.url();
@@ -666,7 +667,7 @@ public class UltraDNSTest {
         return server.credentials();
       }
 
-    }), new UltraDNSProvider.FeignModule());
+    }));
   }
 
   /**


### PR DESCRIPTION
Feign will no longer support dagger in version 8.0. This avoids using
dagger to construct Feign objects.

This also shows how to wire a lazy initialized provider, as this is an
issue with TLS certificate auth.