### PR TITLE
Publishes model and core test jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Version 4.5
 * Documents third-party provider process
+* Publishes model and core test jars
 * Adds example server
 
 ### Version 4.4.2

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'nebula-test-jar'
 
 sourceCompatibility = 1.6
 

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'nebula-test-jar'
 
 sourceCompatibility = 1.6
 


### PR DESCRIPTION
Verified that after doing `./gradlew clean test install` the jars pop up in the right place.

```bash
$ find ~/.m2/repository/com/netflix/denominator/ -name \*test\*.jar
/Users/user/.m2/repository/com/netflix/denominator//denominator-core/0.1.0-SNAPSHOT/denominator-core-0.1.0-SNAPSHOT-tests.jar
/Users/user/.m2/repository/com/netflix/denominator//denominator-model/0.1.0-SNAPSHOT/denominator-model-0.1.0-SNAPSHOT-tests.jar
```

closes #343