### PR TITLE
Unhooks discoverydns from 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ### Version 4.4
-* Adds support for DiscoveryDNS (http://www.discoverydns.com)
 * Accommodates UltraDNS accounts without directional support
 * Allows map credentials to be used without regard to iteration order
 * Changes DynECT to return type-safe rdata

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,18 +32,6 @@ url: https://alternative/rest/endpoint
 credentials:
   username: your_username
   password: your_password
----
-name: discoverydns-prod
-provider: discoverydns
-credentials:
-  certificatePem: |
-    -----BEGIN CERTIFICATE-----
-    [PEM CONTENT HERE]
-    -----END CERTIFICATE-----
-  keyPem: |
-    -----BEGIN PRIVATE KEY-----
-    [PEM CONTENT HERE]
-    -----END PRIVATE KEY-----
 ```
 
 Use the `-n` arg to select the named provider.

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -12,7 +12,6 @@ dependencies {
   compile      project(':denominator-route53')
   compile      project(':denominator-clouddns')
   compile      project(':denominator-designate')
-  compile      project(':denominator-discoverydns')
   testCompile  project(':denominator-model').sourceSets.test.output
   testCompile  project(':denominator-core').sourceSets.test.output
   testCompile 'junit:junit:4.12'

--- a/cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -50,7 +50,6 @@ public class DenominatorTest {
                              "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           password       username password",
                              "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           apiKey         username apiKey",
                              "designate  http://localhost:5000/v2.0                          true           password       tenantId username password",
-                             "discoverydns https://api.reseller.discoverydns.com               false          clientCertificate x509Certificate privateKey",
                              "dynect     https://api2.dynect.net/REST                        false          password       customer username password",
                              "mock       mem:mock                                            false          ",
                              "route53    https://route53.amazonaws.com                       true           accessKey      accessKey secretKey",

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name='denominator'
 
-include 'model', 'core', 'route53', 'ultradns', 'dynect', 'clouddns', 'designate', 'discoverydns', 'cli'
+include 'model', 'core', 'route53', 'ultradns', 'dynect', 'clouddns', 'designate', 'cli'
 
 rootProject.children.each { childProject ->
     childProject.name = 'denominator-' + childProject.name


### PR DESCRIPTION
DiscoveryDNS is not ready to be released as it has not been live tested.
This commit can be reverted once the above is false.

see #288