### PR TITLE
Revert to primarily addressing CloudDNS and Designate zones by ID

### DIFF
--- a/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
+++ b/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
@@ -15,7 +15,6 @@ import denominator.CheckConnection;
 import denominator.DNSApiManager;
 import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
-import denominator.clouddns.RackspaceAdapters.DomainIdListAdapter;
 import denominator.clouddns.RackspaceAdapters.DomainListAdapter;
 import denominator.clouddns.RackspaceAdapters.JobIdAndStatusAdapter;
 import denominator.clouddns.RackspaceAdapters.RecordListAdapter;
@@ -142,7 +141,6 @@ public class CloudDNSProvider extends BasicProvider {
                        new KeystoneAccessAdapter("rax:dns"),
                        new JobIdAndStatusAdapter(),
                        new DomainListAdapter(),
-                       new DomainIdListAdapter(),
                        new RecordListAdapter()))
           )
           .build();

--- a/clouddns/src/main/java/denominator/clouddns/CloudDNSResourceRecordSetApi.java
+++ b/clouddns/src/main/java/denominator/clouddns/CloudDNSResourceRecordSetApi.java
@@ -181,10 +181,8 @@ class CloudDNSResourceRecordSetApi implements denominator.ResourceRecordSetApi {
     }
 
     @Override
-    public ResourceRecordSetApi create(String name) {
-      ListWithNext<Integer> matching = api.domainIdsByName(name);
-      checkArgument(!matching.isEmpty(), "zone %s does not exist", name);
-      return new CloudDNSResourceRecordSetApi(api, matching.get(0));
+    public ResourceRecordSetApi create(String id) {
+      return new CloudDNSResourceRecordSetApi(api, Integer.parseInt(id));
     }
   }
 }

--- a/clouddns/src/main/java/denominator/clouddns/RackspaceAdapters.java
+++ b/clouddns/src/main/java/denominator/clouddns/RackspaceAdapters.java
@@ -58,30 +58,6 @@ class RackspaceAdapters {
     }
   }
 
-  static class DomainIdListAdapter extends ListWithNextAdapter<Integer> {
-
-    @Override
-    protected String jsonKey() {
-      return "domains";
-    }
-
-    protected Integer build(JsonReader reader) throws IOException {
-      Integer id = null;
-      while (reader.hasNext()) {
-        if (reader.nextName().equals("id")) {
-          id = reader.nextInt();
-        } else {
-          reader.skipValue();
-        }
-      }
-      return id;
-    }
-  }
-
-  /**
-   * Note that we do not expose the ID back to the user as ID isn't semantic when the API doesn't
-   * support multiple zones
-   */
   static class DomainListAdapter extends ListWithNextAdapter<Zone> {
 
     @Override
@@ -93,8 +69,11 @@ class RackspaceAdapters {
       String name = null;
       String id = null;
       while (reader.hasNext()) {
-        if (reader.nextName().equals("name")) {
+        String nextName = reader.nextName();
+        if (nextName.equals("name")) {
           name = reader.nextString();
+        } else if (nextName.equals("id")) {
+          id = reader.nextString();
         } else {
           reader.skipValue();
         }

--- a/clouddns/src/main/java/denominator/clouddns/RackspaceApis.java
+++ b/clouddns/src/main/java/denominator/clouddns/RackspaceApis.java
@@ -51,7 +51,7 @@ class RackspaceApis {
      * aren't permitted in the create api.
      */
     @RequestLine("GET /domains?name={name}")
-    ListWithNext<Integer> domainIdsByName(@Param("name") String name);
+    ListWithNext<Zone> domainsByName(@Param("name") String name);
 
     @RequestLine("GET")
     ListWithNext<Zone> domains(URI href);

--- a/clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/CloudDNSResourceRecordSetApiMockTest.java
@@ -12,7 +12,7 @@ import denominator.model.ResourceRecordSet;
 import denominator.model.rdata.AData;
 
 import static denominator.assertj.ModelAssertions.assertThat;
-import static denominator.clouddns.RackspaceApisTest.domainsResponse;
+import static denominator.clouddns.RackspaceApisTest.domainId;
 import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
@@ -40,10 +40,9 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void listWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(records));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
     Iterator<ResourceRecordSet<?>> records = api.iterator();
 
     while (records.hasNext()) {
@@ -53,9 +52,6 @@ public class CloudDNSResourceRecordSetApiMockTest {
     }
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -64,18 +60,14 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void listWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setResponseCode(404).setBody(
         "{\"message\":\"Not Found\",\"code\":404,\"details\":\"\"}"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
 
     assertFalse(api.iterator().hasNext());
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -84,11 +76,10 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void listPagesWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsPage1.replace("URL", server.url())));
     server.enqueue(new MockResponse().setBody(recordsPage2.replace("URL", server.url())));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
     Iterator<ResourceRecordSet<?>> records = api.iterator();
 
     while (records.hasNext()) {
@@ -98,9 +89,6 @@ public class CloudDNSResourceRecordSetApiMockTest {
     }
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -112,10 +100,9 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void iterateByNameWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsByName));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
     Iterator<ResourceRecordSet<?>> records = api.iterateByName("www.denominator.io");
 
     while (records.hasNext()) {
@@ -127,26 +114,19 @@ public class CloudDNSResourceRecordSetApiMockTest {
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
-        .hasPath("/v1.0/123123/domains?name=denominator.io");
-    server.assertRequest()
-        .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
   }
 
   @Test
   public void iterateByNameWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setResponseCode(404).setBody(
         "{\"message\":\"Not Found\",\"code\":404,\"details\":\"\"}"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
     assertFalse(api.iterateByName("www.denominator.io").hasNext());
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records");
@@ -155,10 +135,9 @@ public class CloudDNSResourceRecordSetApiMockTest {
   @Test
   public void getByNameAndTypeWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsByNameAndType));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
 
     assertThat(api.getByNameAndType("www.denominator.io", "A"))
         .hasName("www.denominator.io")
@@ -169,26 +148,19 @@ public class CloudDNSResourceRecordSetApiMockTest {
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
-        .hasPath("/v1.0/123123/domains?name=denominator.io");
-    server.assertRequest()
-        .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records?name=www.denominator.io&type=A");
   }
 
   @Test
   public void getByNameAndTypeWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setResponseCode(404).setBody(
         "{\"message\":\"Not Found\",\"code\":404,\"details\":\"\"}"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId + "");
     assertNull(api.getByNameAndType("www.denominator.io", "A"));
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1.0/123123/domains?name=denominator.io");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath("/v1.0/123123/domains/1234/records?name=www.denominator.io&type=A");

--- a/clouddns/src/test/java/denominator/clouddns/CloudDNSZoneApiMockTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/CloudDNSZoneApiMockTest.java
@@ -11,6 +11,7 @@ import denominator.ZoneApi;
 import denominator.model.Zone;
 
 import static denominator.assertj.ModelAssertions.assertThat;
+import static denominator.clouddns.RackspaceApisTest.domainId;
 import static denominator.clouddns.RackspaceApisTest.domainsResponse;
 import static org.junit.Assert.assertFalse;
 
@@ -28,7 +29,8 @@ public class CloudDNSZoneApiMockTest {
     Iterator<Zone> domains = api.iterator();
 
     assertThat(domains.next())
-        .hasName("denominator.io");
+        .hasName("denominator.io")
+        .hasId(String.valueOf(domainId));
 
     server.assertAuthRequest();
     server.assertRequest().hasPath("/v1.0/123123/domains");

--- a/clouddns/src/test/java/denominator/clouddns/RackspaceApisTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/RackspaceApisTest.java
@@ -13,6 +13,7 @@ import denominator.clouddns.RackspaceApis.CloudDNS;
 import denominator.clouddns.RackspaceApis.CloudIdentity;
 import denominator.clouddns.RackspaceApis.Job;
 import denominator.clouddns.RackspaceApis.TokenIdAndPublicURL;
+import denominator.model.Zone;
 import feign.Feign;
 
 import static denominator.assertj.ModelAssertions.assertThat;
@@ -74,12 +75,12 @@ public class RackspaceApisTest {
   }
 
   @Test
-  public void domainIdsByNamePresent() throws Exception {
+  public void domainsByNamePresent() throws Exception {
     server.enqueueAuthResponse();
     server.enqueue(new MockResponse().setBody(domainsResponse));
 
-    assertThat(mockApi().domainIdsByName("denominator.io"))
-        .containsOnly(1234);
+    assertThat(mockApi().domainsByName("denominator.io"))
+        .containsOnly(Zone.create("denominator.io", "1234"));
 
     server.assertAuthRequest();
     server.assertRequest()

--- a/designate/src/main/java/denominator/designate/Designate.java
+++ b/designate/src/main/java/denominator/designate/Designate.java
@@ -17,9 +17,6 @@ public interface Designate {
   @RequestLine("GET /domains")
   List<Zone> domains();
 
-  @RequestLine("GET /domains")
-  Map<String, String> domainIdsByName();
-
   @RequestLine("GET /domains/{domainId}/records")
   List<Record> records(@Param("domainId") String domainId);
 

--- a/designate/src/main/java/denominator/designate/DesignateAdapters.java
+++ b/designate/src/main/java/denominator/designate/DesignateAdapters.java
@@ -7,10 +7,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import denominator.designate.Designate.Record;
 import denominator.model.Zone;
@@ -80,48 +78,6 @@ class DesignateAdapters {
     }
   }
 
-  static class DomainNameToIdAdapter extends TypeAdapter<Map<String, String>> {
-
-    @Override
-    public Map<String, String> read(JsonReader reader) throws IOException {
-      Map<String, String> result = new LinkedHashMap<String, String>();
-      reader.beginObject();
-      while (reader.hasNext()) {
-        String nextName = reader.nextName();
-        if ("domains".equals(nextName)) {
-          reader.beginArray();
-          while (reader.hasNext()) {
-            reader.beginObject();
-            String name = null;
-            String id = null;
-            while (reader.hasNext()) {
-              nextName = reader.nextName();
-              if (nextName.equals("name")) {
-                name = reader.nextString();
-              } else if (nextName.equals("id")) {
-                id = reader.nextString();
-              } else {
-                reader.skipValue();
-              }
-            }
-            result.put(name, id);
-            reader.endObject();
-          }
-          reader.endArray();
-        } else {
-          reader.skipValue();
-        }
-      }
-      reader.endObject();
-      return result;
-    }
-
-    @Override
-    public void write(JsonWriter out, Map<String, String> value) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-  }
-
   static class DomainListAdapter extends ListAdapter<Zone> {
 
     @Override
@@ -131,14 +87,18 @@ class DesignateAdapters {
 
     protected Zone build(JsonReader reader) throws IOException {
       String name = null;
+      String id = null;
       while (reader.hasNext()) {
-        if (reader.nextName().equals("name")) {
+        String key = reader.nextName();
+        if (key.equals("name")) {
           name = reader.nextString();
+        } else if (key.equals("id")) {
+          id = reader.nextString();
         } else {
           reader.skipValue();
         }
       }
-      return Zone.create(name);
+      return Zone.create(name, id);
     }
   }
 

--- a/designate/src/main/java/denominator/designate/DesignateProvider.java
+++ b/designate/src/main/java/denominator/designate/DesignateProvider.java
@@ -23,7 +23,6 @@ import denominator.config.NothingToClose;
 import denominator.config.OnlyBasicResourceRecordSets;
 import denominator.config.WeightedUnsupported;
 import denominator.designate.DesignateAdapters.DomainListAdapter;
-import denominator.designate.DesignateAdapters.DomainNameToIdAdapter;
 import denominator.designate.DesignateAdapters.RecordAdapter;
 import denominator.designate.DesignateAdapters.RecordListAdapter;
 import feign.Feign;
@@ -140,7 +139,6 @@ public class DesignateProvider extends BasicProvider {
                        new KeystoneV2AccessAdapter(),
                        recordAdapter,
                        new DomainListAdapter(),
-                       new DomainNameToIdAdapter(),
                        new RecordListAdapter()))
           )
           .build();

--- a/designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
+++ b/designate/src/main/java/denominator/designate/DesignateResourceRecordSetApi.java
@@ -117,11 +117,8 @@ class DesignateResourceRecordSetApi implements denominator.ResourceRecordSetApi 
     }
 
     @Override
-    public ResourceRecordSetApi create(String name) {
-      checkNotNull(name, "name");
-      String id = api.domainIdsByName().get(name);
-      checkArgument(id != null, "zone %s does not exist", name);
-      return new DesignateResourceRecordSetApi(api, id);
+    public ResourceRecordSetApi create(String id) {
+      return new DesignateResourceRecordSetApi(api, checkNotNull(id, "id"));
     }
   }
 }

--- a/designate/src/test/java/denominator/designate/DesignateResourceRecordSetApiMockTest.java
+++ b/designate/src/test/java/denominator/designate/DesignateResourceRecordSetApiMockTest.java
@@ -16,7 +16,6 @@ import denominator.model.rdata.MXData;
 import static denominator.assertj.ModelAssertions.assertThat;
 import static denominator.designate.DesignateTest.aRecordResponse;
 import static denominator.designate.DesignateTest.domainId;
-import static denominator.designate.DesignateTest.domainsResponse;
 import static denominator.designate.DesignateTest.recordsResponse;
 import static denominator.model.ResourceRecordSets.a;
 import static java.lang.String.format;
@@ -29,12 +28,11 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void listWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsResponse));
 
     Iterator<ResourceRecordSet<?>>
         records =
-        server.connect().api().basicRecordSetsInZone("denominator.io.").iterator();
+        server.connect().api().basicRecordSetsInZone(domainId).iterator();
     assertThat(records.next())
         .hasName("denominator.io.")
         .hasType("MX")
@@ -52,24 +50,17 @@ public class DesignateResourceRecordSetApiMockTest {
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
-        .hasPath("/v1/domains");
-    server.assertRequest()
-        .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
   }
 
   @Test
   public void listWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
 
-    assertThat(server.connect().api().basicRecordSetsInZone("denominator.io.")).isEmpty();
+    assertThat(server.connect().api().basicRecordSetsInZone(domainId)).isEmpty();
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -78,17 +69,13 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void putCreatesRecord() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
     server.enqueue(new MockResponse().setBody(aRecordResponse));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     api.put(a("www.denominator.io.", 3600, "192.0.2.1"));
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -106,16 +93,12 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void putSameRecordNoOp() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsResponse));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     api.put(a("www.denominator.io.", Arrays.asList("192.0.2.1", "192.0.2.2")));
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -124,18 +107,14 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void putUpdatesWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsResponse));
     server.enqueue(new MockResponse().setBody(aRecordResponse));
     server.enqueue(new MockResponse().setBody(aRecordResponse));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     api.put(a("www.denominator.io.", 10000000, Arrays.asList("192.0.2.1", "192.0.2.2")));
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -164,17 +143,13 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void putOneLessDeletesExtra() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsResponse));
     server.enqueue(new MockResponse());
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     api.put(a("www.denominator.io.", "192.0.2.2"));
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -187,10 +162,9 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void iterateByNameWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsResponse));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
 
     assertThat(api.iterateByName("www.denominator.io.").next())
         .hasName("www.denominator.io.")
@@ -201,25 +175,18 @@ public class DesignateResourceRecordSetApiMockTest {
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
-        .hasPath("/v1/domains");
-    server.assertRequest()
-        .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
   }
 
   @Test
   public void iterateByNameWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     assertThat(api.iterateByName("www.denominator.io.")).isEmpty();
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -228,10 +195,9 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void getByNameAndTypeWhenPresent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsResponse));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
 
     assertThat(api.getByNameAndType("www.denominator.io.", "A"))
         .hasName("www.denominator.io.")
@@ -242,25 +208,18 @@ public class DesignateResourceRecordSetApiMockTest {
     server.assertAuthRequest();
     server.assertRequest()
         .hasMethod("GET")
-        .hasPath("/v1/domains");
-    server.assertRequest()
-        .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
   }
 
   @Test
   public void getByNameAndTypeWhenAbsent() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody("{ \"records\": [] }"));
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     assertThat(api.getByNameAndType("www.denominator.io.", "A")).isNull();
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -269,17 +228,13 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void deleteOne() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(recordsResponse));
     server.enqueue(new MockResponse());
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     api.deleteByNameAndType("denominator.io.", "MX");
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));
@@ -292,17 +247,13 @@ public class DesignateResourceRecordSetApiMockTest {
   @Test
   public void deleteAbsentRRSDoesNothing() throws Exception {
     server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
     server.enqueue(new MockResponse().setBody(aRecordResponse));
     server.enqueue(new MockResponse());
 
-    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone("denominator.io.");
+    ResourceRecordSetApi api = server.connect().api().basicRecordSetsInZone(domainId);
     api.deleteByNameAndType("www1.denominator.io.", "A");
 
     server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
     server.assertRequest()
         .hasMethod("GET")
         .hasPath(format("/v1/domains/%s/records", domainId));

--- a/designate/src/test/java/denominator/designate/DesignateTest.java
+++ b/designate/src/test/java/denominator/designate/DesignateTest.java
@@ -67,21 +67,7 @@ public class DesignateTest {
     server.enqueue(new MockResponse().setBody(domainsResponse));
 
     assertThat(mockApi().domains())
-        .containsExactly(Zone.create("denominator.io."));
-
-    server.assertAuthRequest();
-    server.assertRequest()
-        .hasMethod("GET")
-        .hasPath("/v1/domains");
-  }
-
-  @Test
-  public void domainIdsByNamePresent() throws Exception {
-    server.enqueueAuthResponse();
-    server.enqueue(new MockResponse().setBody(domainsResponse));
-
-    assertThat(mockApi().domainIdsByName())
-        .containsEntry("denominator.io.", domainId);
+        .containsExactly(Zone.create("denominator.io.", domainId));
 
     server.assertAuthRequest();
     server.assertRequest()

--- a/designate/src/test/java/denominator/designate/DesignateZoneApiMockTest.java
+++ b/designate/src/test/java/denominator/designate/DesignateZoneApiMockTest.java
@@ -11,6 +11,7 @@ import denominator.ZoneApi;
 import denominator.model.Zone;
 
 import static denominator.assertj.ModelAssertions.assertThat;
+import static denominator.designate.DesignateTest.domainId;
 import static denominator.designate.DesignateTest.domainsResponse;
 
 public class DesignateZoneApiMockTest {
@@ -27,7 +28,8 @@ public class DesignateZoneApiMockTest {
     Iterator<Zone> domains = api.iterator();
 
     assertThat(domains.next())
-        .hasName("denominator.io.");
+        .hasName("denominator.io.")
+        .hasId(domainId);
 
     server.assertAuthRequest();
     server.assertRequest().hasPath("/v1/domains");


### PR DESCRIPTION
Per [discussion](https://groups.google.com/forum/#!topic/denominator-dev/X_yjoykCReU), we can continue to permit zones to be looked up using ids as long as we change documentation about what `Provider.supportsDuplicateZoneNames()` means. In doing so, we can be more efficient and also remain compatible with prior versions of denominator.


