### PR TITLE
Normalizes hashCode and equals for model classes

### DIFF
--- a/model/src/main/java/denominator/model/ResourceRecordSet.java
+++ b/model/src/main/java/denominator/model/ResourceRecordSet.java
@@ -133,32 +133,30 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (o == this) {
-      return true;
+  public boolean equals(Object obj) {
+    if (obj instanceof ResourceRecordSet) {
+      ResourceRecordSet<?> other = (ResourceRecordSet) obj;
+      return equal(name(), other.name())
+             && equal(type(), other.type())
+             && equal(qualifier(), other.qualifier())
+             && equal(ttl(), other.ttl())
+             && equal(records(), other.records())
+             && equal(geo(), other.geo())
+             && equal(weighted(), other.weighted());
     }
-    if (!(o instanceof ResourceRecordSet)) {
-      return false;
-    }
-    ResourceRecordSet<?> that = ResourceRecordSet.class.cast(o);
-    return equal(name(), that.name()) && equal(type(), that.type()) && equal(qualifier(),
-                                                                             that.qualifier())
-           && equal(ttl(), that.ttl()) && equal(records(), that.records()) && equal(geo(),
-                                                                                    that.geo())
-           && equal(weighted(), that.weighted());
+    return false;
   }
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * name().hashCode();
-    result = prime * type().hashCode();
-    result = prime * result + ((qualifier() == null) ? 0 : qualifier().hashCode());
-    result = prime * result + ((ttl() == null) ? 0 : ttl().hashCode());
-    result = prime * records().hashCode();
-    result = prime * result + ((geo() == null) ? 0 : geo().hashCode());
-    result = prime * result + ((weighted() == null) ? 0 : weighted().hashCode());
+    int result = 17;
+    result = 31 * result + name().hashCode();
+    result = 31 * result + type().hashCode();
+    result = 31 * result + (qualifier() != null ? qualifier().hashCode() : 0);
+    result = 31 * result + (ttl() != null ? ttl().hashCode() : 0);
+    result = 31 * records().hashCode();
+    result = 31 * result + (geo() != null ? geo().hashCode() : 0);
+    result = 31 * result + (weighted() != null ? weighted().hashCode() : 0);
     return result;
   }
 

--- a/model/src/main/java/denominator/model/Zone.java
+++ b/model/src/main/java/denominator/model/Zone.java
@@ -73,23 +73,20 @@ public class Zone {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (o == this) {
-      return true;
+  public boolean equals(Object obj) {
+    if (obj instanceof Zone) {
+      Zone other = (Zone) obj;
+      return equal(name(), other.name())
+             && equal(id(), other.id());
     }
-    if (!(o instanceof Zone)) {
-      return false;
-    }
-    Zone that = Zone.class.cast(o);
-    return equal(name(), that.name()) && equal(id(), that.id());
+    return false;
   }
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + name().hashCode();
-    result = prime * result + ((id() == null) ? 0 : id().hashCode());
+    int result = 17;
+    result = 31 * result + name().hashCode();
+    result = 31 * result + (id() != null ? id().hashCode() : 0);
     return result;
   }
 

--- a/model/src/main/java/denominator/model/profile/Geo.java
+++ b/model/src/main/java/denominator/model/profile/Geo.java
@@ -42,15 +42,8 @@ public class Geo {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (o == this) {
-      return true;
-    }
-    if (!(o instanceof Geo)) {
-      return false;
-    }
-    Geo that = Geo.class.cast(o);
-    return regions().equals(that.regions());
+  public boolean equals(Object obj) {
+    return obj instanceof Geo && regions().equals(((Geo) obj).regions());
   }
 
   @Override

--- a/model/src/main/java/denominator/model/profile/Geos.java
+++ b/model/src/main/java/denominator/model/profile/Geos.java
@@ -32,8 +32,7 @@ public class Geos {
       throws IllegalArgumentException {
     checkArgument(!regionsToAdd.isEmpty(), "no regions specified");
     checkArgument(existing.geo() != null, "rrset does not include geo configuration: %s", existing);
-    Map<String, Collection<String>>
-        regionsToApply =
+    Map<String, Collection<String>> regionsToApply =
         new LinkedHashMap<String, Collection<String>>();
     for (Entry<String, Collection<String>> entry : existing.geo().regions().entrySet()) {
       regionsToApply.put(entry.getKey(), entry.getValue());

--- a/model/src/main/java/denominator/model/profile/Weighted.java
+++ b/model/src/main/java/denominator/model/profile/Weighted.java
@@ -43,15 +43,8 @@ public class Weighted {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (o == this) {
-      return true;
-    }
-    if (!(o instanceof Weighted)) {
-      return false;
-    }
-    Weighted that = Weighted.class.cast(o);
-    return weight() == that.weight();
+  public boolean equals(Object obj) {
+    return obj instanceof Weighted && weight() == ((Weighted) obj).weight();
   }
 
   @Override

--- a/route53/src/main/java/denominator/route53/Route53AllProfileResourceRecordSetApi.java
+++ b/route53/src/main/java/denominator/route53/Route53AllProfileResourceRecordSetApi.java
@@ -15,7 +15,6 @@ import denominator.route53.Route53.ActionOnResourceRecordSet;
 import denominator.route53.Route53.ResourceRecordSetList;
 import denominator.route53.Route53.ResourceRecordSetList.NextRecord;
 
-import static denominator.common.Util.equal;
 import static denominator.common.Util.filter;
 import static denominator.common.Util.nextOrNull;
 import static denominator.common.Util.peekingIterator;
@@ -91,7 +90,7 @@ public final class Route53AllProfileResourceRecordSetApi implements AllProfileRe
       oldRRS = getByNameAndType(rrset.name(), rrset.type());
     }
     if (oldRRS != null) {
-      if (equal(oldRRS.ttl(), rrset.ttl()) && oldRRS.equals(rrset)) {
+      if (oldRRS.equals(rrset)) {
         return;
       }
       changes.add(delete(oldRRS));

--- a/route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
+++ b/route53/src/test/java/denominator/route53/Route53ResourceRecordSetApiMockTest.java
@@ -58,12 +58,12 @@ public class Route53ResourceRecordSetApiMockTest {
   }
 
   @Test
-  public void putRecreatesWhenPresent() throws Exception {
+  public void putRecreates_ttlChanged() throws Exception {
     server.enqueue(new MockResponse().setBody(oneRecord));
     server.enqueue(new MockResponse().setBody(changeSynced));
 
     ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("Z1PA6795UKMFR9");
-    api.put(a("www.denominator.io.", 10000000, Arrays.asList("192.0.2.1", "198.51.100.1")));
+    api.put(a("www.denominator.io.", 10000000, Arrays.asList("192.0.2.1")));
 
     server.assertRequest()
         .hasPath("/2012-12-12/hostedzone/Z1PA6795UKMFR9/rrset?name=www.denominator.io.&type=A");
@@ -71,7 +71,24 @@ public class Route53ResourceRecordSetApiMockTest {
         .hasMethod("POST")
         .hasPath("/2012-12-12/hostedzone/Z1PA6795UKMFR9/rrset")
         .hasXMLBody(
-            "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-12-12/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.denominator.io.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.denominator.io.</Name><Type>A</Type><TTL>10000000</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>");
+            "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-12-12/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.denominator.io.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.denominator.io.</Name><Type>A</Type><TTL>10000000</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>");
+  }
+
+  @Test
+  public void putRecreates_recordAdded() throws Exception {
+    server.enqueue(new MockResponse().setBody(oneRecord));
+    server.enqueue(new MockResponse().setBody(changeSynced));
+
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("Z1PA6795UKMFR9");
+    api.put(a("www.denominator.io.", 3600, Arrays.asList("192.0.2.1", "198.51.100.1")));
+
+    server.assertRequest()
+        .hasPath("/2012-12-12/hostedzone/Z1PA6795UKMFR9/rrset?name=www.denominator.io.&type=A");
+    server.assertRequest()
+        .hasMethod("POST")
+        .hasPath("/2012-12-12/hostedzone/Z1PA6795UKMFR9/rrset")
+        .hasXMLBody(
+            "<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-12-12/\"><ChangeBatch><Changes><Change><Action>DELETE</Action><ResourceRecordSet><Name>www.denominator.io.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change><Change><Action>CREATE</Action><ResourceRecordSet><Name>www.denominator.io.</Name><Type>A</Type><TTL>3600</TTL><ResourceRecords><ResourceRecord><Value>192.0.2.1</Value></ResourceRecord><ResourceRecord><Value>198.51.100.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>");
   }
 
   @Test


### PR DESCRIPTION
hashCode and equals were out-of-sync for ResourceRecordSet. This
distracted me, when looking at #319. This fixes that.