### PR TITLE
Enforces source compatibility with animal-sniffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Documents third-party provider process
 * Publishes model and core test jars
 * Adds example server
+* Enforces source compatibility with animal-sniffer
 
 ### Version 4.4.2
 * Updates to feign 8.1

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+    repositories { jcenter() }
+    dependencies {
+        classpath 'be.insaneprogramming.gradle:animalsniffer-gradle-plugin:1.4.0'
+    }
+}
+
 plugins {
     id 'nebula.netflixoss' version '2.2.9'
 }
@@ -14,4 +21,9 @@ subprojects {
     }
     apply from: rootProject.file('dagger.gradle')
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
+    apply plugin: 'be.insaneprogramming.gradle.animalsniffer'
+
+    animalsniffer { // Don't use apis that may not be available on Android
+        signature = "org.codehaus.mojo.signature:java16:+@signature"
+    }
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'java'
 
+animalsniffer { // Don't use apis that require JRE 8
+    signature = "org.codehaus.mojo.signature:java17:+@signature"
+}
+
 sourceCompatibility = 1.6
 
 dependencies {


### PR DESCRIPTION
Before, finding source compatibility issues relied on building with an
old JDK. This uses animal-sniffer to enforce java language level 6 for
libraries and 7 for executables.

closes #344