### PR TITLE
Simplifies Mock and CLI Test in preparation of zone write

### DIFF
--- a/cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
+++ b/cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
@@ -195,7 +195,8 @@ class GeoResourceRecordSetCommands {
         public String next() {
           GeoResourceRecordSetApi api = mgr.api().geoRecordSetsInZone(idOrName(mgr, zoneIdOrName));
           ResourceRecordSet<?> rrs = api.getByNameTypeAndQualifier(name, type, group);
-          if (rrs != null && rrs.ttl() != null && rrs.ttl().intValue() != ttl) {
+          if (rrs != null && 
+              (rrs.ttl() == null || (rrs.ttl() != null && rrs.ttl().intValue() != ttl))) {
             api.put(ResourceRecordSet.<Map<String, Object>>builder()
                         .name(name)
                         .type(type)
@@ -233,7 +234,7 @@ class GeoResourceRecordSetCommands {
     public String group;
 
     @Option(type = OptionType.COMMAND, required = true, name = {"-r",
-                                                                "--regions"}, description = "regions to add in json. ex. {\"Mexico\":[\"Mexico\"],\"South America\":[\"Ecuador\"]}")
+                                                                "--regions"}, description = "regions to add in json. ex. {\"Mexico\":[\"CM\"],\"United States\":[\"AZ\"]}")
     public String regions;
 
     @Option(type = OptionType.COMMAND, required = false, name = {
@@ -307,8 +308,7 @@ class GeoResourceRecordSetCommands {
         }.getType());
       } catch (RuntimeException e) {
         throw new IllegalArgumentException(
-            "parse failure on regions! check json syntax. ex. {\"United States (US)\":[\"Arizona\"]}",
-            e);
+            "parse failure on regions! check json syntax. ex. {\"United States\":[\"AZ\"]}", e);
       }
     }
   }

--- a/clouddns/src/test/java/denominator/clouddns/CloudDNSZoneApiMockTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/CloudDNSZoneApiMockTest.java
@@ -13,7 +13,7 @@ import denominator.model.Zone;
 import static denominator.assertj.ModelAssertions.assertThat;
 import static denominator.clouddns.RackspaceApisTest.domainId;
 import static denominator.clouddns.RackspaceApisTest.domainsResponse;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 
 public class CloudDNSZoneApiMockTest {
 

--- a/clouddns/src/test/java/denominator/clouddns/LimitsReadableMockTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/LimitsReadableMockTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import denominator.DNSApiManager;
 
 import static denominator.clouddns.RackspaceApisTest.limitsResponse;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class LimitsReadableMockTest {

--- a/core/src/main/java/denominator/BasicProvider.java
+++ b/core/src/main/java/denominator/BasicProvider.java
@@ -1,6 +1,5 @@
 package denominator;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -52,23 +51,18 @@ public abstract class BasicProvider implements Provider {
 
   @Override
   public Set<String> basicRecordTypes() {
-    Set<String> types = new LinkedHashSet<String>();
-    types.addAll(
-        asList("A", "AAAA", "CERT", "CNAME", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV",
-               "SSHFP", "TXT"));
-    return types;
+    Set<String> result = new LinkedHashSet<String>();
+    result.addAll(asList("A", "AAAA", "CERT", "CNAME", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF",
+                         "SRV", "SSHFP", "TXT"));
+    return result;
   }
 
   @Override
   public Map<String, Collection<String>> profileToRecordTypes() {
-    Map<String, Collection<String>>
-        profileToRecordTypes =
-        new LinkedHashMap<String, Collection<String>>();
-    List<String>
-        roundRobinType =
-        asList("A", "AAAA", "MX", "NS", "PTR", "SPF", "SRV", "SSHFP", "TXT");
-    profileToRecordTypes.put("roundRobin", roundRobinType);
-    return profileToRecordTypes;
+    Map<String, Collection<String>> result = new LinkedHashMap<String, Collection<String>>();
+    List<String> roundRobin = asList("A", "AAAA", "MX", "NS", "PTR", "SPF", "SRV", "SSHFP", "TXT");
+    result.put("roundRobin", roundRobin);
+    return result;
   }
 
   @Override
@@ -82,26 +76,30 @@ public abstract class BasicProvider implements Provider {
   }
 
   @Override
-  public int hashCode() {
-    return 37 * name().hashCode() + url().hashCode();
+  public boolean equals(Object obj) {
+    if (obj instanceof Provider) {
+      Provider other = (Provider) obj;
+      return name().equals(other.name())
+             && url().equals(other.url());
+    }
+    return false;
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
-    }
-    return this.name().equals(Provider.class.cast(obj).name()) && this.url()
-        .equals(Provider.class.cast(obj).url());
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + name().hashCode();
+    result = 31 * result + url().hashCode();
+    return result;
   }
 
   @Override
   public String toString() {
-    return new StringBuilder().append(getClass().getSimpleName()).append('{').append("name=")
-        .append(name())
-        .append(',').append("url=").append(url()).append('}').toString();
+    StringBuilder builder = new StringBuilder();
+    builder.append("Provider [");
+    builder.append("name=").append(name());
+    builder.append("url=").append(url());
+    builder.append("]");
+    return builder.toString();
   }
 }

--- a/core/src/main/java/denominator/mock/MockAllProfileResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/mock/MockAllProfileResourceRecordSetApi.java
@@ -1,16 +1,11 @@
 package denominator.mock;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.SortedSet;
 
-import javax.inject.Inject;
-
-import denominator.AllProfileResourceRecordSetApi;
-import denominator.Provider;
 import denominator.common.Filter;
 import denominator.model.ResourceRecordSet;
-import denominator.model.Zone;
 
 import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Preconditions.checkNotNull;
@@ -22,17 +17,16 @@ import static denominator.model.ResourceRecordSets.nameEqualTo;
 import static denominator.model.ResourceRecordSets.nameTypeAndQualifierEqualTo;
 import static denominator.model.ResourceRecordSets.notNull;
 
-public class MockAllProfileResourceRecordSetApi
-    implements denominator.AllProfileResourceRecordSetApi {
+class MockAllProfileResourceRecordSetApi implements denominator.AllProfileResourceRecordSetApi {
 
-  protected final Provider provider;
-  protected final SortedSet<ResourceRecordSet<?>> records;
-  protected final Filter<ResourceRecordSet<?>> filter;
+  private final Map<String, Collection<ResourceRecordSet<?>>> data;
+  private final String zoneName;
+  private final Filter<ResourceRecordSet<?>> filter;
 
-  MockAllProfileResourceRecordSetApi(Provider provider, SortedSet<ResourceRecordSet<?>> records,
-                                     Filter<ResourceRecordSet<?>> filter) {
-    this.provider = provider;
-    this.records = records;
+  MockAllProfileResourceRecordSetApi(Map<String, Collection<ResourceRecordSet<?>>> data,
+                                     String zoneName, Filter<ResourceRecordSet<?>> filter) {
+    this.data = data;
+    this.zoneName = zoneName;
     this.filter = filter;
   }
 
@@ -41,11 +35,12 @@ public class MockAllProfileResourceRecordSetApi
    */
   @Override
   public Iterator<ResourceRecordSet<?>> iterator() {
-    return filter(records.iterator(), filter);
+    return filter(records().iterator(), filter);
   }
 
   @Override
   public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
+    Collection<ResourceRecordSet<?>> records = records();
     return filter(records.iterator(), and(nameEqualTo(name), filter));
   }
 
@@ -53,13 +48,16 @@ public class MockAllProfileResourceRecordSetApi
     checkNotNull(rrset, "rrset was null");
     checkArgument(rrset.qualifier() != null, "no qualifier on: %s", rrset);
     checkArgument(valid.apply(rrset), "%s failed on: %s", valid, rrset);
-    ResourceRecordSet<?>
-        rrsMatch =
-        getByNameTypeAndQualifier(rrset.name(), rrset.type(), rrset.qualifier());
-    if (rrsMatch != null) {
-      records.remove(rrsMatch);
+    Collection<ResourceRecordSet<?>> records = records();
+    synchronized (records) {
+      ResourceRecordSet<?>
+          rrsMatch =
+          getByNameTypeAndQualifier(records, rrset.name(), rrset.type(), rrset.qualifier());
+      if (rrsMatch != null) {
+        records.remove(rrsMatch);
+      }
+      records.add(rrset);
     }
-    records.add(rrset);
   }
 
   @Override
@@ -69,12 +67,19 @@ public class MockAllProfileResourceRecordSetApi
 
   @Override
   public Iterator<ResourceRecordSet<?>> iterateByNameAndType(String name, String type) {
+    Collection<ResourceRecordSet<?>> records = records();
     return filter(records.iterator(), and(nameAndTypeEqualTo(name, type), filter));
   }
 
   @Override
   public ResourceRecordSet<?> getByNameTypeAndQualifier(String name, String type,
                                                         String qualifier) {
+    return getByNameTypeAndQualifier(records(), name, type, qualifier);
+  }
+
+  private ResourceRecordSet<?> getByNameTypeAndQualifier(Collection<ResourceRecordSet<?>> records,
+                                                         String name, String type,
+                                                         String qualifier) {
     Filter<ResourceRecordSet<?>>
         scoped =
         and(nameTypeAndQualifierEqualTo(name, type, qualifier), filter);
@@ -83,37 +88,28 @@ public class MockAllProfileResourceRecordSetApi
 
   @Override
   public void deleteByNameTypeAndQualifier(String name, String type, String qualifier) {
-    ResourceRecordSet<?> rrsMatch = getByNameTypeAndQualifier(name, type, qualifier);
-    if (rrsMatch != null) {
-      records.remove(rrsMatch);
+    Collection<ResourceRecordSet<?>> records = records();
+    synchronized (records) {
+      ResourceRecordSet<?> rrsMatch = getByNameTypeAndQualifier(records, name, type, qualifier);
+      if (rrsMatch != null) {
+        records.remove(rrsMatch);
+      }
     }
   }
 
   @Override
   public void deleteByNameAndType(String name, String type) {
-    for (Iterator<ResourceRecordSet<?>> it = iterateByNameAndType(name, type); it.hasNext(); ) {
-      records.remove(it.next());
+    Collection<ResourceRecordSet<?>> records = records();
+    synchronized (records) {
+      for (Iterator<ResourceRecordSet<?>> it = iterateByNameAndType(name, type); it.hasNext(); ) {
+        records.remove(it.next());
+      }
     }
   }
 
-  static class Factory implements denominator.AllProfileResourceRecordSetApi.Factory {
-
-    private final Provider provider;
-    private final Map<Zone, SortedSet<ResourceRecordSet<?>>> records;
-
-    // unbound wildcards are not currently injectable in dagger
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Inject
-    Factory(Provider provider, Map<Zone, SortedSet<ResourceRecordSet>> records) {
-      this.provider = provider;
-      this.records = Map.class.cast(records);
-    }
-
-    @Override
-    public AllProfileResourceRecordSetApi create(String idOrName) {
-      Zone zone = Zone.create(idOrName);
-      checkArgument(records.keySet().contains(zone), "zone %s not found", idOrName);
-      return new MockAllProfileResourceRecordSetApi(provider, records.get(zone), notNull());
-    }
+  Collection<ResourceRecordSet<?>> records() {
+    Collection<ResourceRecordSet<?>> result = data.get(zoneName);
+    checkArgument(result != null, "zone %s not found", zoneName);
+    return result;
   }
 }

--- a/core/src/main/java/denominator/mock/MockGeoResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/mock/MockGeoResourceRecordSetApi.java
@@ -7,22 +7,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.SortedSet;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import denominator.Provider;
 import denominator.common.Filter;
 import denominator.model.ResourceRecordSet;
-import denominator.model.Zone;
 import denominator.model.profile.Geo;
 import denominator.profile.GeoResourceRecordSetApi;
 
-import static denominator.common.Preconditions.checkArgument;
-
-public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRecordSetApi implements
-                                                                                          GeoResourceRecordSetApi {
+final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRecordSetApi
+    implements GeoResourceRecordSetApi {
 
   private static final Filter<ResourceRecordSet<?>> IS_GEO = new Filter<ResourceRecordSet<?>>() {
     @Override
@@ -33,9 +25,9 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
 
   private final Map<String, Collection<String>> supportedRegions;
 
-  MockGeoResourceRecordSetApi(Provider provider, SortedSet<ResourceRecordSet<?>> records,
+  MockGeoResourceRecordSetApi(Map<String, Collection<ResourceRecordSet<?>>> data, String zoneName,
                               Map<String, Collection<String>> supportedRegions) {
-    super(provider, records, IS_GEO);
+    super(data, zoneName, IS_GEO);
     this.supportedRegions = supportedRegions;
   }
 
@@ -46,14 +38,13 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
 
   @Override
   public void put(ResourceRecordSet<?> rrset) {
+    Collection<ResourceRecordSet<?>> records = records();
     synchronized (records) {
       put(IS_GEO, rrset);
       Geo newGeo = rrset.geo();
-      Iterator<ResourceRecordSet<?>>
-          iterateByNameAndType =
-          iterateByNameAndType(rrset.name(), rrset.type());
-      while (iterateByNameAndType.hasNext()) {
-        ResourceRecordSet<?> toTest = iterateByNameAndType.next();
+      Iterator<ResourceRecordSet<?>> nameAndType = iterateByNameAndType(rrset.name(), rrset.type());
+      while (nameAndType.hasNext()) {
+        ResourceRecordSet<?> toTest = nameAndType.next();
         if (toTest.qualifier().equals(rrset.qualifier())) {
           continue;
         }
@@ -73,39 +64,15 @@ public final class MockGeoResourceRecordSetApi extends MockAllProfileResourceRec
           }
         }
         records.remove(toTest);
-        records.add(ResourceRecordSet.<Map<String, Object>>builder() //
-                        .name(toTest.name())//
-                        .type(toTest.type())//
-                        .qualifier(toTest.qualifier())//
-                        .ttl(toTest.ttl())//
-                        .geo(Geo.create(without))//
-                        .weighted(toTest.weighted())//
+        records.add(ResourceRecordSet.builder()
+                        .name(toTest.name())
+                        .type(toTest.type())
+                        .qualifier(toTest.qualifier())
+                        .ttl(toTest.ttl())
+                        .geo(Geo.create(without))
+                        .weighted(toTest.weighted())
                         .addAll(toTest.records()).build());
       }
-    }
-  }
-
-  public static final class Factory implements GeoResourceRecordSetApi.Factory {
-
-    private final Map<Zone, SortedSet<ResourceRecordSet<?>>> records;
-    private final Map<String, Collection<String>> supportedRegions;
-    private Provider provider;
-
-    // unbound wildcards are not currently injectable in dagger
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Inject
-    Factory(Map<Zone, SortedSet<ResourceRecordSet>> records, Provider provider,
-            @Named("geo") Map<String, Collection<String>> supportedRegions) {
-      this.records = Map.class.cast(records);
-      this.provider = provider;
-      this.supportedRegions = supportedRegions;
-    }
-
-    @Override
-    public GeoResourceRecordSetApi create(String idOrName) {
-      Zone zone = Zone.create(idOrName);
-      checkArgument(records.keySet().contains(zone), "zone %s not found", idOrName);
-      return new MockGeoResourceRecordSetApi(provider, records.get(zone), supportedRegions);
     }
   }
 }

--- a/core/src/main/java/denominator/mock/MockProvider.java
+++ b/core/src/main/java/denominator/mock/MockProvider.java
@@ -1,16 +1,14 @@
 package denominator.mock;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentSkipListSet;
 
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import dagger.Provides;
@@ -22,26 +20,13 @@ import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
 import denominator.config.NothingToClose;
 import denominator.model.ResourceRecordSet;
-import denominator.model.Zone;
-import denominator.model.profile.Geo;
-import denominator.model.profile.Weighted;
-import denominator.model.rdata.AData;
-import denominator.model.rdata.CNAMEData;
-import denominator.model.rdata.SOAData;
 import denominator.profile.GeoResourceRecordSetApi;
 import denominator.profile.WeightedResourceRecordSetApi;
 
-import static denominator.model.ResourceRecordSets.a;
-import static denominator.model.ResourceRecordSets.cert;
-import static denominator.model.ResourceRecordSets.cname;
-import static denominator.model.ResourceRecordSets.mx;
-import static denominator.model.ResourceRecordSets.naptr;
-import static denominator.model.ResourceRecordSets.ns;
-import static denominator.model.ResourceRecordSets.ptr;
-import static denominator.model.ResourceRecordSets.spf;
-import static denominator.model.ResourceRecordSets.srv;
-import static denominator.model.ResourceRecordSets.sshfp;
-import static denominator.model.ResourceRecordSets.txt;
+import static denominator.common.Preconditions.checkArgument;
+import static denominator.model.ResourceRecordSets.notNull;
+import static java.util.Arrays.asList;
+import static java.util.Collections.synchronizedMap;
 
 /**
  * in-memory {@code Provider}, used for testing.
@@ -68,21 +53,45 @@ public class MockProvider extends BasicProvider {
 
   @Override
   public Map<String, Collection<String>> profileToRecordTypes() {
-    Map<String, Collection<String>> profileToRecordTypes = super.profileToRecordTypes();
-    profileToRecordTypes.put("geo", Arrays
-        .asList("A", "AAAA", "CNAME", "NS", "PTR", "SPF", "TXT", "MX", "SRV", "DS", "CERT", "NAPTR",
-                "SSHFP", "LOC", "TLSA"));
-    profileToRecordTypes.put("weighted", Arrays
-        .asList("A", "AAAA", "CNAME", "NS", "PTR", "SPF", "TXT", "MX", "SRV", "DS", "CERT", "NAPTR",
-                "SSHFP", "LOC", "TLSA"));
-    return profileToRecordTypes;
+    Map<String, Collection<String>> result = super.profileToRecordTypes();
+    List<String> special = new ArrayList<String>(basicRecordTypes());
+    special.remove("SOA");
+    result.put("geo", Collections.unmodifiableList(special));
+    result.put("weighted", result.get("geo"));
+    return result;
   }
 
-  // normally, we'd set package private visibility, but this module is helpful
-  // in tests, so we mark it public
   @dagger.Module(injects = DNSApiManager.class, complete = false, // denominator.Provider
       includes = NothingToClose.class)
   public static final class Module {
+
+    /**
+     * Backing data for all views.
+     */
+    private final Map<String, Collection<ResourceRecordSet<?>>> data;
+    private final Map<String, Collection<String>> supportedRegions;
+    private final SortedSet<Integer> supportedWeights;
+
+    public Module() {
+      data = synchronizedMap(new LinkedHashMap<String, Collection<ResourceRecordSet<?>>>(2));
+      SortedSet<Integer> weights = new TreeSet<Integer>();
+      for (int i = 0;i <= 100; i++) {
+        weights.add(i);
+      }
+      this.supportedWeights = Collections.unmodifiableSortedSet(weights);
+      Map<String, Collection<String>> region = new LinkedHashMap<String, Collection<String>>();
+      region.put("United States", asList("AL", "AK", "AS", "AZ", "AR", "AA", "AE", "AP", "CA", "CO",
+                                         "CT", "DE", "DC", "FM", "FL", "GA", "GU", "HI", "ID", "IL",
+                                         "IN", "IA", "KS", "KY", "LA", "ME", "MH", "MD", "MA", "MI",
+                                         "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
+                                         "NC", "ND", "MP", "OH", "OK", "OR", "PW", "PA", "PR", "RI",
+                                         "SC", "SD", "TN", "TX", "UT", "VT", "VI", "VA", "WA", "WV",
+                                         "WI", "WY"));
+      region.put("Mexico", asList("AG", "CM", "CP", "CH", "CA", "CL", "DU", "GJ", "GR", "HI", "JA",
+                                  "MX", "MC", "MR", "NA", "OA", "PU", "QE", "SI", "SO", "TB", "TM",
+                                  "TL", "VE", "YU", "ZA"));
+      this.supportedRegions = Collections.unmodifiableMap(region);
+    }
 
     @Provides
     CheckConnection alwaysOK() {
@@ -94,265 +103,50 @@ public class MockProvider extends BasicProvider {
     }
 
     @Provides
-    ZoneApi provideZoneApi(MockZoneApi in) {
-      return in;
-    }
-
-    @Provides
-    ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(
-        MockResourceRecordSetApi.Factory in) {
-      return in;
-    }
-
-    @Provides
-    AllProfileResourceRecordSetApi.Factory provideAllProfileResourceRecordSetApiFactory(
-        MockAllProfileResourceRecordSetApi.Factory in) {
-      return in;
-    }
-
-    @Provides
-    GeoResourceRecordSetApi.Factory provideGeoResourceRecordSetApiFactory(
-        MockGeoResourceRecordSetApi.Factory in) {
-      return in;
-    }
-
-    // unbound wildcards are not currently injectable in dagger
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Provides
     @Singleton
-    Map<Zone, SortedSet<ResourceRecordSet>> provideRecords() {
-      String idOrName = "denominator.io.";
-      Comparator<ResourceRecordSet<?>> toStringComparator = new Comparator<ResourceRecordSet<?>>() {
+    ZoneApi provideZoneApi() {
+      return new MockZoneApi(data);
+    }
+
+    @Provides
+    ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory() {
+      return new denominator.ResourceRecordSetApi.Factory() {
         @Override
-        public int compare(ResourceRecordSet<?> arg0, ResourceRecordSet<?> arg1) {
-          return arg0.toString().compareTo(arg1.toString());
+        public ResourceRecordSetApi create(String idOrName) {
+          return new MockResourceRecordSetApi(data, idOrName);
         }
       };
-      SortedSet<ResourceRecordSet<?>>
-          records =
-          new ConcurrentSkipListSet<ResourceRecordSet<?>>(toStringComparator);
-      records.add(ResourceRecordSet
-                      .builder()
-                      .type("SOA")
-                      .name(idOrName)
-                      .ttl(3600)
-                      .add(SOAData.builder().mname("ns1." + idOrName).rname("admin." + idOrName)
-                               .serial(1).refresh(3600)
-                               .retry(600).expire(604800).minimum(60).build()).build());
-      records.add(ns(idOrName, 86400, "ns1." + idOrName));
-      records.add(mx(idOrName, 86400, "1 mx1.denominator.io."));
-      records.add(spf(idOrName, 86400, "v=spf1 a mx -all"));
-      records.add(txt(idOrName, 86400, "blah"));
-      records.add(a("www1." + idOrName, 3600, Arrays.asList("192.0.2.1", "192.0.2.2")));
-      records.add(a("www2." + idOrName, 3600, "198.51.100.1"));
-      records.add(cname("www." + idOrName, 3600, "www1." + idOrName));
-      Map<String, Collection<String>> alazona = new LinkedHashMap<String, Collection<String>>();
-      alazona.put("United States (US)", Arrays.asList("Alaska", "Arizona"));
-      records.add(ResourceRecordSet.builder().name("www2.geo.denominator.io.")
-                      .type("A")
-                      .qualifier("alazona").ttl(300).add(AData.create("192.0.2.1"))
-                      .geo(Geo.create(alazona))
-                      .build());
-      records.add(ResourceRecordSet.builder().name("www.geo.denominator.io.")
-                      .type("CNAME")
-                      .qualifier("alazona").ttl(300).add(CNAMEData.create("a.denominator.io."))
-                      .geo(Geo.create(alazona)).build());
-      Map<String, Collection<String>> columbador = new LinkedHashMap<String, Collection<String>>();
-      columbador.put("South America", Arrays.asList("Colombia", "Ecuador"));
-      records.add(ResourceRecordSet.builder().name("www.geo.denominator.io.")
-                      .type("CNAME")
-                      .qualifier("columbador").ttl(86400).add(CNAMEData.create("b.denominator.io."))
-                      .geo(Geo.create(columbador)).build());
-      Map<String, Collection<String>> antarctica = new LinkedHashMap<String, Collection<String>>();
-      antarctica.put("Antarctica",
-                     Arrays.asList("Bouvet Island", "French Southern Territories", "Antarctica"));
-      records.add(ResourceRecordSet.builder().name("www.geo.denominator.io.")
-                      .type("CNAME")
-                      .qualifier("antarctica").ttl(0).add(CNAMEData.create("c.denominator.io."))
-                      .geo(Geo.create(antarctica)).build());
-      records.add(
-          ResourceRecordSet.builder().name("www2.weighted.denominator.io.")
-              .type("A").qualifier("US-West").ttl(0).add(AData.create("192.0.2.1"))
-              .weighted(Weighted.create(0)).build());
-      records
-          .add(ResourceRecordSet.builder().name("www.weighted.denominator.io.")
-                   .type("CNAME").qualifier("US-West").ttl(0)
-                   .add(CNAMEData.create("a.denominator.io."))
-                   .weighted(Weighted.create(1)).build());
-      records
-          .add(ResourceRecordSet.builder().name("www.weighted.denominator.io.")
-                   .type("CNAME").qualifier("US-East").ttl(0)
-                   .add(CNAMEData.create("b.denominator.io."))
-                   .weighted(Weighted.create(1)).build());
-      records
-          .add(ResourceRecordSet.builder().name("www.weighted.denominator.io.")
-                   .type("CNAME").qualifier("EU-West").ttl(0)
-                   .add(CNAMEData.create("c.denominator.io."))
-                   .weighted(Weighted.create(1)).build());
-      records.add(ns("subdomain." + idOrName, 3600, "ns1.denominator.io."));
-      records.add(naptr("phone." + idOrName, 3600,
-                        "1 1 U E2U+sip !^.*$!sip:customer-service@example.com! ."));
-      records.add(ptr("ptr." + idOrName, 3600, "www.denominator.io."));
-      records.add(srv("server1." + idOrName, 3600, "0 1 80 www.denominator.io."));
-      records.add(cert("server1." + idOrName, 3600, "12345 1 1 B33F"));
-      records.add(sshfp("server1." + idOrName, 3600, "1 1 B33F"));
-      Map<Zone, SortedSet<ResourceRecordSet<?>>>
-          zoneToRecords =
-          new LinkedHashMap<Zone, SortedSet<ResourceRecordSet<?>>>();
-      zoneToRecords.put(Zone.create(idOrName), records);
-      return Map.class.cast(zoneToRecords);
+    }
+
+
+    @Provides
+    AllProfileResourceRecordSetApi.Factory provideAllProfileResourceRecordSetApiFactory() {
+      return new denominator.AllProfileResourceRecordSetApi.Factory() {
+        @Override
+        public AllProfileResourceRecordSetApi create(String idOrName) {
+          return new MockAllProfileResourceRecordSetApi(data, idOrName, notNull());
+        }
+      };
     }
 
     @Provides
-    @Singleton
-    @Named("geo")
-    Map<String, Collection<String>> provideRegions() {
-      Map<String, Collection<String>> regions = new LinkedHashMap<String, Collection<String>>();
-      regions.put("Anonymous Proxy (A1)", Collections.singleton("Anonymous Proxy"));
-      regions.put("Satellite Provider (A2)", Collections.singleton("Satellite Provider"));
-      regions
-          .put("Unknown / Uncategorized IPs", Collections.singleton("Unknown / Uncategorized IPs"));
-      regions.put("United States (US)", Arrays.asList("Alabama", "Alaska", "Arizona", "Arkansas",
-                                                      "Armed Forces Americas",
-                                                      "Armed Forces Europe, Middle East, and Canada",
-                                                      "Armed Forces Pacific",
-                                                      "California", "Colorado", "Connecticut",
-                                                      "Delaware", "District of Columbia", "Florida",
-                                                      "Georgia",
-                                                      "Hawaii", "Idaho", "Illinois", "Indiana",
-                                                      "Iowa", "Kansas", "Kentucky", "Louisiana",
-                                                      "Maine",
-                                                      "Maryland", "Massachusetts", "Michigan",
-                                                      "Minnesota", "Mississippi", "Missouri",
-                                                      "Montana",
-                                                      "Nebraska", "Nevada", "New Hampshire",
-                                                      "New Jersey", "New Mexico", "New York",
-                                                      "North Carolina",
-                                                      "North Dakota", "Ohio", "Oklahoma", "Oregon",
-                                                      "Pennsylvania", "Rhode Island",
-                                                      "South Carolina",
-                                                      "South Dakota", "Tennessee", "Texas",
-                                                      "Undefined United States",
-                                                      "United States Minor Outlying Islands",
-                                                      "Utah", "Vermont", "Virginia", "Washington",
-                                                      "West Virginia", "Wisconsin", "Wyoming"));
-      regions.put("Mexico", Collections.singleton("Mexico"));
-      regions
-          .put("Canada (CA)", Arrays.asList("Alberta", "British Columbia", "Greenland", "Manitoba",
-                                            "New Brunswick", "Newfoundland and Labrador",
-                                            "Northwest Territories", "Nova Scotia", "Nunavut",
-                                            "Ontario", "Prince Edward Island", "Quebec",
-                                            "Saint Pierre and Miquelon", "Saskatchewan",
-                                            "Undefined Canada", "Yukon"));
-      regions
-          .put("The Caribbean", Arrays.asList("Anguilla", "Antigua and Barbuda", "Aruba", "Bahamas",
-                                              "Barbados", "Bermuda", "British Virgin Islands",
-                                              "Cayman Islands", "Cuba", "Dominica",
-                                              "Dominican Republic", "Grenada", "Guadeloupe",
-                                              "Haiti", "Jamaica", "Martinique", "Montserrat",
-                                              "Netherlands Antilles", "Puerto Rico",
-                                              "Saint Barthelemy", "Saint Martin",
-                                              "Saint Vincent and the Grenadines",
-                                              "St. Kitts and Nevis", "St. Lucia",
-                                              "Trinidad and Tobago",
-                                              "Turks and Caicos Islands", "U.S. Virgin Islands"));
-      regions
-          .put("Central America", Arrays.asList("Belize", "Costa Rica", "El Salvador", "Guatemala",
-                                                "Honduras", "Nicaragua", "Panama",
-                                                "Undefined Central America"));
-      regions
-          .put("South America", Arrays.asList("Argentina", "Bolivia", "Brazil", "Chile", "Colombia",
-                                              "Ecuador", "Falkland Islands", "French Guiana",
-                                              "Guyana", "Paraguay", "Peru",
-                                              "South Georgia and the South Sandwich Islands",
-                                              "Suriname", "Undefined South America", "Uruguay",
-                                              "Venezuela, Bolivarian Republic of"));
-      regions
-          .put("Europe", Arrays.asList("Aland Islands", "Albania", "Andorra", "Armenia", "Austria",
-                                       "Azerbaijan", "Belarus", "Belgium", "Bosnia-Herzegovina",
-                                       "Bulgaria", "Croatia", "Czech Republic",
-                                       "Denmark", "Estonia", "Faroe Islands", "Finland", "France",
-                                       "Georgia", "Germany", "Gibraltar",
-                                       "Greece", "Guernsey", "Hungary", "Iceland", "Ireland",
-                                       "Isle of Man", "Italy", "Jersey", "Latvia",
-                                       "Liechtenstein", "Lithuania", "Luxembourg",
-                                       "Macedonia, the former Yugoslav Republic of", "Malta",
-                                       "Moldova, Republic of", "Monaco", "Montenegro",
-                                       "Netherlands", "Norway", "Poland", "Portugal",
-                                       "Romania", "San Marino", "Serbia", "Slovakia", "Slovenia",
-                                       "Spain", "Svalbard and Jan Mayen",
-                                       "Sweden", "Switzerland", "Ukraine", "Undefined Europe",
-                                       "United Kingdom - England, Northern Ireland, Scotland, Wales",
-                                       "Vatican City"));
-      regions.put("Russian Federation", Collections.singleton("Russian Federation"));
-      regions.put("Middle East",
-                  Arrays.asList("Afghanistan", "Bahrain", "Cyprus", "Iran", "Iraq", "Israel",
-                                "Jordan", "Kuwait", "Lebanon", "Oman",
-                                "Palestinian Territory, Occupied", "Qatar", "Saudi Arabia",
-                                "Syrian Arab Republic", "Turkey, Republic of",
-                                "Undefined Middle East", "United Arab Emirates",
-                                "Yemen"));
-      regions.put("Africa",
-                  Arrays.asList("Algeria", "Angola", "Benin", "Botswana", "Burkina Faso", "Burundi",
-                                "Cameroon", "Cape Verde", "Central African Republic", "Chad",
-                                "Comoros", "Congo",
-                                "Cote d\u0027Ivoire", "Democratic Republic of the Congo",
-                                "Djibouti", "Egypt", "Equatorial Guinea",
-                                "Eritrea", "Ethiopia", "Gabon", "Gambia", "Ghana", "Guinea",
-                                "Guinea-Bissau", "Kenya", "Lesotho",
-                                "Liberia", "Libyan Arab Jamahiriya", "Madagascar", "Malawi", "Mali",
-                                "Mauritania", "Mauritius",
-                                "Mayotte", "Morocco", "Mozambique", "Namibia", "Niger", "Nigeria",
-                                "Reunion", "Rwanda",
-                                "Sao Tome and Principe", "Senegal", "Seychelles", "Sierra Leone",
-                                "Somalia", "South Africa",
-                                "St. Helena", "Sudan", "Swaziland", "Tanzania, United Republic of",
-                                "Togo", "Tunisia", "Uganda",
-                                "Undefined Africa", "Western Sahara", "Zambia", "Zimbabwe"));
-      regions.put("Asia", Arrays.asList("Bangladesh", "Bhutan",
-                                        "British Indian Ocean Territory - Chagos Islands",
-                                        "Brunei Darussalam", "Cambodia", "China",
-                                        "Hong Kong", "India", "Indonesia", "Japan", "Kazakhstan",
-                                        "Korea, Democratic People\u0027s Republic of",
-                                        "Korea, Republic of", "Kyrgyzstan",
-                                        "Lao People\u0027s Democratic Republic", "Macao",
-                                        "Malaysia", "Maldives", "Mongolia", "Myanmar",
-                                        "Nepal", "Pakistan", "Philippines", "Singapore",
-                                        "Sri Lanka", "Taiwan", "Tajikistan", "Thailand",
-                                        "Timor-Leste, Democratic Republic of", "Turkmenistan",
-                                        "Undefined Asia", "Uzbekistan", "Vietnam"));
-      regions.put("Australia / Oceania",
-                  Arrays.asList("American Samoa", "Australia", "Christmas Island",
-                                "Cocos (Keeling) Islands", "Cook Islands", "Fiji",
-                                "French Polynesia", "Guam",
-                                "Heard Island and McDonald Islands", "Kiribati", "Marshall Islands",
-                                "Micronesia , Federated States of", "Nauru", "New Caledonia",
-                                "New Zealand", "Niue",
-                                "Norfolk Island", "Northern Mariana Islands, Commonwealth of",
-                                "Palau", "Papua New Guinea",
-                                "Pitcairn", "Samoa", "Solomon Islands", "Tokelau", "Tonga",
-                                "Tuvalu",
-                                "Undefined Australia / Oceania", "Vanuatu", "Wallis and Futuna"));
-      regions.put("Antarctica",
-                  Arrays.asList("Antarctica", "Bouvet Island", "French Southern Territories"));
-      return Collections.unmodifiableMap(regions);
+    GeoResourceRecordSetApi.Factory provideGeoResourceRecordSetApiFactory() {
+      return new GeoResourceRecordSetApi.Factory() {
+        @Override
+        public GeoResourceRecordSetApi create(String idOrName) {
+          return new MockGeoResourceRecordSetApi(data, idOrName, supportedRegions);
+        }
+      };
     }
 
     @Provides
-    WeightedResourceRecordSetApi.Factory provideWeightedResourceRecordSetApiFactory(
-        MockWeightedResourceRecordSetApi.Factory in) {
-      return in;
-    }
-
-    @Provides
-    @Singleton
-    @Named("weighted")
-    SortedSet<Integer> provideSupportedWeights() {
-      SortedSet<Integer> supportedWeights = new TreeSet<Integer>();
-      for (int i = 0; i <= 100; i++) {
-        supportedWeights.add(i);
-      }
-      return Collections.unmodifiableSortedSet(supportedWeights);
+    WeightedResourceRecordSetApi.Factory provideWeightedResourceRecordSetApiFactory() {
+      return new WeightedResourceRecordSetApi.Factory() {
+        @Override
+        public WeightedResourceRecordSetApi create(String idOrName) {
+          return new MockWeightedResourceRecordSetApi(data, idOrName, supportedWeights);
+        }
+      };
     }
   }
 }

--- a/core/src/main/java/denominator/mock/MockResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/mock/MockResourceRecordSetApi.java
@@ -1,85 +1,62 @@
 package denominator.mock;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.SortedSet;
 
-import javax.inject.Inject;
-
-import denominator.ResourceRecordSetApi;
 import denominator.model.ResourceRecordSet;
-import denominator.model.Zone;
 
-import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Preconditions.checkNotNull;
-import static denominator.common.Util.and;
-import static denominator.common.Util.filter;
 import static denominator.common.Util.nextOrNull;
 import static denominator.model.ResourceRecordSets.alwaysVisible;
-import static denominator.model.ResourceRecordSets.nameAndTypeEqualTo;
-import static denominator.model.ResourceRecordSets.nameEqualTo;
 
-public final class MockResourceRecordSetApi implements denominator.ResourceRecordSetApi {
+final class MockResourceRecordSetApi implements denominator.ResourceRecordSetApi {
 
-  private final SortedSet<ResourceRecordSet<?>> records;
+  private final MockAllProfileResourceRecordSetApi delegate;
 
-  MockResourceRecordSetApi(SortedSet<ResourceRecordSet<?>> records) {
-    this.records = records;
+  MockResourceRecordSetApi(Map<String, Collection<ResourceRecordSet<?>>> data, String zoneName) {
+    this.delegate = new MockAllProfileResourceRecordSetApi(data, zoneName, alwaysVisible());
   }
 
-  /**
-   * sorted to help tests from breaking
-   */
   @Override
   public Iterator<ResourceRecordSet<?>> iterator() {
-    return filter(records.iterator(), alwaysVisible());
+    return delegate.iterator();
   }
 
   @Override
   public Iterator<ResourceRecordSet<?>> iterateByName(String name) {
-    return filter(records.iterator(), and(nameEqualTo(name), alwaysVisible()));
+    return delegate.iterateByName(name);
   }
 
   @Override
   public ResourceRecordSet<?> getByNameAndType(String name, String type) {
-    return nextOrNull(
-        filter(records.iterator(), and(nameAndTypeEqualTo(name, type), alwaysVisible())));
+    return nextOrNull(delegate.iterateByNameAndType(name, type));
   }
 
   @Override
   public void put(ResourceRecordSet<?> rrset) {
     checkNotNull(rrset, "rrset was null");
-    ResourceRecordSet<?> rrsMatch = getByNameAndType(rrset.name(), rrset.type());
-    if (rrsMatch != null) {
-      records.remove(rrsMatch);
+    Collection<ResourceRecordSet<?>> records = delegate.records();
+    synchronized (records) {
+      removeByNameAndType(records.iterator(), rrset.name(), rrset.type());
+      records.add(rrset);
     }
-    records.add(rrset);
+  }
+
+  private void removeByNameAndType(Iterator<ResourceRecordSet<?>> i, String name, String type) {
+    while (i.hasNext()) {
+      ResourceRecordSet<?> test = i.next();
+      if (test.name().equals(name) && test.type().equals(type) && test.qualifier() == null) {
+        i.remove();
+      }
+    }
   }
 
   @Override
   public void deleteByNameAndType(String name, String type) {
-    ResourceRecordSet<?> rrsMatch = getByNameAndType(name, type);
-    if (rrsMatch != null) {
-      records.remove(rrsMatch);
-    }
-  }
-
-  public static final class Factory implements denominator.ResourceRecordSetApi.Factory {
-
-    private final Map<Zone, SortedSet<ResourceRecordSet<?>>> records;
-
-    // unbound wildcards are not currently injectable in dagger
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Inject
-    Factory(Map<Zone, SortedSet<ResourceRecordSet>> records) {
-      this.records = Map.class.cast(records);
-    }
-
-    @Override
-    public ResourceRecordSetApi create(String idOrName) {
-      Zone zone = Zone.create(idOrName);
-      checkArgument(records.keySet().contains(zone), "zone %s not found", idOrName);
-      return new MockResourceRecordSetApi(records.get(zone));
+    Collection<ResourceRecordSet<?>> records = delegate.records();
+    synchronized (records) {
+      removeByNameAndType(records.iterator(), name, type);
     }
   }
 }

--- a/core/src/main/java/denominator/mock/MockWeightedResourceRecordSetApi.java
+++ b/core/src/main/java/denominator/mock/MockWeightedResourceRecordSetApi.java
@@ -1,22 +1,15 @@
 package denominator.mock;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.SortedSet;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import denominator.Provider;
 import denominator.common.Filter;
 import denominator.model.ResourceRecordSet;
-import denominator.model.Zone;
 import denominator.profile.WeightedResourceRecordSetApi;
 
-import static denominator.common.Preconditions.checkArgument;
-
-public final class MockWeightedResourceRecordSetApi extends MockAllProfileResourceRecordSetApi
-    implements
-    WeightedResourceRecordSetApi {
+final class MockWeightedResourceRecordSetApi extends MockAllProfileResourceRecordSetApi
+    implements WeightedResourceRecordSetApi {
 
   private static final Filter<ResourceRecordSet<?>>
       IS_WEIGHTED =
@@ -29,9 +22,10 @@ public final class MockWeightedResourceRecordSetApi extends MockAllProfileResour
 
   private final SortedSet<Integer> supportedWeights;
 
-  MockWeightedResourceRecordSetApi(Provider provider, SortedSet<ResourceRecordSet<?>> records,
+  MockWeightedResourceRecordSetApi(Map<String, Collection<ResourceRecordSet<?>>> data,
+                                   String zoneName,
                                    SortedSet<Integer> supportedWeights) {
-    super(provider, records, IS_WEIGHTED);
+    super(data, zoneName, IS_WEIGHTED);
     this.supportedWeights = supportedWeights;
   }
 
@@ -43,29 +37,5 @@ public final class MockWeightedResourceRecordSetApi extends MockAllProfileResour
   @Override
   public void put(ResourceRecordSet<?> rrset) {
     put(IS_WEIGHTED, rrset);
-  }
-
-  public static final class Factory implements WeightedResourceRecordSetApi.Factory {
-
-    private final Map<Zone, SortedSet<ResourceRecordSet<?>>> records;
-    private final SortedSet<Integer> supportedWeights;
-    private Provider provider;
-
-    // unbound wildcards are not currently injectable in dagger
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Inject
-    Factory(Map<Zone, SortedSet<ResourceRecordSet>> records, Provider provider,
-            @Named("weighted") SortedSet<Integer> supportedWeights) {
-      this.records = Map.class.cast(records);
-      this.provider = provider;
-      this.supportedWeights = supportedWeights;
-    }
-
-    @Override
-    public WeightedResourceRecordSetApi create(String idOrName) {
-      Zone zone = Zone.create(idOrName);
-      checkArgument(records.keySet().contains(zone), "zone %s not found", idOrName);
-      return new MockWeightedResourceRecordSetApi(provider, records.get(zone), supportedWeights);
-    }
   }
 }

--- a/core/src/main/java/denominator/mock/MockZoneApi.java
+++ b/core/src/main/java/denominator/mock/MockZoneApi.java
@@ -1,27 +1,69 @@
 package denominator.mock;
 
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.SortedSet;
-
-import javax.inject.Inject;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import denominator.model.ResourceRecordSet;
 import denominator.model.Zone;
+import denominator.model.rdata.SOAData;
 
-public final class MockZoneApi implements denominator.ZoneApi {
+import static denominator.common.Preconditions.checkArgument;
+import static denominator.model.ResourceRecordSets.ns;
 
-  private final Map<Zone, SortedSet<ResourceRecordSet<?>>> data;
+final class MockZoneApi implements denominator.ZoneApi {
 
-  // unbound wildcards are not currently injectable in dagger
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  @Inject
-  MockZoneApi(Map<Zone, SortedSet<ResourceRecordSet>> data) {
-    this.data = Map.class.cast(data);
+  private static final Comparator<ResourceRecordSet<?>> TO_STRING =
+      new Comparator<ResourceRecordSet<?>>() {
+        @Override
+        public int compare(ResourceRecordSet<?> arg0, ResourceRecordSet<?> arg1) {
+          return arg0.toString().compareTo(arg1.toString());
+        }
+      };
+
+  private final Map<String, Collection<ResourceRecordSet<?>>> data;
+
+  MockZoneApi(Map<String, Collection<ResourceRecordSet<?>>> data) {
+    this.data = data;
+    create("denominator.io.");
+  }
+
+  public void create(String idOrName) {
+    checkArgument(!data.containsKey(idOrName), "zone %s already exists", idOrName);
+    Collection<ResourceRecordSet<?>>
+        zone =
+        new ConcurrentSkipListSet<ResourceRecordSet<?>>(TO_STRING);
+    zone.add(ResourceRecordSet.builder()
+                 .type("SOA")
+                 .name(idOrName)
+                 .ttl(3600)
+                 .add(SOAData.builder().mname("ns1." + idOrName).rname("admin." + idOrName)
+                          .serial(1).refresh(3600).retry(600).expire(604800).minimum(60).build())
+                 .build());
+    zone.add(ns(idOrName, 86400, "ns1." + idOrName));
+    data.put(idOrName, zone);
   }
 
   @Override
   public Iterator<Zone> iterator() {
-    return data.keySet().iterator();
+    final Iterator<String> delegate = data.keySet().iterator();
+    return new Iterator<Zone>() {
+      @Override
+      public boolean hasNext() {
+        return delegate.hasNext();
+      }
+
+      @Override
+      public Zone next() {
+        return Zone.create(delegate.next());
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException("remove");
+      }
+    };
   }
 }

--- a/core/src/test/java/denominator/DynamicCredentialsProviderExampleTest.java
+++ b/core/src/test/java/denominator/DynamicCredentialsProviderExampleTest.java
@@ -6,12 +6,10 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.inject.Inject;
@@ -23,8 +21,6 @@ import denominator.config.GeoUnsupported;
 import denominator.config.NothingToClose;
 import denominator.config.OnlyBasicResourceRecordSets;
 import denominator.config.WeightedUnsupported;
-import denominator.mock.MockResourceRecordSetApi;
-import denominator.model.ResourceRecordSet;
 import denominator.model.Zone;
 
 import static denominator.CredentialsConfiguration.anonymous;
@@ -189,17 +185,15 @@ public class DynamicCredentialsProviderExampleTest {
        * using mock as example case is made already with the zone api
        */
       @Provides
-      ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory(
-          MockResourceRecordSetApi.Factory in) {
-        return in;
-      }
+      ResourceRecordSetApi.Factory provideResourceRecordSetApiFactory() {
+        return new ResourceRecordSetApi.Factory() {
+          final DNSApi mock = Denominator.create("mock").api();
 
-      // unbound wildcards are not currently injectable in dagger
-      @SuppressWarnings("rawtypes")
-      @Provides
-      @Singleton
-      Map<Zone, SortedSet<ResourceRecordSet>> provideRecords() {
-        return Collections.emptyMap();
+          @Override
+          public ResourceRecordSetApi create(String idOrName) {
+            return mock.basicRecordSetsInZone(idOrName);
+          }
+        };
       }
 
       /**

--- a/core/src/test/java/denominator/mock/MockProviderTest.java
+++ b/core/src/test/java/denominator/mock/MockProviderTest.java
@@ -1,10 +1,8 @@
-package denominator;
+package denominator.mock;
 
 import org.junit.Test;
 
 import denominator.Provider;
-import denominator.mock.MockProvider;
-import denominator.mock.MockZoneApi;
 
 import static denominator.Denominator.create;
 import static denominator.Providers.list;

--- a/model/src/main/java/denominator/model/ResourceRecordSet.java
+++ b/model/src/main/java/denominator/model/ResourceRecordSet.java
@@ -154,7 +154,7 @@ public class ResourceRecordSet<D extends Map<String, Object>> {
     result = 31 * result + type().hashCode();
     result = 31 * result + (qualifier() != null ? qualifier().hashCode() : 0);
     result = 31 * result + (ttl() != null ? ttl().hashCode() : 0);
-    result = 31 * records().hashCode();
+    result = 31 * result + records().hashCode();
     result = 31 * result + (geo() != null ? geo().hashCode() : 0);
     result = 31 * result + (weighted() != null ? weighted().hashCode() : 0);
     return result;


### PR DESCRIPTION
Zone write support requires preliminary work in mock, as it formerly
assumed there was a single zone. This refactors mock to be simpler, and
removes duplicate work around stock records. The latter impacted the
CLI test, which was dependent on stock records in mock.

See #264