### PR TITLE
Corrects CloudDNS implementation as it doesn't support duplicate zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Publishes model and core test jars
 * Adds example server
 * Enforces source compatibility with animal-sniffer
-* Corrects Designate implementation as it doesn't support duplicate zones
+* Corrects CloudDNS and Designate implementations as they don't support duplicate zones
 
 ### Version 4.4.2
 * Updates to feign 8.1

--- a/cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -63,8 +63,8 @@ public class DenominatorTest {
     assertThat(ListProviders.providerAndCredentialsTable())
         .isEqualTo(Util.join('\n',
                              "provider   url                                                 duplicateZones credentialType credentialArgs",
-                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           password       username password",
-                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        true           apiKey         username apiKey",
+                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        false          password       username password",
+                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        false          apiKey         username apiKey",
                              "designate  http://localhost:5000/v2.0                          false          password       tenantId username password",
                              "dynect     https://api2.dynect.net/REST                        false          password       customer username password",
                              "mock       mem:mock                                            false          ",

--- a/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
+++ b/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
@@ -15,6 +15,7 @@ import denominator.CheckConnection;
 import denominator.DNSApiManager;
 import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
+import denominator.clouddns.RackspaceAdapters.DomainIdListAdapter;
 import denominator.clouddns.RackspaceAdapters.DomainListAdapter;
 import denominator.clouddns.RackspaceAdapters.JobIdAndStatusAdapter;
 import denominator.clouddns.RackspaceAdapters.RecordListAdapter;
@@ -71,11 +72,6 @@ public class CloudDNSProvider extends BasicProvider {
   }
 
   @Override
-  public boolean supportsDuplicateZoneNames() {
-    return true;
-  }
-
-  @Override
   public Map<String, Collection<String>> credentialTypeToParameterNames() {
     Map<String, Collection<String>> options = new LinkedHashMap<String, Collection<String>>();
     options.put("password", Arrays.asList("username", "password"));
@@ -109,7 +105,7 @@ public class CloudDNSProvider extends BasicProvider {
   }
 
   @dagger.Module(injects = CloudDNSResourceRecordSetApi.Factory.class,
-      complete = false // doesn't bind Provider used by DesignateTarget
+      complete = false // doesn't bind Provider used by CloudDNSTarget
   )
   public static final class FeignModule {
 
@@ -146,6 +142,7 @@ public class CloudDNSProvider extends BasicProvider {
                        new KeystoneAccessAdapter("rax:dns"),
                        new JobIdAndStatusAdapter(),
                        new DomainListAdapter(),
+                       new DomainIdListAdapter(),
                        new RecordListAdapter()))
           )
           .build();

--- a/clouddns/src/main/java/denominator/clouddns/RackspaceAdapters.java
+++ b/clouddns/src/main/java/denominator/clouddns/RackspaceAdapters.java
@@ -9,7 +9,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Comparator;
 
-import denominator.clouddns.RackspaceApis.JobIdAndStatus;
+import denominator.clouddns.RackspaceApis.Job;
 import denominator.clouddns.RackspaceApis.ListWithNext;
 import denominator.clouddns.RackspaceApis.Record;
 import denominator.model.Zone;
@@ -28,25 +28,25 @@ class RackspaceAdapters {
     return Comparator.class.cast(TO_STRING_COMPARATOR);
   }
 
-  static class JobIdAndStatusAdapter extends TypeAdapter<JobIdAndStatus> {
+  static class JobIdAndStatusAdapter extends TypeAdapter<Job> {
 
     @Override
-    public void write(JsonWriter out, JobIdAndStatus value) throws IOException {
+    public void write(JsonWriter out, Job value) throws IOException {
       // never need to write this object
     }
 
     @Override
-    public JobIdAndStatus read(JsonReader reader) throws IOException {
-      JobIdAndStatus jobIdAndStatus = new JobIdAndStatus();
+    public Job read(JsonReader reader) throws IOException {
+      Job job = new Job();
 
       reader.beginObject();
 
       while (reader.hasNext()) {
         String key = reader.nextName();
         if (key.equals("jobId")) {
-          jobIdAndStatus.id = reader.nextString();
+          job.id = reader.nextString();
         } else if (key.equals("status")) {
-          jobIdAndStatus.status = reader.nextString();
+          job.status = reader.nextString();
         } else {
           reader.skipValue();
         }
@@ -54,10 +54,34 @@ class RackspaceAdapters {
 
       reader.endObject();
 
-      return jobIdAndStatus;
+      return job;
     }
   }
 
+  static class DomainIdListAdapter extends ListWithNextAdapter<Integer> {
+
+    @Override
+    protected String jsonKey() {
+      return "domains";
+    }
+
+    protected Integer build(JsonReader reader) throws IOException {
+      Integer id = null;
+      while (reader.hasNext()) {
+        if (reader.nextName().equals("id")) {
+          id = reader.nextInt();
+        } else {
+          reader.skipValue();
+        }
+      }
+      return id;
+    }
+  }
+
+  /**
+   * Note that we do not expose the ID back to the user as ID isn't semantic when the API doesn't
+   * support multiple zones
+   */
   static class DomainListAdapter extends ListWithNextAdapter<Zone> {
 
     @Override
@@ -69,11 +93,8 @@ class RackspaceAdapters {
       String name = null;
       String id = null;
       while (reader.hasNext()) {
-        String key = reader.nextName();
-        if (key.equals("name")) {
+        if (reader.nextName().equals("name")) {
           name = reader.nextString();
-        } else if (key.equals("id")) {
-          id = reader.nextString();
         } else {
           reader.skipValue();
         }

--- a/clouddns/src/main/java/denominator/clouddns/RackspaceApis.java
+++ b/clouddns/src/main/java/denominator/clouddns/RackspaceApis.java
@@ -44,7 +44,14 @@ class RackspaceApis {
     Map<String, Object> limits();
 
     @RequestLine("GET /status/{jobId}?showDetails=true")
-    JobIdAndStatus getStatus(@Param("jobId") String jobId);
+    Job getStatus(@Param("jobId") String jobId);
+
+    /**
+     * Note this doesn't make sense to return anything except one or none, as duplicate domains
+     * aren't permitted in the create api.
+     */
+    @RequestLine("GET /domains?name={name}")
+    ListWithNext<Integer> domainIdsByName(@Param("name") String name);
 
     @RequestLine("GET")
     ListWithNext<Zone> domains(URI href);
@@ -66,27 +73,25 @@ class RackspaceApis {
     @RequestLine("POST /domains/{domainId}/records")
     @Body("%7B\"records\":[%7B\"name\":\"{name}\",\"type\":\"{type}\",\"ttl\":\"{ttl}\",\"data\":\"{data}\"%7D]%7D")
     @Headers("Content-Type: application/json")
-    JobIdAndStatus createRecord(@Param("domainId") int id, @Param("name") String name,
-                                @Param("type") String type, @Param("ttl") int ttl,
-                                @Param("data") String data);
+    Job createRecord(@Param("domainId") int id, @Param("name") String name,
+                     @Param("type") String type, @Param("ttl") int ttl, @Param("data") String data);
 
     @RequestLine("POST /domains/{domainId}/records")
     @Body("%7B\"records\":[%7B\"name\":\"{name}\",\"type\":\"{type}\",\"ttl\":\"{ttl}\",\"data\":\"{data}\",\"priority\":\"{priority}\"%7D]%7D")
     @Headers("Content-Type: application/json")
-    JobIdAndStatus createRecordWithPriority(@Param("domainId") int id, @Param("name") String name,
-                                            @Param("type") String type, @Param("ttl") int ttl,
-                                            @Param("data") String data,
-                                            @Param("priority") int priority);
+    Job createRecordWithPriority(@Param("domainId") int id, @Param("name") String name,
+                                 @Param("type") String type, @Param("ttl") int ttl,
+                                 @Param("data") String data, @Param("priority") int priority);
 
     @RequestLine("PUT /domains/{domainId}/records/{recordId}")
     @Body("%7B\"ttl\":\"{ttl}\",\"data\":\"{data}\"%7D")
     @Headers("Content-Type: application/json")
-    JobIdAndStatus updateRecord(@Param("domainId") int domainId, @Param("recordId") String recordId,
-                                @Param("ttl") int ttl, @Param("data") String data);
+    Job updateRecord(@Param("domainId") int domainId, @Param("recordId") String recordId,
+                     @Param("ttl") int ttl, @Param("data") String data);
 
     @RequestLine("DELETE /domains/{domainId}/records/{recordId}")
-    JobIdAndStatus deleteRecord(@Param("domainId") int domainId,
-                                @Param("recordId") String recordId);
+    Job deleteRecord(@Param("domainId") int domainId,
+                     @Param("recordId") String recordId);
   }
 
   interface Pager<X> {
@@ -100,7 +105,7 @@ class RackspaceApis {
     String publicURL;
   }
 
-  static class JobIdAndStatus {
+  static class Job {
 
     String id;
     String status;

--- a/clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
@@ -18,7 +18,6 @@ import static denominator.Denominator.create;
 import static denominator.Providers.list;
 import static denominator.Providers.provide;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class CloudDNSProviderTest {
 
@@ -30,7 +29,7 @@ public class CloudDNSProviderTest {
   @Test
   public void testCloudDNSMetadata() {
     assertThat(PROVIDER.name()).isEqualTo("clouddns");
-    assertTrue(PROVIDER.supportsDuplicateZoneNames());
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isFalse();
     assertThat(PROVIDER.credentialTypeToParameterNames())
         .containsEntry("password", Arrays.asList("username", "password"))
         .containsEntry("apiKey", Arrays.asList("username", "apiKey"));

--- a/clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
@@ -12,7 +12,7 @@ import denominator.model.ResourceRecordSet;
 import denominator.model.rdata.AData;
 
 import static denominator.assertj.ModelAssertions.assertThat;
-import static denominator.clouddns.RackspaceApisTest.domainId;
+import static denominator.clouddns.RackspaceApisTest.domainsResponse;
 import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
@@ -40,9 +40,10 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void listWhenPresent() throws Exception {
     server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(records));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
     Iterator<ResourceRecordSet<?>> records = api.iterator();
 
     while (records.hasNext()) {
@@ -52,6 +53,9 @@ public class CloudDNSResourceRecordSetApiMockTest {
     }
 
     server.assertAuthRequest();
+    server.assertRequest()
+        .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -60,14 +64,18 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void listWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setResponseCode(404).setBody(
         "{\"message\":\"Not Found\",\"code\":404,\"details\":\"\"}"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
 
     assertFalse(api.iterator().hasNext());
 
     server.assertAuthRequest();
+    server.assertRequest()
+        .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -76,10 +84,11 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void listPagesWhenPresent() throws Exception {
     server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsPage1.replace("URL", server.url())));
     server.enqueue(new MockResponse().setBody(recordsPage2.replace("URL", server.url())));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
     Iterator<ResourceRecordSet<?>> records = api.iterator();
 
     while (records.hasNext()) {
@@ -89,6 +98,9 @@ public class CloudDNSResourceRecordSetApiMockTest {
     }
 
     server.assertAuthRequest();
+    server.assertRequest()
+        .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -100,9 +112,10 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void iterateByNameWhenPresent() throws Exception {
     server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsByName));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
     Iterator<ResourceRecordSet<?>> records = api.iterateByName("www.denominator.io");
 
     while (records.hasNext()) {
@@ -114,19 +127,26 @@ public class CloudDNSResourceRecordSetApiMockTest {
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
+    server.assertRequest()
+        .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
   }
 
   @Test
   public void iterateByNameWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setResponseCode(404).setBody(
         "{\"message\":\"Not Found\",\"code\":404,\"details\":\"\"}"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
     assertFalse(api.iterateByName("www.denominator.io").hasNext());
 
     server.assertAuthRequest();
+    server.assertRequest()
+        .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -135,9 +155,10 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void getByNameAndTypeWhenPresent() throws Exception {
     server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsByNameAndType));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
 
     assertThat(api.getByNameAndType("www.denominator.io", "A"))
         .hasName("www.denominator.io")
@@ -148,19 +169,26 @@ public class CloudDNSResourceRecordSetApiMockTest {
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
+    server.assertRequest()
+        .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records?name=www.denominator.io&type=A");
   }
 
   @Test
   public void getByNameAndTypeWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setResponseCode(404).setBody(
         "{\"message\":\"Not Found\",\"code\":404,\"details\":\"\"}"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
     assertNull(api.getByNameAndType("www.denominator.io", "A"));
 
     server.assertAuthRequest();
+    server.assertRequest()
+        .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records?name=www.denominator.io&type=A");

--- a/clouddns/src/test/java/denominator/clouddns/CloudDNSZoneApiMockTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/CloudDNSZoneApiMockTest.java
@@ -11,7 +11,6 @@ import denominator.ZoneApi;
 import denominator.model.Zone;
 
 import static denominator.assertj.ModelAssertions.assertThat;
-import static denominator.clouddns.RackspaceApisTest.domainId;
 import static denominator.clouddns.RackspaceApisTest.domainsResponse;
 import static org.junit.Assert.assertFalse;
 
@@ -29,8 +28,7 @@ public class CloudDNSZoneApiMockTest {
     Iterator<Zone> domains = api.iterator();
 
     assertThat(domains.next())
-        .hasName("denominator.io")
-        .hasId(String.valueOf(domainId));
+        .hasName("denominator.io");
 
     server.assertAuthRequest();
     server.assertRequest().hasPath("/v1.0/123123/domains");

--- a/clouddns/src/test/java/denominator/clouddns/RackspaceApisTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/RackspaceApisTest.java
@@ -11,7 +11,7 @@ import denominator.Credentials;
 import denominator.Provider;
 import denominator.clouddns.RackspaceApis.CloudDNS;
 import denominator.clouddns.RackspaceApis.CloudIdentity;
-import denominator.clouddns.RackspaceApis.JobIdAndStatus;
+import denominator.clouddns.RackspaceApis.Job;
 import denominator.clouddns.RackspaceApis.TokenIdAndPublicURL;
 import feign.Feign;
 
@@ -65,13 +65,26 @@ public class RackspaceApisTest {
     server.enqueue(new MockResponse().setBody(domainsResponse));
 
     assertThat(mockApi().domains().get(0))
-        .hasName("denominator.io")
-        .hasId(String.valueOf("1234"));
+        .hasName("denominator.io");
 
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains");
+  }
+
+  @Test
+  public void domainIdsByNamePresent() throws Exception {
+    server.enqueueAuthResponse();
+    server.enqueue(new MockResponse().setBody(domainsResponse));
+
+    assertThat(mockApi().domainIdsByName("denominator.io"))
+        .containsOnly(1234);
+
+    server.assertAuthRequest();
+    server.assertRequest()
+        .hasMethod("GET")
+        .hasPath("/v1.0/123123/domains?name=denominator.io");
   }
 
   @Test
@@ -125,9 +138,8 @@ public class RackspaceApisTest {
     server.enqueueAuthResponse();
     server.enqueue(new MockResponse().setBody(mxRecordInitialResponse));
 
-    JobIdAndStatus job = mockApi().createRecordWithPriority(domainId, "www.denominator.io", "MX",
-                                                            1800,
-                                                            "mail.denominator.io", 10);
+    Job job = mockApi().createRecordWithPriority(domainId, "www.denominator.io", "MX",
+                                                            1800, "mail.denominator.io", 10);
 
     assertThat(job.id).isEqualTo("0ade2b3b-07e4-4e68-821a-fcce4f5406f3");
     assertThat(job.status).isEqualTo("RUNNING");
@@ -144,7 +156,7 @@ public class RackspaceApisTest {
     server.enqueueAuthResponse();
     server.enqueue(new MockResponse().setBody(mxRecordRunningResponse));
 
-    JobIdAndStatus job = mockApi().getStatus("0ade2b3b-07e4-4e68-821a-fcce4f5406f3");
+    Job job = mockApi().getStatus("0ade2b3b-07e4-4e68-821a-fcce4f5406f3");
 
     assertThat(job.id).isEqualTo("0ade2b3b-07e4-4e68-821a-fcce4f5406f3");
     assertThat(job.status).isEqualTo("RUNNING");
@@ -160,7 +172,7 @@ public class RackspaceApisTest {
     server.enqueueAuthResponse();
     server.enqueue(new MockResponse().setBody(mxRecordCompletedResponse));
 
-    JobIdAndStatus job = mockApi().getStatus("0ade2b3b-07e4-4e68-821a-fcce4f5406f3");
+    Job job = mockApi().getStatus("0ade2b3b-07e4-4e68-821a-fcce4f5406f3");
 
     assertThat(job.id).isEqualTo("0ade2b3b-07e4-4e68-821a-fcce4f5406f3");
     assertThat(job.status).isEqualTo("COMPLETED");
@@ -176,8 +188,7 @@ public class RackspaceApisTest {
     server.enqueueAuthResponse();
     server.enqueue(new MockResponse().setBody(mxRecordUpdateInitialResponse));
 
-    JobIdAndStatus job = mockApi().updateRecord(domainId, "MX-4582544", 600,
-                                                "mail.denominator.io");
+    Job job = mockApi().updateRecord(domainId, "MX-4582544", 600, "mail.denominator.io");
 
     assertThat(job.id).isEqualTo("e32eace1-c44f-49af-8f74-768fa34469f4");
     assertThat(job.status).isEqualTo("RUNNING");
@@ -194,7 +205,7 @@ public class RackspaceApisTest {
     server.enqueueAuthResponse();
     server.enqueue(new MockResponse().setBody(mxRecordDeleteInitialResponse));
 
-    JobIdAndStatus job = mockApi().deleteRecord(domainId, "MX-4582544");
+    Job job = mockApi().deleteRecord(domainId, "MX-4582544");
 
     assertThat(job.id).isEqualTo("da520d24-dd5b-4387-92be-2020a7f2b176");
     assertThat(job.status).isEqualTo("RUNNING");


### PR DESCRIPTION
Note: this impacts CLI usage, as formerly you'd pass a integer id to affect clouddns zones. Now, you pass the zone name.

Live tested, and had some throttling related failures, but nothing functional...

```bash
$ ./gradlew clean test install -Dclouddns.username=XXXX -Dclouddns.apiKey=XXXX -Dclouddns.zone=denominator.com
```