### PR TITLE
Support hyphens in domain names in "example-daemon", and handle dynect token expiration

### DIFF
--- a/dynect/src/main/java/denominator/dynect/DynECTErrorDecoder.java
+++ b/dynect/src/main/java/denominator/dynect/DynECTErrorDecoder.java
@@ -76,6 +76,9 @@ class DynECTErrorDecoder implements ErrorDecoder {
         for (Message message : messages) {
           if ("token: This session already has a job running".equals(message.info())) {
             return new RetryableException(messages.toString(), cause, null);
+          } else if ("login: Bad or expired credentials".equals(message.info)) {
+              sessionValid.set(false);
+              return new RetryableException(messages.toString(), cause, null);
           } else if ("zone: Operation blocked by current task".equals(message.info())) {
             // Tasks are not exposed so the only thing we can do is wait a relatively long time.
             Date retryAfter = new Date(currentTimeMillis() + 1000);

--- a/dynect/src/test/java/denominator/dynect/DynECTProviderDynamicUpdateMockTest.java
+++ b/dynect/src/test/java/denominator/dynect/DynECTProviderDynamicUpdateMockTest.java
@@ -43,6 +43,24 @@ public class DynECTProviderDynamicUpdateMockTest {
   }
 
   @Test
+  public void tokenExpirationInvalidatesAndRetries() throws Exception {
+    server.enqueueSessionResponse();
+    server.enqueue(new MockResponse().setResponseCode(400).setBody(
+            "{\"status\": \"failure\", \"data\": {}, \"job_id\": 3462106051, \"msgs\": [{\"INFO\": \"login: Bad or expired credentials\", \"SOURCE\": \"BLL\", \"ERR_CD\": \"INVALID_DATA\", \"LVL\": \"ERROR\"}, {\"INFO\": \"login: There was a problem with your credentials\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO]\"}]}"));
+    server.enqueueSessionResponse();
+    server.enqueue(new MockResponse().setBody(noZones));
+
+    DNSApi api = server.connect().api();
+
+    assertThat(api.zones()).isEmpty();
+
+    server.assertSessionRequest();
+    server.assertRequest();
+    server.assertSessionRequest();
+    server.assertRequest();
+  }
+
+  @Test
   public void dynamicEndpointUpdates() throws Exception {
     final AtomicReference<String> url = new AtomicReference<String>(server.url());
     server.enqueueSessionResponse();

--- a/example-daemon/src/main/java/denominator/denominatord/RecordSetDispatcher.java
+++ b/example-daemon/src/main/java/denominator/denominatord/RecordSetDispatcher.java
@@ -23,7 +23,7 @@ import static java.util.Collections.singleton;
 
 public class RecordSetDispatcher extends Dispatcher {
 
-  static final Pattern RECORDSET_PATTERN = Pattern.compile("/zones/([\\.\\w]+)/recordsets(\\?.*)?");
+  static final Pattern RECORDSET_PATTERN = Pattern.compile("/zones/([\\.\\w-]+)/recordsets(\\?.*)?");
 
   private final Logger log = Logger.getLogger(Dispatcher.class.getName());
   private final DNSApiManager mgr;


### PR DESCRIPTION
* example-daemon's RECORDSET_PATTERN regex didn't match domains containing hyphens
* when using dynect via example-daemon, the dyn token expires after a few hours ; catching that error makes it possible to re-authenticate after expiration.