### PR TITLE
Reverts Zone.Identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,8 @@
 * Adds email and ttl to CLI zone list output
 * Adds `ZoneApi.iterateByName()` to support lookups
 * Adds `-n` parameter to CLI zone list
-* Refines zone identifiers and handling of zones with the same name
-  * Adds `Zone.qualifier()` in support duplicate zones
-  * Deprecates `supportsDuplicateZoneNames()` in favor of `Provider.zoneIdentification()` in `NAME`, `OPAQUE` and `QUALIFIED`
-  * Deprecates `Zone.idOrName()` as `Zone.id()` cannot be null
+* `supportsDuplicateZoneNames()` means `Zone.qualifier()` is present
+* Deprecates `Zone.idOrName()` as `Zone.id()` cannot be null
 * Documents third-party provider process
 * Publishes model and core test jars
 * Adds example server

--- a/cli/README.md
+++ b/cli/README.md
@@ -85,15 +85,14 @@ Different providers connect to different urls and need different credentials.  F
 
 ```bash
 $ denominator providers
-provider   url                                                 zoneIds   credentialType credentialArgs
-clouddns   https://identity.api.rackspacecloud.com/v2.0        opaque    password       username password
-clouddns   https://identity.api.rackspacecloud.com/v2.0        opaque    apiKey         username apiKey
-designate  http://localhost:5000/v2.0                          opaque    password       tenantId username password
-dynect     https://api2.dynect.net/REST                        name      password       customer username password
-mock       mem:mock                                            name           
-route53    https://route53.amazonaws.com                       qualified accessKey      accessKey secretKey
-route53    https://route53.amazonaws.com                       qualified session        accessKey secretKey sessionToken
-ultradns   https://ultra-api.ultradns.com:8443/UltraDNS_WS/v01 name      password       username password
+provider   url                                                 duplicateZones credentialType credentialArgs
+mock       mem:mock                                            false
+clouddns   https://identity.api.rackspacecloud.com/v2.0/       true           apiKey         username apiKey
+designate  http://localhost:5000/v2.0                          true           password       tenantId username password
+dynect     https://api2.dynect.net/REST                        false          password       customer username password
+route53    https://route53.amazonaws.com                       true           accessKey      accessKey secretKey
+route53    https://route53.amazonaws.com                       true           session        accessKey secretKey sessionToken
+ultradns   https://ultra-api.ultradns.com:8443/UltraDNS_WS/v01 false          password       username password
 ```
 
 If the credentialType column is blank it needs no credentials.  Otherwise, credentialArgs describes what you need to pass.  Say for example, you were using `ultradns`.  
@@ -110,8 +109,7 @@ If you need to connect to an alternate url, pass the `-u` parameter:
 ./denominator -p ultradns -u https://ultra-api.ultradns.com:8443/UltraDNS_WS/v01-BETA -c myusername -c mypassword zone list
 ```
 
-The `zoneIds` column indicates how the provider addresses zones. For example, `name` means you simply
-pass the zone name (like `denominator.io.`) to commands that need it. This topic is further described in the `Zone Identifiers` section to follow.
+The `duplicateZones` column indicates that zone list output will include a qualifier, which differentiates zones with the same name.
 
 ### Zone
 `zone list` returns the zones in your account.  Ex.
@@ -131,7 +129,7 @@ email.netflix.com.                                 A     3600   69.53.237.168
 --snip--
 ```
 
-### Zone ID
+### Zone Id
 The first column in the zone list is the `id`. This can be used to disambiguate zones with the same
 name, or to improve performance by eliminating a network call. If you wish to use a zone's
 identifier, simply pass it instead of the zone name in record commands.

--- a/cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
+++ b/cli/src/main/java/denominator/cli/GeoResourceRecordSetCommands.java
@@ -58,7 +58,7 @@ class GeoResourceRecordSetCommands {
     }
   }
 
-  static enum GeoResourceRecordSetToString implements Function<ResourceRecordSet<?>, String> {
+  enum GeoResourceRecordSetToString implements Function<ResourceRecordSet<?>, String> {
     INSTANCE;
 
     @Override

--- a/cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
+++ b/cli/src/main/java/denominator/cli/ResourceRecordSetCommands.java
@@ -39,7 +39,7 @@ import static java.lang.String.format;
 
 class ResourceRecordSetCommands {
 
-  static enum ResourceRecordSetToString implements Function<ResourceRecordSet<?>, String> {
+  enum ResourceRecordSetToString implements Function<ResourceRecordSet<?>, String> {
     INSTANCE;
 
     @Override
@@ -433,8 +433,7 @@ class ResourceRecordSetCommands {
 
         @Override
         public String next() {
-          mgr.api().basicRecordSetsInZone(id(mgr, zoneIdOrName))
-              .deleteByNameAndType(name, type);
+          mgr.api().basicRecordSetsInZone(id(mgr, zoneIdOrName)).deleteByNameAndType(name, type);
           done = true;
           return ";; ok";
         }

--- a/cli/src/test/java/denominator/cli/DenominatorTest.java
+++ b/cli/src/test/java/denominator/cli/DenominatorTest.java
@@ -60,15 +60,15 @@ public class DenominatorTest {
   public void listsAllProvidersWithCredentials() {
     assertThat(ListProviders.providerAndCredentialsTable())
         .isEqualTo(Util.join('\n',
-                             "provider   url                                                 zoneIds   credentialType credentialArgs",
-                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        opaque    password       username password",
-                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        opaque    apiKey         username apiKey",
-                             "designate  http://localhost:5000/v2.0                          opaque    password       tenantId username password",
-                             "dynect     https://api2.dynect.net/REST                        name      password       customer username password",
-                             "mock       mem:mock                                            name           ",
-                             "route53    https://route53.amazonaws.com                       qualified accessKey      accessKey secretKey",
-                             "route53    https://route53.amazonaws.com                       qualified session        accessKey secretKey sessionToken",
-                             "ultradns   https://ultra-api.ultradns.com:8443/UltraDNS_WS/v01 name      password       username password",
+                             "provider   url                                                 duplicateZones credentialType credentialArgs",
+                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        false          password       username password",
+                             "clouddns   https://identity.api.rackspacecloud.com/v2.0        false          apiKey         username apiKey",
+                             "designate  http://localhost:5000/v2.0                          false          password       tenantId username password",
+                             "dynect     https://api2.dynect.net/REST                        false          password       customer username password",
+                             "mock       mem:mock                                            false          ",
+                             "route53    https://route53.amazonaws.com                       true           accessKey      accessKey secretKey",
+                             "route53    https://route53.amazonaws.com                       true           session        accessKey secretKey sessionToken",
+                             "ultradns   https://ultra-api.ultradns.com:8443/UltraDNS_WS/v01 false          password       username password",
                              ""));
   }
 

--- a/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
+++ b/clouddns/src/main/java/denominator/clouddns/CloudDNSProvider.java
@@ -24,8 +24,6 @@ import denominator.config.GeoUnsupported;
 import denominator.config.NothingToClose;
 import denominator.config.OnlyBasicResourceRecordSets;
 import denominator.config.WeightedUnsupported;
-import denominator.model.Zone;
-import denominator.model.Zone.Identification;
 import feign.Feign;
 import feign.Logger;
 import feign.Target.EmptyTarget;
@@ -50,11 +48,6 @@ public class CloudDNSProvider extends BasicProvider {
   @Override
   public String url() {
     return url;
-  }
-
-  @Override
-  public Identification zoneIdentification() {
-    return Identification.OPAQUE;
   }
 
   // http://docs.rackspace.com/cdns/api/v1.0/cdns-devguide/content/supported_record_types.htm

--- a/clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
+++ b/clouddns/src/test/java/denominator/clouddns/CloudDNSProviderTest.java
@@ -12,7 +12,6 @@ import dagger.ObjectGraph;
 import denominator.Credentials.MapCredentials;
 import denominator.DNSApiManager;
 import denominator.Provider;
-import denominator.model.Zone.Identification;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
@@ -30,7 +29,7 @@ public class CloudDNSProviderTest {
   @Test
   public void testCloudDNSMetadata() {
     assertThat(PROVIDER.name()).isEqualTo("clouddns");
-    assertThat(PROVIDER.zoneIdentification()).isEqualTo(Identification.OPAQUE);
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isFalse();
     assertThat(PROVIDER.credentialTypeToParameterNames())
         .containsEntry("password", Arrays.asList("username", "password"))
         .containsEntry("apiKey", Arrays.asList("username", "apiKey"));

--- a/core/src/main/java/denominator/BasicProvider.java
+++ b/core/src/main/java/denominator/BasicProvider.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import denominator.model.Zone.Identification;
-
 import static denominator.common.Preconditions.checkArgument;
 import static java.util.Arrays.asList;
 
@@ -52,11 +50,6 @@ public abstract class BasicProvider implements Provider {
   }
 
   @Override
-  public Identification zoneIdentification() {
-    return Identification.NAME;
-  }
-
-  @Override
   public Set<String> basicRecordTypes() {
     Set<String> result = new LinkedHashSet<String>();
     result.addAll(asList("A", "AAAA", "CERT", "CNAME", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF",
@@ -74,7 +67,7 @@ public abstract class BasicProvider implements Provider {
 
   @Override
   public boolean supportsDuplicateZoneNames() {
-    return zoneIdentification() == Identification.QUALIFIED;
+    return false;
   }
 
   @Override

--- a/core/src/main/java/denominator/Provider.java
+++ b/core/src/main/java/denominator/Provider.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import denominator.model.ResourceRecordSet;
 import denominator.model.Zone;
-import denominator.model.Zone.Identification;
 
 /**
  * Metadata about a provider of DNS services.
@@ -46,13 +45,6 @@ public interface Provider {
   String url();
 
   /**
-   * Metadata about zone identifiers and uniqueness.
-   *
-   * @since 4.5
-   */
-  Identification zoneIdentification();
-
-  /**
    * The set of basic {@link ResourceRecordSet#type() record types} that are supported by {@link
    * ResourceRecordSetApi} commands. <br> For example:
    *
@@ -78,10 +70,8 @@ public interface Provider {
   Map<String, Collection<String>> profileToRecordTypes();
 
   /**
-   * @deprecated Use {@link #zoneIdentification()}. {@link denominator.model.Zone.Identification#QUALIFIED
-   * Qualified} indicates duplicate zones are supported. This will be removed in version 5.
+   * Zones have {@link Zone#qualifier()} set, as duplicate zones can exist with the same name.
    */
-  @Deprecated
   boolean supportsDuplicateZoneNames();
 
   /**

--- a/core/src/main/java/denominator/ZoneApi.java
+++ b/core/src/main/java/denominator/ZoneApi.java
@@ -15,8 +15,7 @@ public interface ZoneApi extends Iterable<Zone> {
 
   /**
    * Returns a potentially empty iterator of zones with the supplied {@link Zone#name()}. This can
-   * only have multiple results when {@link Provider#zoneIdentification() zone identification} is
-   * {@link denominator.model.Zone.Identification#QUALIFIED qualified}.
+   * only have multiple results when {@link Provider#supportsDuplicateZoneNames()}.
    *
    * @since 4.5
    */

--- a/core/src/test/java/denominator/ReadOnlyLiveTest.java
+++ b/core/src/test/java/denominator/ReadOnlyLiveTest.java
@@ -7,7 +7,6 @@ import org.junit.runners.Parameterized.Parameter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 
 import denominator.model.ResourceRecordSet;
 import denominator.model.Zone;
@@ -26,25 +25,13 @@ public class ReadOnlyLiveTest {
     Iterator<Zone> zones = manager.api().zones().iterator();
     assumeTrue("No zones to test", zones.hasNext());
     Zone zone = zones.next();
-    switch (manager.provider().zoneIdentification()) {
-      case NAME:
-        assertThat(zone).hasNoQualifier()
-            .hasId(zone.name());
-        break;
-      case OPAQUE:
-        assertThat(zone).hasNoQualifier();
-        assertThat(zone.id())
-            .isNotNull()
-            .isNotEqualTo(zone.name());
-        break;
-      case QUALIFIED:
-        assertThat(zone.qualifier()).isNotNull();
-        assertThat(zone.id())
-            .isNotNull()
-            .isNotEqualTo(zone.name());
-        break;
-      default:
-        throw new AssertionError("unknown zone identification");
+    if (manager.provider().supportsDuplicateZoneNames()) {
+      assertThat(zone.qualifier()).isNotNull();
+      assertThat(zone.id())
+          .isNotNull()
+          .isNotEqualTo(zone.name());
+    } else {
+      assertThat(zone).hasNoQualifier();
     }
   }
 

--- a/core/src/test/java/denominator/mock/MockProviderTest.java
+++ b/core/src/test/java/denominator/mock/MockProviderTest.java
@@ -3,7 +3,6 @@ package denominator.mock;
 import org.junit.Test;
 
 import denominator.Provider;
-import denominator.model.Zone.Identification;
 
 import static denominator.Denominator.create;
 import static denominator.Providers.list;
@@ -16,7 +15,7 @@ public class MockProviderTest {
   @Test
   public void testMockMetadata() {
     assertThat(PROVIDER.name()).isEqualTo("mock");
-    assertThat(PROVIDER.zoneIdentification()).isEqualTo(Identification.NAME);
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isFalse();
     assertThat(PROVIDER.credentialTypeToParameterNames()).isEmpty();
   }
 

--- a/designate/src/main/java/denominator/designate/DesignateProvider.java
+++ b/designate/src/main/java/denominator/designate/DesignateProvider.java
@@ -25,7 +25,6 @@ import denominator.config.WeightedUnsupported;
 import denominator.designate.DesignateAdapters.DomainListAdapter;
 import denominator.designate.DesignateAdapters.RecordAdapter;
 import denominator.designate.DesignateAdapters.RecordListAdapter;
-import denominator.model.Zone.Identification;
 import feign.Feign;
 import feign.Logger;
 import feign.Target.EmptyTarget;
@@ -50,11 +49,6 @@ public class DesignateProvider extends BasicProvider {
   @Override
   public String url() {
     return url;
-  }
-
-  @Override
-  public Identification zoneIdentification() {
-    return Identification.OPAQUE;
   }
 
   // http://docs.hpcloud.com/api/dns/#create_record-jumplink-span

--- a/designate/src/test/java/denominator/designate/DesignateProviderTest.java
+++ b/designate/src/test/java/denominator/designate/DesignateProviderTest.java
@@ -12,7 +12,6 @@ import dagger.ObjectGraph;
 import denominator.Credentials.MapCredentials;
 import denominator.DNSApiManager;
 import denominator.Provider;
-import denominator.model.Zone.Identification;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
@@ -30,7 +29,7 @@ public class DesignateProviderTest {
   @Test
   public void testDesignateMetadata() {
     assertThat(PROVIDER.name()).isEqualTo("designate");
-    assertThat(PROVIDER.zoneIdentification()).isEqualTo(Identification.OPAQUE);
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isFalse();
     assertThat(PROVIDER.credentialTypeToParameterNames())
         .containsEntry("password", Arrays.asList("tenantId", "username", "password"));
   }

--- a/dynect/src/test/java/denominator/dynect/DynECTProviderTest.java
+++ b/dynect/src/test/java/denominator/dynect/DynECTProviderTest.java
@@ -12,7 +12,6 @@ import dagger.ObjectGraph;
 import denominator.Credentials.MapCredentials;
 import denominator.DNSApiManager;
 import denominator.Provider;
-import denominator.model.Zone.Identification;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
@@ -30,7 +29,7 @@ public class DynECTProviderTest {
   @Test
   public void testDynECTMetadata() {
     assertThat(PROVIDER.name()).isEqualTo("dynect");
-    assertThat(PROVIDER.zoneIdentification()).isEqualTo(Identification.NAME);
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isFalse();
     assertThat(PROVIDER.credentialTypeToParameterNames())
         .containsEntry("password", Arrays.asList("customer", "username", "password"));
   }

--- a/model/src/main/java/denominator/model/Zone.java
+++ b/model/src/main/java/denominator/model/Zone.java
@@ -1,7 +1,5 @@
 package denominator.model;
 
-import denominator.model.rdata.SOAData;
-
 import static denominator.common.Preconditions.checkArgument;
 import static denominator.common.Preconditions.checkNotNull;
 import static denominator.common.Util.equal;
@@ -13,42 +11,6 @@ import static denominator.common.Util.equal;
  * @since 1.2 See <a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>
  */
 public class Zone {
-
-  /**
-   * Metadata about how zones are identified within the scope of a connection to a provider.
-   *
-   * <p/>For example {@link denominator.model.Zone.Identification#NAME} means you can safely assume
-   * a zone's id is its name.
-   *
-   * <pre>
-   * String zoneId;
-   * if (mgr.provider().zoneIdentification() == NAME) {
-   *    zoneId = zoneName;
-   * } else {
-   *    zoneId = mgr.api().zones().iterateByName(zoneName).next().id();
-   * }
-   * </pre>
-   *
-   * @since 4.5
-   */
-  public enum Identification {
-    /**
-     * Only one zone allowed with the same name, and it is {@link Zone#id() identified} by {@link
-     * Zone#name() name}.
-     */
-    NAME,
-    /**
-     * Only one zone allowed with the same name, but its {@link Zone#id() identifier} is opaque.
-     * <p/> Note that a zone with the name name may have different identifiers over time.
-     */
-    OPAQUE,
-    /**
-     * Multiple zones are allowed with the same name, and each have a {@link Zone#qualifier()
-     * user-defined qualifier}. Each zone's {@link Zone#id() identifier} is opaque. <p/> Note that a
-     * zone with the name name may have different identifiers over time.
-     */
-    QUALIFIED;
-  }
 
   private final String name;
   private final String qualifier;
@@ -77,7 +39,7 @@ public class Zone {
 
   /**
    * A user-defined unique string that differentiates zones with the same name. Only supported when
-   * the {@code denominator.Provider#zoneIdentification()} is {@link denominator.model.Zone.Identification#QUALIFIED}.
+   * the {@code denominator.Provider#supportsDuplicateZoneNames()}.
    *
    * @return qualifier or null if the provider doesn't support multiple zones with the same name.
    * @since 4.5
@@ -93,8 +55,6 @@ public class Zone {
    * <p/>Note that this is not used in {@link #hashCode()} or {@link #equals(Object)}, as it may
    * change over time.
    *
-   * @return identifier based on {@code denominator.Provider#zoneIdentification()}.
-   * @see denominator.model.Zone.Identification
    * @since 4.5
    */
   public String id() {

--- a/route53/src/main/java/denominator/route53/Route53Provider.java
+++ b/route53/src/main/java/denominator/route53/Route53Provider.java
@@ -22,8 +22,6 @@ import denominator.ResourceRecordSetApi;
 import denominator.ZoneApi;
 import denominator.config.GeoUnsupported;
 import denominator.config.NothingToClose;
-import denominator.model.Zone;
-import denominator.model.Zone.Identification;
 import denominator.profile.WeightedResourceRecordSetApi;
 import denominator.route53.Route53ErrorDecoder.Messages;
 import denominator.route53.Route53ErrorDecoder.Route53Error;
@@ -53,8 +51,8 @@ public class Route53Provider extends BasicProvider {
   }
 
   @Override
-  public Identification zoneIdentification() {
-    return Identification.QUALIFIED;
+  public boolean supportsDuplicateZoneNames() {
+    return true;
   }
 
   // http://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html
@@ -77,11 +75,6 @@ public class Route53Provider extends BasicProvider {
     profileToRecordTypes
         .put("roundRobin", Arrays.asList("A", "AAAA", "MX", "NS", "PTR", "SPF", "SRV", "TXT"));
     return profileToRecordTypes;
-  }
-
-  @Override
-  public boolean supportsDuplicateZoneNames() {
-    return true;
   }
 
   @Override

--- a/route53/src/test/java/denominator/route53/Route53ProviderTest.java
+++ b/route53/src/test/java/denominator/route53/Route53ProviderTest.java
@@ -12,7 +12,6 @@ import dagger.ObjectGraph;
 import denominator.Credentials.MapCredentials;
 import denominator.DNSApiManager;
 import denominator.Provider;
-import denominator.model.Zone.Identification;
 
 import static denominator.CredentialsConfiguration.anonymous;
 import static denominator.CredentialsConfiguration.credentials;
@@ -31,7 +30,7 @@ public class Route53ProviderTest {
   @Test
   public void testRoute53Metadata() {
     assertThat(PROVIDER.name()).isEqualTo("route53");
-    assertThat(PROVIDER.zoneIdentification()).isEqualTo(Identification.QUALIFIED);
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isTrue();
     assertThat(PROVIDER.credentialTypeToParameterNames())
         .containsEntry("accessKey", Arrays.asList("accessKey", "secretKey"))
         .containsEntry("session", Arrays.asList("accessKey", "secretKey", "sessionToken"));

--- a/ultradns/src/test/java/denominator/ultradns/UltraDNSProviderTest.java
+++ b/ultradns/src/test/java/denominator/ultradns/UltraDNSProviderTest.java
@@ -12,7 +12,6 @@ import dagger.ObjectGraph;
 import denominator.Credentials.MapCredentials;
 import denominator.DNSApiManager;
 import denominator.Provider;
-import denominator.model.Zone.Identification;
 
 import static denominator.CredentialsConfiguration.credentials;
 import static denominator.Denominator.create;
@@ -30,7 +29,7 @@ public class UltraDNSProviderTest {
   @Test
   public void testUltraDNSMetadata() {
     assertThat(PROVIDER.name()).isEqualTo("ultradns");
-    assertThat(PROVIDER.zoneIdentification()).isEqualTo(Identification.NAME);
+    assertThat(PROVIDER.supportsDuplicateZoneNames()).isFalse();
     assertThat(PROVIDER.credentialTypeToParameterNames())
         .containsEntry("password", Arrays.asList("username", "password"));
   }


### PR DESCRIPTION
`Zone.Identifier` doesn't pull its weight. The only thing it adds beyond
`Provider.supportsDuplicateZones`, is that it can indicate a zone id is
the same as its name. This isn't enough to warrant the added complexity.

see #350