### PR TITLE
Polls DynECT on incomplete, even when http status is 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Accommodates UltraDNS accounts without directional support
 * Allows map credentials to be used without regard to iteration order
 * Changes DynECT to return type-safe rdata
+* Polls DynECT on incomplete, even when http status is 200
 * Updates to feign 7.3.0 and dagger 1.2.2
 * Reformats code according to [Google Java Style](https://google-styleguide.googlecode.com/svn/trunk/javaguide.html)
 * Removes java.beans.ConstructorProperties from value types

--- a/dynect/src/main/java/denominator/dynect/DynECTProvider.java
+++ b/dynect/src/main/java/denominator/dynect/DynECTProvider.java
@@ -79,8 +79,7 @@ public class DynECTProvider extends BasicProvider {
     profileToRecordTypes
         .put("roundRobin", Arrays.asList("A", "AAAA", "CERT", "DHCID", "DNAME", "DNSKEY", "DS",
                                          "IPSECKEY", "KEY", "KX", "LOC", "MX", "NAPTR", "NS",
-                                         "NSAP", "PTR", "PX", "RP", "SPF", "SRV", "SSHFP",
-                                         "TXT"));
+                                         "NSAP", "PTR", "PX", "RP", "SPF", "SRV", "SSHFP", "TXT"));
     return profileToRecordTypes;
   }
 

--- a/dynect/src/test/java/denominator/dynect/DynECTTest.java
+++ b/dynect/src/test/java/denominator/dynect/DynECTTest.java
@@ -61,8 +61,8 @@ public class DynECTTest {
   }
 
   @Test
-  public void incompleteRetries() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(400).setBody(incomplete));
+  public void incompleteRetriesOn200() throws Exception {
+    server.enqueue(new MockResponse().setBody(incomplete));
     server.enqueue(new MockResponse().setBody(zones));
 
     mockApi().zones();


### PR DESCRIPTION
DynECT occasionally sends back the wrong http status on incomplete. This
change ensures the request is retried even if the status was 200.

closes #261