### PR TITLE
Corrects Designate implementation as it doesn't support duplicate zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Publishes model and core test jars
 * Adds example server
 * Enforces source compatibility with animal-sniffer
+* Corrects Designate implementation as it doesn't support duplicate zones
 
 ### Version 4.4.2
 * Updates to feign 8.1

--- a/cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -65,7 +65,7 @@ public class DenominatorTest {
                              "provider   url                                                 duplicateZones credentialType credentialArgs",
                              "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           password       username password",
                              "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           apiKey         username apiKey",
-                             "designate  http://localhost:5000/v2.0                          true           password       tenantId username password",
+                             "designate  http://localhost:5000/v2.0                          false          password       tenantId username password",
                              "dynect     https://api2.dynect.net/REST                        false          password       customer username password",
                              "mock       mem:mock                                            false          ",
                              "route53    https://route53.amazonaws.com                       true           accessKey      accessKey secretKey",

--- a/designate/src/main/java/denominator/designate/Designate.java
+++ b/designate/src/main/java/denominator/designate/Designate.java
@@ -8,7 +8,7 @@ import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 
-// http://docs.hpcloud.com/api/dns/#4.RESTAPISpecifications
+// http://designate.readthedocs.org/en/latest/rest.html#v1-api
 public interface Designate {
 
   @RequestLine("GET /limits")
@@ -16,6 +16,9 @@ public interface Designate {
 
   @RequestLine("GET /domains")
   List<Zone> domains();
+
+  @RequestLine("GET /domains")
+  Map<String, String> domainIdsByName();
 
   @RequestLine("GET /domains/{domainId}/records")
   List<Record> records(@Param("domainId") String domainId);

--- a/designate/src/main/java/denominator/designate/DesignateAdapters.java
+++ b/designate/src/main/java/denominator/designate/DesignateAdapters.java
@@ -7,8 +7,10 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import denominator.designate.Designate.Record;
 import denominator.model.Zone;
@@ -78,6 +80,48 @@ class DesignateAdapters {
     }
   }
 
+  static class DomainNameToIdAdapter extends TypeAdapter<Map<String, String>> {
+
+    @Override
+    public Map<String, String> read(JsonReader reader) throws IOException {
+      Map<String, String> result = new LinkedHashMap<String, String>();
+      reader.beginObject();
+      while (reader.hasNext()) {
+        String nextName = reader.nextName();
+        if ("domains".equals(nextName)) {
+          reader.beginArray();
+          while (reader.hasNext()) {
+            reader.beginObject();
+            String name = null;
+            String id = null;
+            while (reader.hasNext()) {
+              nextName = reader.nextName();
+              if (nextName.equals("name")) {
+                name = reader.nextString();
+              } else if (nextName.equals("id")) {
+                id = reader.nextString();
+              } else {
+                reader.skipValue();
+              }
+            }
+            result.put(name, id);
+            reader.endObject();
+          }
+          reader.endArray();
+        } else {
+          reader.skipValue();
+        }
+      }
+      reader.endObject();
+      return result;
+    }
+
+    @Override
+    public void write(JsonWriter out, Map<String, String> value) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
+
   static class DomainListAdapter extends ListAdapter<Zone> {
 
     @Override
@@ -87,18 +131,14 @@ class DesignateAdapters {
 
     protected Zone build(JsonReader reader) throws IOException {
       String name = null;
-      String id = null;
       while (reader.hasNext()) {
-        String key = reader.nextName();
-        if (key.equals("name")) {
+        if (reader.nextName().equals("name")) {
           name = reader.nextString();
-        } else if (key.equals("id")) {
-          id = reader.nextString();
         } else {
           reader.skipValue();
         }
       }
-      return Zone.create(name, id);
+      return Zone.create(name);
     }
   }
 

--- a/designate/src/main/java/denominator/designate/DesignateProvider.java
+++ b/designate/src/main/java/denominator/designate/DesignateProvider.java
@@ -23,6 +23,7 @@ import denominator.config.NothingToClose;
 import denominator.config.OnlyBasicResourceRecordSets;
 import denominator.config.WeightedUnsupported;
 import denominator.designate.DesignateAdapters.DomainListAdapter;
+import denominator.designate.DesignateAdapters.DomainNameToIdAdapter;
 import denominator.designate.DesignateAdapters.RecordAdapter;
 import denominator.designate.DesignateAdapters.RecordListAdapter;
 import feign.Feign;
@@ -66,11 +67,6 @@ public class DesignateProvider extends BasicProvider {
         new LinkedHashMap<String, Collection<String>>();
     profileToRecordTypes.put("roundRobin", Arrays.asList("A", "AAAA", "MX", "NS", "SRV", "TXT"));
     return profileToRecordTypes;
-  }
-
-  @Override
-  public boolean supportsDuplicateZoneNames() {
-    return true;
   }
 
   @Override
@@ -144,6 +140,7 @@ public class DesignateProvider extends BasicProvider {
                        new KeystoneV2AccessAdapter(),
                        recordAdapter,
                        new DomainListAdapter(),
+                       new DomainNameToIdAdapter(),
                        new RecordListAdapter()))
           )
           .build();

--- a/designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
+++ b/designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
@@ -117,8 +117,11 @@ class DesignateResourceRecordSetApi implements denominator.ResourceRecordSetApi 
     }
 
     @Override
-    public ResourceRecordSetApi create(String id) {
-      return new DesignateResourceRecordSetApi(api, checkNotNull(id, "id"));
+    public ResourceRecordSetApi create(String name) {
+      checkNotNull(name, "name");
+      String id = api.domainIdsByName().get(name);
+      checkArgument(id != null, "zone %s does not exist", name);
+      return new DesignateResourceRecordSetApi(api, id);
     }
   }
 }

--- a/designate/src/test/java/denominator/designate/DesignateProviderTest.java
+++ b/designate/src/test/java/denominator/designate/DesignateProviderTest.java
@@ -29,7 +29,7 @@ public class DesignateProviderTest {
   @Test
   public void testDesignateMetadata() {
     assertThat(PROVIDER.name()).isEqualTo("designate");
-    assertThat(PROVIDER.supportsDuplicateZoneNames()).isTrue();
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isFalse();
     assertThat(PROVIDER.credentialTypeToParameterNames())
         .containsEntry("password", Arrays.asList("tenantId", "username", "password"));
   }

--- a/designate/src/test/java/denominator/designate/DesignateTest.java
+++ b/designate/src/test/java/denominator/designate/DesignateTest.java
@@ -67,7 +67,21 @@ public class DesignateTest {
     server.enqueue(new MockResponse().setBody(domainsResponse));
 
     assertThat(mockApi().domains())
-        .containsExactly(Zone.create("denominator.io.", domainId));
+        .containsExactly(Zone.create("denominator.io."));
+
+    server.assertAuthRequest();
+    server.assertRequest()
+        .hasMethod("GET")
+        .hasPath("/v1/domains");
+  }
+
+  @Test
+  public void domainIdsByNamePresent() throws Exception {
+    server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
+
+    assertThat(mockApi().domainIdsByName())
+        .containsEntry("denominator.io.", domainId);
 
     server.assertAuthRequest();
     server.assertRequest()

--- a/designate/src/test/java/denominator/designate/DesignateZoneApiMockTest.java
+++ b/designate/src/test/java/denominator/designate/DesignateZoneApiMockTest.java
@@ -11,7 +11,6 @@ import denominator.ZoneApi;
 import denominator.model.Zone;
 
 import static denominator.assertj.ModelAssertions.assertThat;
-import static denominator.designate.DesignateTest.domainId;
 import static denominator.designate.DesignateTest.domainsResponse;
 
 public class DesignateZoneApiMockTest {
@@ -28,8 +27,7 @@ public class DesignateZoneApiMockTest {
     Iterator<Zone> domains = api.iterator();
 
     assertThat(domains.next())
-        .hasName("denominator.io.")
-        .hasId(domainId);
+        .hasName("denominator.io.");
 
     server.assertAuthRequest();
     server.assertRequest().hasPath("/v1/domains");


### PR DESCRIPTION
Note: this impacts CLI usage, as formerly you'd pass a UUID to affect designate zones. Now, you pass the zone name.

Live tested on hpcloud via...

```bash
$ ./gradlew clean test install  -Ddesignate.url=https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/ -Ddesignate.tenantId=XXX -Ddesignate.username=XXX -Ddesignate.password=XXX -Ddesignate.zone=denominator.io.
```