### PR TITLE
Fixes Round Robin Record update in UltraDNS

### DIFF
--- a/ultradns/src/main/java/denominator/ultradns/UltraDNS.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNS.java
@@ -2,7 +2,6 @@ package denominator.ultradns;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -69,6 +68,11 @@ interface UltraDNS {
   void addRecordToRRPool(@Param("type") int type, @Param("ttl") int ttl,
                          @Param("address") String rdata,
                          @Param("lbPoolID") String lbPoolID, @Param("zoneName") String zoneName);
+
+  @RequestLine("POST")
+  @Body("<v01:updateRecordOfRRPool><transactionID /><resourceRecord rrGuid=\"{rrGuid}\" lbPoolID=\"{lbPoolID}\" info1Value=\"{info1Value}\" TTL=\"{ttl}\"/></v01:updateRecordOfRRPool>")
+  void updateRecordOfRRPool(@Param("rrGuid") String rrGuid, @Param("lbPoolID") String lbPoolID,
+                            @Param("info1Value") String info1Value, @Param("ttl") int ttl);
 
   /**
    * @throws UltraDNSException with code {@link UltraDNSException#POOL_NOT_FOUND} and {@link

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSRoundRobinPoolApi.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSRoundRobinPoolApi.java
@@ -40,11 +40,15 @@ class UltraDNSRoundRobinPoolApi {
       if (e.code() != UltraDNSException.POOL_ALREADY_EXISTS) {
         throw e;
       }
-      NameAndType nameAndType = new NameAndType();
-      nameAndType.name = name;
-      nameAndType.type = type;
-      return api.getLoadBalancingPoolsByZone(zoneName).get(nameAndType);
+      return getPoolByNameAndType(name, type);
     }
+  }
+
+  String getPoolByNameAndType(String name, String type) {
+    NameAndType nameAndType = new NameAndType();
+    nameAndType.name = name;
+    nameAndType.type = type;
+    return api.getLoadBalancingPoolsByZone(zoneName).get(nameAndType);
   }
 
   void deletePool(String name, String type) {

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSTest.java
@@ -206,7 +206,22 @@ public class UltraDNSTest {
     record.rdata.add("1.1.1.1");
     mockApi().updateResourceRecord(record, "denominator.io.");
 
-    server.assertRequestHasBody(updateResourceRecord);
+    server.assertRequestHasBody(format(
+        SOAP_TEMPLATE,
+        "<v01:updateResourceRecord><transactionID /><resourceRecord Guid=\"ABCDEF\" ZoneName=\"denominator.io.\" Type=\"1\" DName=\"www.denominator.io.\" TTL=\"3600\"><InfoValues Info1Value=\"1.1.1.1\" /></resourceRecord></v01:updateResourceRecord>"));
+  }
+
+  @Test
+  public void updateRecordOfRRPool() throws Exception {
+    server.enqueue(new MockResponse().setBody(updateResourceRecordResponse));
+
+    mockApi().updateRecordOfRRPool("ABCDEF", "000000000000002", "1.1.1.1", 3600);
+
+    server.assertRequestHasBody(format(SOAP_TEMPLATE,
+                                       "<v01:updateRecordOfRRPool>\n"
+                                       + "    <transactionID/>\n"
+                                       + "    <resourceRecord TTL=\"3600\" info1Value=\"1.1.1.1\" lbPoolID=\"000000000000002\" rrGuid=\"ABCDEF\"/>\n"
+                                       + "</v01:updateRecordOfRRPool>"));
   }
 
   /**
@@ -805,9 +820,6 @@ public class UltraDNSTest {
       + "    </ns1:createResourceRecordResponse>\n"
       + "  </soap:Body>\n"
       + "</soap:Envelope>";
-  static String updateResourceRecord = format(
-      SOAP_TEMPLATE,
-      "<v01:updateResourceRecord><transactionID /><resourceRecord Guid=\"ABCDEF\" ZoneName=\"denominator.io.\" Type=\"1\" DName=\"www.denominator.io.\" TTL=\"3600\"><InfoValues Info1Value=\"1.1.1.1\" /></resourceRecord></v01:updateResourceRecord>");
   static String
       updateResourceRecordResponse =
       "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"


### PR DESCRIPTION
UltraDNS provider was failing on ttl update of a round-robin rrset of
type A or AAAA. The error code was 20000. This changes implementation
to use a different api when updating pooled records.

Thanks to @jonbodner for the help identifying the problem!